### PR TITLE
test(ai-task): stop pinning which stuck-client drop path runs

### DIFF
--- a/src/features/ai-task/services/TerminalSessionBrokerSource.ts
+++ b/src/features/ai-task/services/TerminalSessionBrokerSource.ts
@@ -596,7 +596,7 @@ function readOwnerPidRecords(session) {
 // larger. Keep the environment-bearing form only on Linux, where it can
 // recover an already reparented cooperative descendant by its owner marker.
 const posixPsArgs = process.platform === 'linux'
-  ? ['eww', '-axo', 'pid=,ppid=,pgid=,lstart=,command=']
+  ? ['axeww', '-o', 'pid=,ppid=,pgid=,lstart=,command=']
   : ['-axo', 'pid=,ppid=,pgid=,lstart=,command='];
 const posixPsOptions = {
   encoding: 'utf8',

--- a/src/features/ai-task/services/TerminalSessionOwnerWatchdogSource.ts
+++ b/src/features/ai-task/services/TerminalSessionOwnerWatchdogSource.ts
@@ -265,7 +265,7 @@ function readPosixSnapshot() {
   if (forcePsFailure) return null;
   try {
     const args = process.platform === 'linux'
-      ? ['eww', '-axo', 'pid=,ppid=,pgid=,lstart=,command=']
+      ? ['axeww', '-o', 'pid=,ppid=,pgid=,lstart=,command=']
       : ['-axo', 'pid=,ppid=,pgid=,lstart=,command='];
     return parsePosixSnapshot(cp.execFileSync(
       '/bin/ps',

--- a/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
+++ b/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
@@ -2244,14 +2244,15 @@ describePosix('TerminalSessionBroker resilience', () => {
       )
       await sleep(200)
 
-      const startedAt = Date.now()
       client.write(sessionId, 'go\n')
       await withTimeout(done.promise)
 
-      // Full delivery requires the broker to pause the PTY stream, wait out
-      // the stuck-client timer, destroy that client, and resume: it cannot
-      // finish before the timer.
-      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(900)
+      // The broker drops a stuck client two ways: markPressured's
+      // stuck-client timer, and sendRaw destroying it the moment its buffered
+      // bytes pass clientBufferLimit. Which one fires depends on how much the
+      // kernel absorbs first - macOS loopback buffers up to 8MB, so the timer
+      // wins there, while Linux passes the 4MB limit almost immediately.
+      // Asserting a floor here would only pin down which path ran.
       // Exact length proves the paused stream resumed without losing or
       // duplicating output once the stuck client was dropped.
       expect(received).toBe(expectedTotal)


### PR DESCRIPTION
Stacked on #128 — merge that first.

## The assertion

`a stuck attached client is dropped while a healthy client receives everything` asserted:

```js
expect(Date.now() - startedAt).toBeGreaterThanOrEqual(900)
```

with the comment "it cannot finish before the timer". On Linux it measured 126–140ms.

## Why

The broker has **two** ways to drop a stuck client:

| path | trigger | wait |
| --- | --- | --- |
| `sendRaw` (`TerminalSessionBrokerSource.ts:281`) | buffered bytes pass `clientBufferLimit` = 4MB | immediate |
| `markPressured` (`:302`) | `stuckClientMs` timer | 1s |

Which one fires depends on how much the kernel absorbs before `socket.write()` returns false. The test itself notes that macOS loopback buffers absorb up to 8MB — so userspace stays under 4MB long enough for the timer to win. Linux socket buffers are far smaller, so the 32MB payload passes 4MB almost immediately and `sendRaw` destroys the client on the spot.

Both are correct behaviour; the Linux path is arguably the better one. The 900ms floor recorded which path ran, not whether the broker did the right thing.

## The change

Drop the floor and the now-unused `startedAt`, and explain both paths in the comment. What the test guarantees is untouched:

- `expect(received).toBe(expectedTotal)` — no bytes lost or duplicated across the pause/resume
- `expect(tail.endsWith('DONE\n')).toBe(true)` — order preserved
- the stuck client's close is still awaited

## Verification

`node:20-bookworm`, both integration suites, three consecutive runs: **90/90, 90/90**, then 88/90 with two *different* intermittent failures (`natural root exit reaps a detached child…` and `a non-force stop preserves the target SIGTERM grace period`).

macOS: 90/90.

So this clears the last deterministic Linux failure. What remains is genuine timing flakiness that moves between tests run to run — tracked separately, and it needs to be settled before the integration suites can join CI.