### PR TITLE
chore(ci): split the commit-time gate from the CI gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,19 +1,20 @@
-name: CI
+name: Lint
 
+# Safety net for the pre-commit hook: the hook only lints staged files, and it
+# can be skipped with --no-verify, so CI lints the whole tree.
 on:
   pull_request:
-  push:
     branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: lint-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,12 +32,3 @@ jobs:
 
       - name: Lint
         run: npm run lint
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      # The *.integration.test.ts suites are excluded here: they drive real
-      # processes, PTYs and sockets, and currently fail on Linux runners. They
-      # get their own job once they pass on ubuntu.
-      - name: Test
-        run: npm run test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+# The merge gate. Runs on PRs targeting main, plus on main itself so a merge
+# that lands without a green PR still gets checked.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      # ts-jest transpiles without diagnostics and esbuild skips type checking,
+      # so nothing else in this workflow catches type errors.
+      - name: Typecheck
+        run: npm run typecheck
+
+      # The *.integration.test.ts suites are excluded here: they drive real
+      # processes, PTYs and sockets, and currently fail on Linux runners. They
+      # get their own job once they pass on ubuntu.
+      - name: Test
+        run: npm run test:unit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,13 +1,7 @@
 PATH="/Users/hiroyaiizuka/.local/share/mise/installs/node/24.8.0/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 export PATH
 
-npm run lint
-
-# ts-jest transpiles without diagnostics and esbuild skips type checking, so
-# nothing else in this hook catches type errors.
-npm run typecheck
-
-# The two *.integration.test.ts suites drive real processes, PTYs and sockets,
-# and take ~50s locally against ~15s for everything else. Run them yourself with
-# npm run test:integration; the commit-time gate stays on the fast suite.
-npm run test:unit
+# Commit-time gate is lint only, and only over the staged files. Typecheck and
+# the test suites moved to CI (.github/workflows/test.yml) so committing stays
+# fast; run them yourself with npm run typecheck / npm run test:unit.
+npx lint-staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,8 @@ npm run dev    # esbuild --watch
 npm run build  # production bundle
 npm test       # Jest (ts-jest, jsdom)
 ```
-- Husky pre-commit runs `npm run lint` と `npm test`; `HUSKY=0` で一時無効化可能（推奨せず）
+- Husky pre-commit は `lint-staged` 経由でステージ済みファイルの `eslint` のみ実行; `HUSKY=0` で一時無効化可能（推奨せず）
+- 型チェックとテストは CI 側（`.github/workflows/test.yml`）が担当。手元では `npm run typecheck` / `npm run test:unit` を任意に実行
 - Jest roots: `tests/`
   - `tests/task-sort/…` – slot persistence & ordering
   - `tests/task-display/…` – display/deletion/target_date logic

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
+        "lint-staged": "^17.3.0",
         "moment": "^2.30.1",
         "obsidian": "^1.8.7",
         "ts-jest": "^29.4.4",
@@ -7433,6 +7434,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
+      "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.5",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -8743,6 +8781,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -9114,6 +9162,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tldts": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "prepare": "husky",
     "lint": "eslint --config eslint.config.mjs \"src/**/*.{ts,tsx,js}\" \"tests/**/*.{ts,tsx,js}\""
   },
+  "lint-staged": {
+    "src/**/*.{ts,tsx,js}": "eslint --config eslint.config.mjs --no-warn-ignored",
+    "tests/**/*.{ts,tsx,js}": "eslint --config eslint.config.mjs --no-warn-ignored"
+  },
   "devDependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.4",
@@ -36,6 +40,7 @@
     "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
+    "lint-staged": "^17.3.0",
     "moment": "^2.30.1",
     "obsidian": "^1.8.7",
     "ts-jest": "^29.4.4",


### PR DESCRIPTION
## Summary

The pre-commit hook and `ci.yml` ran the same three checks — `lint`, `typecheck` and `test:unit` — so every check happened twice and committing paid for the whole suite. This splits them by role: lint at commit time, typecheck and tests in CI.

## Changes

- **Pre-commit is lint only, over staged files**, via `lint-staged`. No `--fix` — the hook still just reports, as it did before. `typecheck` and `test:unit` are gone from the hook.
- **`.github/workflows/test.yml`** (renamed from `ci.yml`) runs `typecheck` + `test:unit` on PRs targeting `main` and on `main` itself, so a merge that lands without a green PR is still checked.
- **`.github/workflows/lint.yml`** lints the whole tree on PRs. The hook only sees staged files and `--no-verify` skips it entirely, so CI keeps a full pass as the safety net.
- `AGENTS.md` updated to describe the new hook.

The `*.integration.test.ts` exclusion is unchanged — those suites still fail on Linux runners and keep their existing comment.

## Follow-up

Branch protection is not set up, so `test.yml` does not block a merge yet. Marking `test` (and `lint`) a required status check is a separate step in repo settings.

## Verification

- Staged a real `src/` file and ran `npx lint-staged` — eslint ran against that one file and passed.