### PR TITLE
chore: relicense to proprietary from 2.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,113 @@
-MIT License
+TaskChute Plus License
 
-Copyright (c) 2025 hiroya iizuka
+Copyright (c) 2025-2026 Hiroya Iizuka. All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This license applies to TaskChute Plus version 2.0.0 and later, which is
+distributed in binary form only (main.js, manifest.json, styles.css) and is not
+open-source software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Version 1.7.10 and earlier were released under the MIT License and remain
+available under it. That source code is on the "v1" branch of this repository
+(tag "v1-oss-final").
+
+
+1. GRANT OF LICENSE
+
+Subject to the terms below, the copyright holder grants you a free of charge,
+non-exclusive, worldwide, non-transferable license to install and use TaskChute
+Plus (the "Software") for any purpose, personal or commercial, on any number of
+devices and Obsidian vaults, for as long as these terms are observed.
+
+
+2. PERMITTED USE
+
+You may:
+
+  (a) install and use the Software as an Obsidian plugin;
+  (b) make copies of the Software for backup purposes;
+  (c) inspect and modify your own installed copy of the Software for your own
+      private use.
+
+
+3. RESTRICTIONS
+
+You may not:
+
+  (a) redistribute, publish, sublicense, rent, lease, or sell the Software or
+      any copy of it, whether modified or unmodified, alone or as part of
+      another product;
+  (b) host the Software for download or distribute it through any plugin
+      directory, marketplace, or package registry other than those operated by
+      the copyright holder;
+  (c) remove, alter, or obscure any copyright, license, or attribution notice
+      contained in the Software;
+  (d) represent a modified copy of the Software as the official TaskChute Plus.
+
+Nothing in this section limits any right you have that cannot be excluded under
+applicable law.
+
+
+4. OWNERSHIP
+
+The Software is licensed, not sold. The copyright holder retains all right,
+title, and interest in and to the Software, including all intellectual property
+rights. No rights are granted except those expressly stated in this license.
+
+
+5. DATA
+
+The Software stores all of the data it creates inside your own Obsidian vault
+and transmits nothing to the author or to any third party.
+
+
+6. THIRD-PARTY COMPONENTS
+
+The distributed build may include third-party components that are governed by
+their own license terms. Those terms continue to apply to those components and
+take precedence over this license with respect to them.
+
+
+7. TERMINATION
+
+This license terminates automatically if you breach any of its terms. On
+termination you must stop using the Software and delete all copies of it in
+your possession.
+
+
+8. NO WARRANTY
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+
+
+9. LIMITATION OF LIABILITY
+
+IN NO EVENT SHALL THE AUTHOR OR COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM,
+DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR
+OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE. THIS INCLUDES, WITHOUT LIMITATION, ANY LOSS
+OR CORRUPTION OF DATA IN YOUR VAULT.
+
+
+---
+
+参考訳（日本語）
+
+本ライセンスは TaskChute Plus バージョン 2.0.0 以降に適用されます。2.0.0 以降は
+ビルド成果物（main.js / manifest.json / styles.css）のみで配布され、オープンソース
+ソフトウェアではありません。1.7.10 以前は MIT License で公開されており、引き続き
+その条件で利用できます（該当のソースコードは本リポジトリの "v1" ブランチ /
+"v1-oss-final" タグ）。
+
+  - 個人利用・商用利用を問わず、台数・vault 数の制限なく無償で利用できます。
+  - バックアップ目的の複製、および自分の環境にインストールした本体を私的に改変する
+    ことは認められます。
+  - 改変の有無を問わず、本ソフトウェアの再配布・公開・再ライセンス・貸与・販売は
+    できません。著作権表示等の削除・改変もできません。
+  - 本ソフトウェアが作成するデータはすべて利用者自身の vault 内に保存され、作者や
+    第三者に送信されることはありません。
+  - 本ソフトウェアは現状有姿で提供され、いかなる保証もありません。利用に起因する
+    損害（vault 内データの消失・破損を含む）について、作者は責任を負いません。
+
+本訳文は便宜のためのものであり、法的な効力を持つのは上記英語版の条文です。

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,6 +9,20 @@
 TaskChute Plus は、実行重視のタスク管理を Obsidian 上で行うためのプラグインです。  
 「今やること」を決めて実行し、実績ログを蓄積して改善につなげます。
 
