### PR TITLE
fix(license): point the license API at the live worker

### DIFF
--- a/src/features/license/config.ts
+++ b/src/features/license/config.ts
@@ -23,7 +23,7 @@ export const LICENSE_PUBLIC_KEY = 'be-8ZHqidokTIubfzpcEUfk5hZbSQYGn6GyHU1nSrKg'
 /** Baked into the token payload (`p`) and the license-id derivation. */
 export const LICENSE_PRODUCT_ID = 'taskchute-plus'
 
-export const LICENSE_API_BASE = 'https://taskchute-license.ancient-truth-f5b4.workers.dev'
+export const LICENSE_API_BASE = 'https://taskchute-license.levers.workers.dev'
 
 /**
  * Refresh once the token has less than this long to live. Comfortably shorter


### PR DESCRIPTION
## What

Switches `LICENSE_API_BASE` from `taskchute-license.ancient-truth-f5b4.workers.dev` to `taskchute-license.levers.workers.dev`.

## Why

The old subdomain no longer resolves. Every `POST /v1/token` and `POST /v1/devices` from a released build fails at the network layer before any response comes back, so license activation and device listing are broken for users on the current release.

## Verification

| Host | `POST /v1/token` |
|---|---|
| `ancient-truth-f5b4` (old) | no response — connection fails |
| `levers` (new) | `400` on an empty body — route live and validating |

`LICENSE_API_BASE` has a single consumer, `LicenseApiClient` (which already accepts a `baseUrl` override), so nothing else needed changing. `tests/features/license` passes: 7 suites / 121 cases.