### PR TITLE
temporary fix, desktop-only true

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,5 @@
   "minAppVersion": "1.6.7",
   "author": "Hiroya Iizuka",
   "description": "Task-based time tracker that lists task notes, records start and stop times, and writes each session to your daily note.",
-  "isDesktopOnly": false
+  "isDesktopOnly": true
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set `isDesktopOnly` to `true` in `manifest.json` to restrict the plugin to desktop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd5ccd0101d04ddc97f0d0899a2f48ca44c95b27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->