+> [!warning]
+> **バージョン 2.0.0 以降、TaskChute Plus はオープンソースではありません。** プラグイン自体は
+> 引き続き無料で利用できます。ソースコードは非公開リポジトリで管理しており、本リポジトリでは
+> ビルド成果物（`main.js` / `manifest.json` / `styles.css`）のみを GitHub Releases として配布します。
+>
+> v1 時点のソースコードは MIT ライセンスのまま公開しています:
+> [v1 source code](https://github.com/hiroyaiizuka/taskchute-for-obsidian/tree/v1)
+> （タグ `v1-oss-final`）
+
+> [!note]
+> **データはあなたの vault の中に置かれます。** タスク・実行ログ・レビュー・ヒートマップの
+> データはすべて、あなたの vault 内に Markdown と JSON として保存されます。現時点では、
+> これらのデータを外部へ送信する機能はありません。
+
 ## できること
 
 - 日付ナビゲーション付きの TaskChute ビューで当日のタスクを管理
@@ -38,9 +52,7 @@ Obsidian のコマンドパレットから利用できます。
 
 ### Obsidian へのインストール
 
-1. `Settings -> Community plugins` を開く
-2. `TaskChute Plus` をインストールして有効化
-3. `Open TaskChute` コマンドを実行
+後述の[インストール方法](#インストール方法)を参照し、`Open TaskChute` コマンドを実行してください。
 
 ### 最初のタスク
 
@@ -91,29 +103,36 @@ scheduled_time: "09:00"
 
 `projectsFolder` はデフォルトで未設定です（必要時に個別指定）。
 
+## CHANGELOG
+
+変更履歴は[こちら](./CHANGELOG.md)を参照してください。
+
+## インストール方法
+
+| 入手元 | 説明 |
+|---|---|
+| [Obsidian Plugin Market](https://obsidian.md/plugins?id=taskchute-plus) | Obsidian の `Settings -> Community plugins` からインストール |
+| [GitHub](https://github.com/hiroyaiizuka/taskchute-for-obsidian/releases/latest) | 最新リリースをダウンロードし、3ファイル（`main.js` / `manifest.json` / `styles.css`）を `{{obsidian_vault}}/.obsidian/plugins/taskchute-plus/` に配置 |
+| BRAT | BRAT に `hiroyaiizuka/taskchute-for-obsidian` を追加 |
+
 ## ソースコード
 
 本リポジトリは配布専用です。プラグイン本体のソースコードは非公開リポジトリで管理しており、
 ビルド成果物を GitHub Releases としてここで配布します。
 
-MIT ライセンスで公開していた v1 時点のソースは引き続き参照できます。
-
-- ブランチ: <https://github.com/hiroyaiizuka/taskchute-for-obsidian/tree/v1>
-- タグ: `v1-oss-final`
-
-### リリース成果物
-
-Obsidian はプラグインルートの以下を読み込みます。
+Obsidian はプラグインルートの以下を読み込みます。これらは各リリースに添付されます。
 
 - `main.js`
 - `manifest.json`
 - `styles.css`
 
-これらは各 GitHub Release に添付されます。
-
 ## ライセンス
 
-MIT
+- **バージョン 2.0.0 以降** — プロプライエタリ。[LICENSE](./LICENSE) を参照。個人利用・商用利用を
+  問わず無償で利用できます。自分の環境での私的な改変は可、再配布は不可です。
+- **バージョン 1.7.10 以前** — MIT License。
+  [`v1` ブランチの LICENSE](https://github.com/hiroyaiizuka/taskchute-for-obsidian/blob/v1/LICENSE)
+  を参照（タグ `v1-oss-final`）。
 
 ## 作者
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@
 TaskChute Plus is an Obsidian plugin focused on execution-first task management:
 you decide what to do now, run it, and keep a reliable log of what actually happened.
 
+> [!warning]
+> **From version 2.0.0, TaskChute Plus is no longer open-source.** The plugin remains
+> free to use. Its source code is maintained in a separate private repository, and only
+> the build artifacts (`main.js`, `manifest.json`, `styles.css`) are published here as
+> GitHub Releases.
+>
+> The v1 source code is still open-source under the MIT license:
+> [v1 source code](https://github.com/hiroyaiizuka/taskchute-for-obsidian/tree/v1)
+> (tag `v1-oss-final`).
+
+> [!note]
+> **Your data stays in your vault.** All task, log, review, and heatmap data is stored as
+> plain Markdown and JSON inside your own vault. As of today, the plugin has no feature
+> that sends this data anywhere.
+
 ## What You Can Do
 
 - Manage daily tasks in one TaskChute view with date navigation.
@@ -38,9 +53,7 @@ Available from Obsidian Command Palette:
 
 ### Install in Obsidian
 
-1. Open `Settings -> Community plugins`.
-2. Install/enable `TaskChute Plus`.
-3. Run the command `Open TaskChute`.
+See [How to Install](#how-to-install) below, then run the command `Open TaskChute`.
 
 ### First Task
 
@@ -91,29 +104,37 @@ With default `vaultRoot` mode, TaskChute-managed folders are:
 
 `projectsFolder` is intentionally unset by default and can be configured separately.
 
+## CHANGELOG
+
+You can read the changelog from [here](./CHANGELOG.md).
+
+## How to Install
+
+| Source | Description |
+|---|---|
+| [Obsidian Plugin Market](https://obsidian.md/plugins?id=taskchute-plus) | Install from Obsidian's `Settings -> Community plugins`. |
+| [GitHub](https://github.com/hiroyaiizuka/taskchute-for-obsidian/releases/latest) | Download the latest release. Put the three files (`main.js`, `manifest.json`, `styles.css`) into `{{obsidian_vault}}/.obsidian/plugins/taskchute-plus/`. |
+| BRAT | Add `hiroyaiizuka/taskchute-for-obsidian` to BRAT. |
+
 ## Source Code
 
-This repository is now distribution-only. The plugin source code is maintained in a
+This repository is distribution-only. The plugin source code is maintained in a
 separate private repository, and builds are published here as GitHub Releases.
 
-The last MIT-licensed open-source snapshot (v1) is still available:
-
-- Branch: <https://github.com/hiroyaiizuka/taskchute-for-obsidian/tree/v1>
-- Tag: `v1-oss-final`
-
-### Release Artifacts
-
-Obsidian loads these files from the plugin root:
+Obsidian loads these files from the plugin root, and they are attached to every release:
 
 - `main.js`
 - `manifest.json`
 - `styles.css`
 
-They are attached to each GitHub Release.
-
 ## License
 
-MIT
+- **Version 2.0.0 and later** — proprietary, see [LICENSE](./LICENSE). Free to use for any
+  purpose, personal or commercial. Private modification of your own copy is allowed;
+  redistribution is not.
+- **Version 1.7.10 and earlier** — MIT License, see the
+  [LICENSE on the `v1` branch](https://github.com/hiroyaiizuka/taskchute-for-obsidian/blob/v1/LICENSE)
+  (tag `v1-oss-final`).
 
 ## Author
 


### PR DESCRIPTION
## Summary

Replace the MIT License with the TaskChute Plus License — proprietary, but free to use — and add the corresponding notices to both READMEs.

The version boundary:

- **1.7.10 and earlier** — MIT License. The source stays on the `v1` branch (tag `v1-oss-final`).
- **2.0.0 and later** — TaskChute Plus License. Distributed as build artifacts only.

## Changes

### LICENSE

- Replaced the MIT License with the TaskChute Plus License:
  - Free to use for any purpose, personal or commercial, on any number of devices and vaults.
  - Backup copies and private modification of your own installed copy are allowed.
  - Redistribution, publication, sublicensing, renting, and selling are not.
- Added a Japanese reference translation (the English text is the binding one).

### README.md / README.ja.md

- Added a notice about the license change at the top.
- Added a note that all data stays inside your own vault.
- Added an install guide covering the Obsidian plugin market, a direct GitHub download, and BRAT.
- Added a `## CHANGELOG` link to `CHANGELOG.md`.
- Rewrote the license section to state the terms per version range.

## Notes

- The README's changelog link points at the `CHANGELOG.md` added in #117, so merge that one first.
- `manifest.json` and `versions.json` are deliberately left out, so merging this does not trigger a release. The 2.0.0 release is a separate step.