### PR TITLE
fix focus bud when to popup tasklist

### DIFF
--- a/src/features/core/views/TaskChuteView.ts
+++ b/src/features/core/views/TaskChuteView.ts
@@ -288,6 +288,14 @@ export class TaskChuteView
       getCurrentDateString: () => this.getCurrentDateString(),
       app: this.app,
       plugin: this.plugin,
+      getDocumentContext: () => {
+        const doc = this.containerEl?.ownerDocument ?? document
+        const defaultView = (doc.defaultView as (Window & typeof globalThis) | null) ?? null
+        return {
+          doc,
+          win: defaultView ?? window,
+        }
+      },
     })
     this.taskScheduleController = new TaskScheduleController({
       tv: (key, fallback, vars) => this.tv(key, fallback, vars),

--- a/src/ui/components/NameModal.ts
+++ b/src/ui/components/NameModal.ts
@@ -7,6 +7,10 @@ export interface NameModalOptions {
   submitText: string
   cancelText: string
   closeLabel: string
+  context?: {
+    doc?: Document
+    win?: Window & typeof globalThis
+  }
 }
 
 export interface NameModalHandle {
@@ -23,12 +27,17 @@ export interface NameModalHandle {
   onClose: (handler: () => void) => void
 }
 
-function appendEl<T extends HTMLElement>(parent: HTMLElement, tag: string, options: {
+function appendEl<T extends HTMLElement>(
+  doc: Document,
+  parent: HTMLElement,
+  tag: string,
+  options: {
   cls?: string
   text?: string
   attr?: Record<string, string>
-} = {}): T {
-  const element = document.createElement(tag) as T
+} = {},
+): T {
+  const element = doc.createElement(tag) as T
   if (options.cls) {
     element.classList.add(...options.cls.split(' ').filter(Boolean))
   }
@@ -47,14 +56,19 @@ function appendEl<T extends HTMLElement>(parent: HTMLElement, tag: string, optio
 }
 
 export function createNameModal(options: NameModalOptions): NameModalHandle {
-  const overlay = document.createElement('div')
+  const doc = options.context?.doc ?? document
+  const overlay = doc.createElement('div')
   overlay.className = 'task-modal-overlay'
 
-  const content = appendEl<HTMLDivElement>(overlay, 'div', { cls: 'task-modal-content' })
+  const content = appendEl<HTMLDivElement>(doc, overlay, 'div', {
+    cls: 'task-modal-content',
+  })
 
-  const header = appendEl<HTMLDivElement>(content, 'div', { cls: 'modal-header' })
-  appendEl<HTMLHeadingElement>(header, 'h3', { text: options.title })
-  const closeButton = appendEl<HTMLButtonElement>(header, 'button', {
+  const header = appendEl<HTMLDivElement>(doc, content, 'div', {
+    cls: 'modal-header',
+  })
+  appendEl<HTMLHeadingElement>(doc, header, 'h3', { text: options.title })
+  const closeButton = appendEl<HTMLButtonElement>(doc, header, 'button', {
     cls: 'modal-close-button',
     attr: {
       'aria-label': options.closeLabel,
@@ -64,29 +78,35 @@ export function createNameModal(options: NameModalOptions): NameModalHandle {
   })
   attachCloseButtonIcon(closeButton)
 
-  const form = appendEl<HTMLFormElement>(content, 'form', { cls: 'task-form' })
-  const inputGroup = appendEl<HTMLDivElement>(form, 'div', { cls: 'form-group' })
-  appendEl<HTMLLabelElement>(inputGroup, 'label', {
+  const form = appendEl<HTMLFormElement>(doc, content, 'form', {
+    cls: 'task-form',
+  })
+  const inputGroup = appendEl<HTMLDivElement>(doc, form, 'div', {
+    cls: 'form-group',
+  })
+  appendEl<HTMLLabelElement>(doc, inputGroup, 'label', {
     text: options.label,
     cls: 'form-label',
   })
-  const input = appendEl<HTMLInputElement>(inputGroup, 'input', {
+  const input = appendEl<HTMLInputElement>(doc, inputGroup, 'input', {
     cls: 'form-input',
     attr: { type: 'text', placeholder: options.placeholder },
   })
 
-  const warning = appendEl<HTMLDivElement>(inputGroup, 'div', {
+  const warning = appendEl<HTMLDivElement>(doc, inputGroup, 'div', {
     cls: 'task-name-warning hidden',
     attr: { role: 'alert', 'aria-live': 'polite' },
   })
 
-  const buttonGroup = appendEl<HTMLDivElement>(form, 'div', { cls: 'form-button-group' })
-  const cancelButton = appendEl<HTMLButtonElement>(buttonGroup, 'button', {
+  const buttonGroup = appendEl<HTMLDivElement>(doc, form, 'div', {
+    cls: 'form-button-group',
+  })
+  const cancelButton = appendEl<HTMLButtonElement>(doc, buttonGroup, 'button', {
     cls: 'form-button cancel',
     text: options.cancelText,
     attr: { type: 'button' },
   })
-  const submitButton = appendEl<HTMLButtonElement>(buttonGroup, 'button', {
+  const submitButton = appendEl<HTMLButtonElement>(doc, buttonGroup, 'button', {
     cls: 'form-button create',
     text: options.submitText,
     attr: { type: 'submit' },
@@ -122,7 +142,8 @@ export function createNameModal(options: NameModalOptions): NameModalHandle {
     }
   })
 
-  document.body.appendChild(overlay)
+  const targetBody = doc.body ?? document.body
+  targetBody.appendChild(overlay)
   input.focus()
 
   return {

--- a/tests/ui/components/task-name-autocomplete.test.ts
+++ b/tests/ui/components/task-name-autocomplete.test.ts
@@ -1,0 +1,41 @@
+import { TaskNameAutocomplete } from '../../../src/ui/components/TaskNameAutocomplete'
+import type { Plugin } from 'obsidian'
+
+describe('TaskNameAutocomplete popout scroll handling', () => {
+  test('handleWindowScroll respects injected Node constructor', () => {
+    const pluginStub = { app: {} } as Plugin
+    const inputEl = document.createElement('input')
+    const containerEl = document.createElement('div')
+
+    class PopoutNode {}
+    const popoutWindow = {
+      Node: PopoutNode as unknown as typeof Node,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      setTimeout: window.setTimeout.bind(window),
+      clearTimeout: window.clearTimeout.bind(window),
+    } as unknown as Window & typeof globalThis
+
+    const autocomplete = new TaskNameAutocomplete(
+      pluginStub,
+      inputEl,
+      containerEl,
+      { doc: document, win: popoutWindow },
+    )
+
+    const hideSpy = jest.fn()
+    ;(autocomplete as unknown as { hideSuggestions: () => void }).hideSuggestions = hideSpy
+
+    const containsMock = jest.fn().mockReturnValue(true)
+    ;(autocomplete as { suggestionsElement?: HTMLElement }).suggestionsElement = {
+      contains: containsMock,
+    } as unknown as HTMLElement
+
+    const eventTarget = new PopoutNode() as unknown as Node
+    const event = { target: eventTarget } as Event
+    ;(autocomplete as unknown as { handleWindowScroll: (event: Event) => void }).handleWindowScroll(event)
+
+    expect(containsMock).toHaveBeenCalledWith(eventTarget)
+    expect(hideSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
fix
https://github.com/hiroyaiizuka/taskchute-for-obsidian/issues/41#issue-3612172365

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes add-task modal and autocomplete to a provided document/window (e.g., popouts) and updates listeners/timers accordingly, with tests.
> 
> - **UI/Interaction**:
>   - `TaskCreationController`: uses host-provided `getDocumentContext()` to inject `doc`/`win` into `NameModal` and `TaskNameAutocomplete`; builds modal elements via injected `doc`.
>   - `TaskChuteView`: supplies `getDocumentContext` based on `containerEl.ownerDocument` and its `defaultView`.
> - **Components**:
>   - `TaskNameAutocomplete`:
>     - Accepts `{ doc, win }` options; replaces global `document/window` usage (timers, events, `Node`, DOM creation/append) with injected context.
>     - Adjusts scroll/resize handling to use injected `win` and `Node`.
>   - `NameModal`: accepts optional `context` and creates/appends elements via injected `doc`.
> - **Tests**:
>   - Add tests for popout scroll handling using injected `Node` and for modal/autocomplete using host-provided document/window context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44797dee13434cb16e4a05d1b8d58a5286d7a491. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->