### PR TITLE
fix(ai-task): use a ps invocation Linux accepts for the owner snapshot

### DIFF
--- a/src/features/ai-task/services/TerminalSessionBrokerSource.ts
+++ b/src/features/ai-task/services/TerminalSessionBrokerSource.ts
@@ -596,7 +596,7 @@ function readOwnerPidRecords(session) {
 // larger. Keep the environment-bearing form only on Linux, where it can
 // recover an already reparented cooperative descendant by its owner marker.
 const posixPsArgs = process.platform === 'linux'
-  ? ['eww', '-axo', 'pid=,ppid=,pgid=,lstart=,command=']
+  ? ['axeww', '-o', 'pid=,ppid=,pgid=,lstart=,command=']
   : ['-axo', 'pid=,ppid=,pgid=,lstart=,command='];
 const posixPsOptions = {
   encoding: 'utf8',

--- a/src/features/ai-task/services/TerminalSessionOwnerWatchdogSource.ts
+++ b/src/features/ai-task/services/TerminalSessionOwnerWatchdogSource.ts
@@ -265,7 +265,7 @@ function readPosixSnapshot() {
   if (forcePsFailure) return null;
   try {
     const args = process.platform === 'linux'
-      ? ['eww', '-axo', 'pid=,ppid=,pgid=,lstart=,command=']
+      ? ['axeww', '-o', 'pid=,ppid=,pgid=,lstart=,command=']
       : ['-axo', 'pid=,ppid=,pgid=,lstart=,command='];
     return parsePosixSnapshot(cp.execFileSync(
       '/bin/ps',


### PR DESCRIPTION
## The bug

Both the owner watchdog and the broker read an environment-bearing process snapshot. On Linux they asked for it as:

```
ps eww -axo pid=,ppid=,pgid=,lstart=,command=
```

That mixes BSD-style flags (`eww`) with a UNIX-style option bundle (`-axo`). procps rejects the `-x` inside `-axo` once BSD flags are present:

```
$ /bin/ps eww -axo pid=,ppid=,pgid=,lstart=,command=
error: must set personality to get -x option     # exit 1

$ /bin/ps -axo pid=,ppid=,pgid=,lstart=,command=
    1     0     1 Mon Aug 24 17:33:27 2026 /sbin/init    # exit 0
```

`readPosixSnapshot` catches the failure and returns `null`, so the watchdog and the broker saw *no processes at all* and retried. Debug output from a Debian container shows the same error repeating over a hundred times in a single test while the caller waited out its budget.

macOS takes the other branch (`-axo`, no BSD flags), which is why this never showed up locally.

## The fix

`ps axeww -o <fields>` — accepted on both platforms, and it keeps the environment in the output. The comment above `posixPsArgs` states why Linux wants the environment-bearing form: to recover an already reparented cooperative descendant by its owner marker.

Measured on Debian with a process carrying a unique env marker:

| invocation | Linux | environment visible |
| --- | --- | --- |
| `ps eww -axo F` | **exit 1** | — |
| `ps axeww -o F` | exit 0 | **yes** |
| `ps axww -o F` | exit 0 | no |
| `ps -e -ww -o F` | exit 0 | no |

So `axww` and `-e -ww` run, but neither preserves the behaviour this code depends on.

`TerminalSessionGuardSource` and `NodeProcessGateway` call plain `ps -axo …` with no BSD flags, which Linux accepts; they are unchanged.

## Effect

Integration suites in `node:20-bookworm`, after #126:

- before this change: 5 failures, 74s
- after: **2 failures, 25s**

Fixed here: the three `owner watchdog …` tests that hung for their full 15s budget, and `the production PTY watchdog reaps a detached descendant after broker SIGKILL`.

macOS: 90/90 integration tests pass, 211 suites / 2,869 unit tests pass.

## Remaining

Two Linux failures are left and are being tracked separately — `a stuck attached client is dropped while a healthy client receives everything` (a wall-clock lower bound in the test) and `natural root exit reaps a detached child that keeps inherited stdio open` (a timeout).