### PR TITLE
chore(build): minify the production bundle

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -43,6 +43,10 @@ const context = await esbuild.context({
 	},
 	target: "es2018",
 	logLevel: "info",
+	// Minify production builds. The unminified bundle exceeds the size/AST
+	// limits of several static-analysis and malware scanners, which then skip
+	// the file instead of reporting a result.
+	minify: prod,
 	sourcemap: prod ? false : "inline",
 	treeShaking: true,
 	outfile: "main.js",


### PR DESCRIPTION
## Problem

`esbuild.config.mjs` has no `minify` option, so even `npm run build` (the production path used by the release workflow) emits an unminified `main.js` — **2.67 MB**.

Many static-analysis and malware scanners cap the file size / AST node count they will process. Past those limits they skip the file entirely and return no result, rather than reporting it as clean. That is what the review feedback on this plugin flagged.

## Change

Add `minify: prod` to the esbuild config. Only the production build is affected; `npm run dev` still emits an unminified bundle with inline sourcemaps for debugging.

## Result

| build | size |
| --- | --- |
| before | 2,671,225 B (2.67 MB) |
| after | 1,611,049 B (1.61 MB) |

About a 40% reduction.

## Verification

- `npm run build` succeeds; `node --check main.js` passes and the esbuild banner comment is preserved.
- No code depends on runtime identifier names (no `constructor.name` usage in `src/`), so mangling is safe.
- `npm run lint`, `npm run typecheck`, and `npm test` (2959 tests) pass.
- `main.js` is gitignored, so this PR only changes the build config; the release workflow picks the minified output up automatically.