### PR TITLE
chore: add CHANGELOG and use it for release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,20 +73,40 @@ jobs:
         if: ${{ steps.verify.outputs.release == 'true' && !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.verify.outputs.version }}
         run: |
           set -euo pipefail
 
+          # 1. CHANGELOG.md の該当バージョンの見出し（例: `## 2.0.0 - 2026-08-06`）から
+          #    次のバージョン見出しまでを本文として使う
+          if [ -f CHANGELOG.md ]; then
+            awk -v ver="$VERSION" '
+              $1 == "##" && $2 == ver { found = 1; next }
+              found && $1 == "##" { exit }
+              found { print }
+            ' CHANGELOG.md > RELEASE_NOTES.md
+          fi
+
+          if [ -s RELEASE_NOTES.md ]; then
+            echo "source=file" >> "$GITHUB_OUTPUT"
+            echo "CHANGELOG.md の \`$VERSION\` セクションをリリースノートに使用します。" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # 2. CHANGELOG.md に記載が無ければマージ済み PR の本文
           BODY=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
             --jq 'map(select(.merged_at != null)) | sort_by(.merged_at) | last | .body // empty' \
             2>/dev/null || true)
 
           if [ -n "${BODY:-}" ]; then
             printf '%s\n' "$BODY" > RELEASE_NOTES.md
