### PR TITLE
prevent close routine modal with Enter key

### DIFF
--- a/src/features/routine/controllers/RoutineController.ts
+++ b/src/features/routine/controllers/RoutineController.ts
@@ -70,7 +70,19 @@ export default class RoutineController {
     }) as HTMLButtonElement
     attachCloseButtonIcon(closeButton)
 
-    const form = modalContent.createEl('form', { cls: 'task-form' })
+    const form = modalContent.createEl('form', { cls: 'task-form' }) as HTMLFormElement
+
+    const preventInputEnterSubmit = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter') {
+        return
+      }
+      const target = event.target
+      if (target instanceof HTMLButtonElement) {
+        return
+      }
+      event.preventDefault()
+    }
+    form.addEventListener('keydown', preventInputEnterSubmit)
     const typeGroup = form.createEl('div', { cls: 'form-group' })
     typeGroup.createEl('label', {
       text: this.tv('forms.routineType', 'Routine type:'),

--- a/tests/ui/routine/routine-controller.test.ts
+++ b/tests/ui/routine/routine-controller.test.ts
@@ -179,4 +179,37 @@ describe('RoutineController', () => {
     expect(task.routine_weeks).toEqual([1, 3, 'last'])
     expect(task.routine_weekdays).toEqual([1, 4])
   })
+
+  it('prevents Enter key presses inside routine modal inputs from closing the modal', () => {
+    const { host } = createHost()
+    const controller = new RoutineController(host)
+    const task = createTask({ isRoutine: false })
+
+    controller.showRoutineEditModal(task)
+
+    const overlay = document.body.querySelector('.task-modal-overlay') as HTMLElement | null
+    expect(overlay).not.toBeNull()
+
+    const targets: HTMLElement[] = []
+    const timeInput = overlay?.querySelector('input[type="time"]') as HTMLElement | null
+    const intervalInput = overlay?.querySelector('input[type="number"]') as HTMLElement | null
+    const typeSelect = overlay?.querySelector('select') as HTMLElement | null
+    ;[timeInput, intervalInput, typeSelect].forEach((element) => {
+      if (element) targets.push(element)
+    })
+
+    expect(targets.length).toBeGreaterThan(0)
+
+    targets.forEach((element) => {
+      const enterEvent = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      })
+      element.dispatchEvent(enterEvent)
+      expect(enterEvent.defaultPrevented).toBe(true)
+    })
+
+    expect(document.body.contains(overlay!)).toBe(true)
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents Enter key in routine modal inputs from submitting/closing the modal and adds a UI test to verify it.
> 
> - **UI/Behavior**:
>   - In `src/features/routine/controllers/RoutineController.ts`:
>     - Add `keydown` handler on the routine form to `preventDefault()` on Enter unless the target is a button, avoiding unintended submit/close.
>     - Explicitly type the created form as `HTMLFormElement`.
> - **Tests**:
>   - In `tests/ui/routine/routine-controller.test.ts`:
>     - Add test to ensure Enter key in time/number/select inputs is prevented and the modal remains open.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fe29fc6feea8860d2c2226c90b554d8285ab0ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->