### PR TITLE
fix routine reuse start unreflected bug

### DIFF
--- a/src/features/core/services/RunningTasksService.ts
+++ b/src/features/core/services/RunningTasksService.ts
@@ -176,8 +176,8 @@ export class RunningTasksService {
     const isDeletedRecord = (record: RunningTaskRecord): boolean => {
       return deletedEntries.some((entry) => {
         if (!entry) return false
-        const instanceMatches =
-          entry.instanceId && record.instanceId && entry.instanceId === record.instanceId
+        const hasInstanceId = typeof entry.instanceId === 'string' && entry.instanceId.length > 0
+        const instanceMatches = hasInstanceId && record.instanceId && entry.instanceId === record.instanceId
         if (instanceMatches) {
           return true
         }
@@ -187,8 +187,12 @@ export class RunningTasksService {
           return false
         }
 
-        if (entry.instanceId && !record.instanceId) {
-          return true
+        if (hasInstanceId) {
+          // Instance-scoped deletions should not suppress other instances for the same path
+          if (!record.instanceId) {
+            return true
+          }
+          return false
         }
 
         if (entry.deletionType === 'permanent') {

--- a/tests/services/running-tasks-service.test.ts
+++ b/tests/services/running-tasks-service.test.ts
@@ -97,6 +97,25 @@ describe('RunningTasksService.restoreForDate', () => {
     expect(instances).toHaveLength(0)
   })
 
+  it('restores routine records when deletion entry targets another duplicated instance', async () => {
+    const record = createRecord({ instanceId: 'original-instance' })
+    const deleted: DeletedInstance = {
+      instanceId: 'duplicate-instance',
+      path: record.taskPath,
+      deletionType: 'temporary',
+      timestamp: Date.now(),
+    }
+
+    const { result, instances } = await runRestore({
+      records: [record],
+      deletedInstances: [deleted],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(instances).toHaveLength(1)
+    expect(instances[0].instanceId).toBe('original-instance')
+  })
+
   it('restores records when not hidden or deleted', async () => {
     const record = createRecord({ slotKey: '0900' })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts deletion matching so instance-scoped deletions only target the specified instance, adding tests to verify restoration of other instances.
> 
> - **Core/RunningTasksService**:
>   - Refines `isDeletedRecord` logic: treats `instanceId`-scoped deletions as targeting only the matching instance; avoids suppressing other instances sharing the same `path`.
>   - Adds explicit `hasInstanceId` guard and clarified path vs instance matching.
> - **Tests** (`tests/services/running-tasks-service.test.ts`):
>   - Adds test ensuring routine records are restored when a deletion targets a different duplicated instance.
>   - Keeps existing coverage for hidden/deleted records and non-routine behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6918a1563a8380334fc57126396effe130607e7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->