### PR TITLE
fix date-dependent test in hasExecutionHistory

### DIFF
--- a/tests/execution/execution-log-service.test.ts
+++ b/tests/execution/execution-log-service.test.ts
@@ -311,19 +311,25 @@ describe('ExecutionLogService.hasExecutionHistory', () => {
   });
 
   test('falls back to month probing when getFiles unavailable', async () => {
-    const { plugin, store, vault } = createPluginStub({ disableGetFiles: true });
-    store.set('LOGS/2025-08-tasks.json', {
-      taskExecutions: {
-        '2025-08-12': [{ taskPath: 'Tasks/history.md' }],
-      },
-      dailySummary: {},
-    });
-    const service = new ExecutionLogService(plugin);
+    // 探索範囲は現在日時から遡る12か月なので、システム時刻を固定する
+    jest.useFakeTimers().setSystemTime(new Date('2025-09-15T00:00:00Z'));
+    try {
+      const { plugin, store, vault } = createPluginStub({ disableGetFiles: true });
+      store.set('LOGS/2025-08-tasks.json', {
+        taskExecutions: {
+          '2025-08-12': [{ taskPath: 'Tasks/history.md' }],
+        },
+        dailySummary: {},
+      });
+      const service = new ExecutionLogService(plugin);
 
-    const result = await service.hasExecutionHistory('Tasks/history.md');
+      const result = await service.hasExecutionHistory('Tasks/history.md');
 
-    expect(result).toBe(true);
-    expect(vault.getAbstractFileByPath).toHaveBeenCalledWith('LOGS/2025-08-tasks.json');
+      expect(result).toBe(true);
+      expect(vault.getAbstractFileByPath).toHaveBeenCalledWith('LOGS/2025-08-tasks.json');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('returns false when no log entries exist for path', async () => {


### PR DESCRIPTION
## Summary

`ExecutionLogService.hasExecutionHistory > falls back to month probing when getFiles unavailable`
started failing because the test depended on the real system clock.

The month probing fallback in `collectLogFiles()` scans the last 12 months
relative to `new Date()`, probing `LOGS/YYYY-MM-tasks.json` one month at a time.
The test hardcoded `2025-08`, which was inside that window when the test was
written. As of 2026-08 the window covers 2026-08 down to 2025-09, so `2025-08`
falls one month short of the range — `getAbstractFileByPath` is never called for
it and the assertion fails.

## Changes

- Freeze the system clock to `2025-09-15T00:00:00Z` with `jest.useFakeTimers().setSystemTime()`
  so the probing window always includes `2025-08`.
- Restore real timers in a `finally` block so following tests are unaffected.

The fixture dates are left as they were: with the clock pinned, the scenario
("probe backwards from 2025-09 and find the 2025-08 log") reads directly from
the test body. This also matches the existing convention in
`tests/heatmap/heatmap-service.test.ts` and `tests/project-board/project-board-service.test.ts`.

No production code was touched — the 12-month window is intended behaviour and
only the test's assumption had expired.

## Testing

- `npx jest tests/execution/execution-log-service.test.ts` — 12 passed
- `npx jest` — 120 suites / 1345 tests passed