-            echo "source=pr" >> "$GITHUB_OUTPUT"
-            echo "PR 本文をリリースノートに使用します。" >> "$GITHUB_STEP_SUMMARY"
+            echo "source=file" >> "$GITHUB_OUTPUT"
+            echo "::warning::CHANGELOG.md に $VERSION のセクションがありません。PR 本文をリリースノートに使用します。"
+            echo "CHANGELOG.md に \`$VERSION\` のセクションが無いため、PR 本文を使用しました。" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "source=auto" >> "$GITHUB_OUTPUT"
-            echo "紐づく PR が見つからないため、リリースノートを自動生成します。" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::CHANGELOG.md にも PR にもリリースノートがありません。自動生成します。"
+            echo "リリースノートを自動生成しました。" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Create GitHub Release (published)
@@ -97,7 +117,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${{ steps.notes.outputs.source }}" = "pr" ]; then
+          if [ "${{ steps.notes.outputs.source }}" = "file" ]; then
             NOTES_ARG=(--notes-file RELEASE_NOTES.md)
           else
             NOTES_ARG=(--generate-notes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,616 @@
+# Changelog
+
+All notable changes to TaskChute Plus.
+Generated from the [GitHub Releases](https://github.com/hiroyaiizuka/taskchute-for-obsidian/releases) of this repository.
+
+## 2.0.0 - 2026-08-06
+
+### Highlights
+
+**TaskChute Plus is now closed-source, and stays free.** Starting with this release the
+plugin is distributed as build artifacts only (`main.js`, `manifest.json`, `styles.css`);
+its source code lives in a separate private repository. The plugin itself remains free to
+use for any purpose, personal or commercial, on any number of vaults. Nothing about how
+you install or use it changes.
+
+Version 1.7.11 and earlier remain under the MIT License, and the last published
+open-source snapshot stays available on the [`v1` branch](https://github.com/hiroyaiizuka/taskchute-for-obsidian/tree/v1)
+(tag `v1-oss-final`). The major version bump marks the license change — there are no
+breaking changes to the plugin.
+
+### Changes
+
+* Fixed duplicate CSS property declarations in `styles.css`
+
+### Documentation
+
+* License replaced with the TaskChute Plus License (proprietary, free to use), including a
+  Japanese reference translation
+* README: added an install guide covering the Obsidian plugin market, direct GitHub
+  download, and BRAT
+* README: added notices about the license change and about all data staying inside your
+  own vault
+* Added this changelog, covering every release back to 1.0.0
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.11...2.0.0
+
+## 1.7.11 - 2026-08-05
+
+### Highlights
+
+**See which version you're running.** The settings tab now shows the installed
+plugin version at the top, so you can confirm what you have without digging into
+`manifest.json` or the community plugins list.
+
+### Changes
+
+* Settings: display the installed plugin version at the top of the settings tab
+
+### Internal
+
+These don't change plugin behavior, but are part of this release:
+
+* Release workflow now publishes build provenance from the distribution repository only
+* Release workflow actions updated to their Node 24 runtime versions
+* Resolved TypeScript compiler options slated for removal in TypeScript 7.0
+* Type checking added to the pre-commit hook
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.10...1.7.11
+
+## 1.7.10 - 2026-05-17
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/106
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.9...1.7.10
+
+## 1.7.9 - 2026-04-16
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/104
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.8...1.7.9
+
+## 1.7.8 - 2026-03-18
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/103
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.7...1.7.8
+
+## 1.7.7 - 2026-03-18
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/102
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.5...1.7.7
+
+## 1.7.5 - 2026-03-10
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/100
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.3...1.7.5
+
+## 1.7.3 - 2026-03-05
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/99
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.2...1.7.3
+
+## 1.7.2 - 2026-02-23
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/98
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.1...1.7.2
+
+## 1.7.1 - 2026-02-22
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/97
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.7.0...1.7.1
+
+## 1.7.0 - 2026-02-21
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/96
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.5.10...1.7.0
+
+## 1.5.10 - 2026-02-20
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/95
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.5.8...1.5.10
+
+## 1.5.8 - 2026-02-17
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/93
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.5.6...1.5.8
+
+## 1.5.6 - 2026-02-14
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/90
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.5.4...1.5.6
+
+## 1.5.4 - 2026-02-10
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/88
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.5.2...1.5.4
+
+## 1.5.2 - 2026-02-07
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/83
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.5.1...1.5.2
+
+## 1.5.1 - 2026-02-02
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/81
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.5.0...1.5.1
+
+## 1.5.0 - 2026-02-01
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/80
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.10...1.5.0
+
+## 1.4.10 - 2026-01-29
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/79
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.9...1.4.10
+
+## 1.4.9 - 2026-01-23
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/77
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/78
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.7...1.4.9
+
+## 1.4.7 - 2026-01-19
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/76
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.6...1.4.7
+
+## 1.4.6 - 2026-01-16
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/75
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.5...1.4.6
+
+## 1.4.5 - 2026-01-10
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/74
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.4...1.4.5
+
+## 1.4.4 - 2026-01-08
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/73
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.3...1.4.4
+
+## 1.4.3 - 2025-12-30
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/72
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.2...1.4.3
+
+## 1.4.2 - 2025-12-24
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/71
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.1...1.4.2
+
+## 1.4.1 - 2025-12-21
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/70
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.4.0...1.4.1
+
+## 1.4.0 - 2025-12-17
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/69
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.3.7...1.4.0
+
+## 1.3.7 - 2025-12-16
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/68
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.3.6...1.3.7
+
+## 1.3.6 - 2025-12-12
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/67
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.3.5...1.3.6
+
+## 1.3.5 - 2025-12-11
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/66
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.3.4...1.3.5
+
+## 1.3.4 - 2025-12-11
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/65
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.3.3...1.3.4
+
+## 1.3.3 - 2025-12-10
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/64
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.3.2...1.3.3
+
+## 1.3.2 - 2025-12-10
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/63
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.3.1...1.3.2
+
+## 1.3.1 - 2025-12-09
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/62
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.3.0...1.3.1
+
+## 1.3.0 - 2025-12-08
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/61
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.9...1.3.0
+
+## 1.2.9 - 2025-12-06
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/59
+* v1.2.8 by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/60
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.8...1.2.9
+
+## 1.2.8 - 2025-12-05
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/58
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.7...1.2.8
+
+## 1.2.7 - 2025-12-04
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/56
+* v1.2.6 by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/57
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.6...1.2.7
+
+## 1.2.6 - 2025-12-04
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/54
+* v1.2.5 by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/55
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.5...1.2.6
+
+## 1.2.5 - 2025-12-04
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/53
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.4...1.2.5
+
+## 1.2.4 - 2025-12-03
+
+### What's Changed
+* fix reminder by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/52
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.3...1.2.4
+
+## 1.2.3 - 2025-12-02
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/51
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.2...1.2.3
+
+## 1.2.2 - 2025-11-28
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/48
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/49
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/50
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.1...1.2.2
+
+## 1.2.1 - 2025-11-26
+
+### What's Changed
+* fix lint errors by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/47
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.2.0...1.2.1
+
+## 1.2.0 - 2025-11-25
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/46
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.1.8...1.2.0
+
+## 1.1.8 - 2025-11-20
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/45
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.1.7...1.1.8
+
+## 1.1.7 - 2025-11-14
+
+### What's Changed
+* temporary fix, desktop-only true by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/44
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.1.6...1.1.7
+
+## 1.1.6 - 2025-11-13
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/43
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.1.5...1.1.6
+
+## 1.1.5 - 2025-11-11
+
+### What's Changed
+* fix focus bud when to popup tasklist by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/42
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.1.4...1.1.5
+
+## 1.1.4 - 2025-11-11
+
+### What's Changed
+* prevent close routine modal with Enter key by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/40
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.1.3...1.1.4
+
+## 1.1.3 - 2025-11-09
+
+### What's Changed
+* hotfix css global degradation by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/39
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.1.2...1.1.3
+
+## 1.1.2 - 2025-11-08
+
+### What's Changed
+* fix routine reuse start unreflected bug by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/38
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.1.1...1.1.2
+
+## 1.1.1 - 2025-11-08
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/36
+* push 1.1.0 by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/37
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.0.6...1.1.1
+
+## 1.1.0 - 2025-11-07
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/35
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.0.5...1.1.0
+
+## 1.0.6 - 2025-11-06
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/35
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.0.5...1.0.6
+
+## 1.0.5 - 2025-11-04
+
+### What's Changed
+* fix past day task move ui/ux problem by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/34
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.0.4...1.0.5
+
+## 1.0.4 - 2025-11-03
+
+### What's Changed
+* improve setting tab ux by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/33
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.0.3...1.0.4
+
+## 1.0.3 - 2025-11-02
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/32
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.0.2...1.0.3
+
+## 1.0.2 - 2025-11-02
+
+### What's Changed
+* fix routine not shown bug because of targetdate by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/31
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/1.0.1...1.0.2
+
+## 1.0.1 - 2025-11-01
+
+### What's Changed
+* fix release settings by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/26
+* update release.yaml by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/27
+* update release.yaml again by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/28
+* fix release.yaml by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/29
+* fix release.yaml auto update by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/30
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/0.1.0...1.0.1
+
+## 0.1.1 - 2025-11-01
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/commits/0.1.1
+
+## 0.1.0 - 2025-10-18
+
+### What's Changed
+* bug fix routine related bug by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/24
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/25
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/0.0.5...0.1.0
+
+## 0.0.5 - 2025-10-16
+
+### What's Changed
+* move review template to custom setting tab by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/22
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/23
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/0.0.2...0.0.5
+
+## 0.0.4 - 2025-10-14
+
+### What's Changed
+* move review template to custom setting tab by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/22
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/23
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/0.0.2...0.0.4
+
+## 0.0.3 - 2025-10-13
+
+### What's Changed
+* move review template to custom setting tab by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/22
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/23
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/0.0.2...0.0.3
+
+## 0.0.2 - 2025-10-13
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/18
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/19
+* polish code with concern separation by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/20
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/21
+
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/compare/0.0.1...0.0.2
+
+## 0.0.1 - 2025-10-08
+
+### What's Changed
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/1
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/3
+* remove doc settings by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/4
+* add taskchute document with docusaurus by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/5
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/6
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/7
+* fix deploy actions by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/8
+* revert actions by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/9
+* fix deploy action error by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/10
+* fix action by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/11
+* update docs by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/12
+* update docs unlink and image problems by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/13
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/14
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/16
+* Develop by @hiroyaiizuka in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/17
+
+### New Contributors
+* @hiroyaiizuka made their first contribution in https://github.com/hiroyaiizuka/taskchute-for-obsidian/pull/1
+
+**Full Changelog**: https://github.com/hiroyaiizuka/taskchute-for-obsidian/commits/0.0.1


### PR DESCRIPTION
## Summary

Add `CHANGELOG.md` and make it the single source for release notes.

Until now the history for 0.0.1 through 1.7.11 lived only in GitHub Releases, so it could not be read from the repository itself. The release workflow also pulled its notes from the merged PR body, which meant a direct push to `main` fell back to an auto-generated commit list.

## Changes

### CHANGELOG.md (new)

- Transcribed every release from 0.0.1 onward out of the existing GitHub Releases.
- Linked from both READMEs under a `## CHANGELOG` section.

### .github/workflows/release.yml

Release notes are now resolved in this order:

1. The section of `CHANGELOG.md` for the version being released — from its `## <version> - <date>` heading up to the next heading.
2. The merged PR body, if the changelog has no such section (the previous behavior).
3. `--generate-notes` as a last resort.

Falling through to 2 or 3 emits a `::warning::` so a missing changelog entry is visible in the run.

## Note

Neither `CHANGELOG.md` nor `release.yml` is in the workflow's `paths` filter, so merging this does not trigger a release.