### PR TITLE
fix(ai-task): keep the broker startable on Linux and stop testing the platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         type: choice
         options: [patch, minor, major]
       skip_tests:
-        description: "Skip the test suite (use only when a known-flaky suite blocks a release)"
+        description: "Skip the integration suite only; the unit suite always runs"
         required: false
         default: false
         type: boolean
@@ -57,9 +57,17 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Test
+      # The unit suite has no escape hatch. A hotfix at 2am is a reason to skip
+      # a ten-minute real-process suite; it is never a reason to ship without
+      # the unit tests.
+      - name: Test (unit)
+        run: npm run test:unit
+
+      - name: Test (integration)
         if: ${{ !inputs.skip_tests }}
-        run: npm test
+        env:
+          TASKCHUTE_TEST_REQUIRE_BINARIES: "1"
+        run: npm run test:integration
 
       - name: Configure git user
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     timeout-minutes: 15
+    # Reports without blocking, because these suites are not green on Linux yet
+    # and never have been — this job is the first time they have run there.
+    #
+    # The remaining failures are cross-test interference, not a Linux defect in
+    # the broker: the failing set changes between runs of the same commit on the
+    # same machine (observed 1, 3 and 5 failures), and every one of them passes
+    # when run alone. A test that fails to reap its detached children leaves them
+    # behind for whatever runs next. Fixing that means giving each case its own
+    # isolation, which is a change to the suites, not to the broker.
+    #
+    # Flip this to a blocking check once a run is green.
+    continue-on-error: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,14 @@ jobs:
         run: npm run typecheck
 
       # The *.integration.test.ts suites are excluded here: they drive real
-      # processes, PTYs and sockets, and currently fail on Linux runners. They
-      # get their own job once they pass on ubuntu.
+      # processes, PTYs and sockets, and a handful of their cases are still
+      # timing-dependent on Linux runners. They get their own job once those are
+      # fixed.
+      #
+      # Note the unit suite now also guards a Linux-only spawn limit the
+      # integration suites cannot reach from macOS: the broker ships as the
+      # single `-e` argument of a spawned node, and Linux rejects an execve
+      # whose individual argv string exceeds MAX_ARG_STRLEN (32 * PAGE_SIZE =
+      # 131_072 bytes) with E2BIG. See broker-source-budget.test.ts.
       - name: Test
         run: npm run test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,15 +37,52 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      # The *.integration.test.ts suites are excluded here: they drive real
-      # processes, PTYs and sockets, and a handful of their cases are still
-      # timing-dependent on Linux runners. They get their own job once those are
-      # fixed.
+      # The *.integration.test.ts suites run in their own job below; this one
+      # stays fast and is the merge gate.
       #
-      # Note the unit suite now also guards a Linux-only spawn limit the
-      # integration suites cannot reach from macOS: the broker ships as the
-      # single `-e` argument of a spawned node, and Linux rejects an execve
-      # whose individual argv string exceeds MAX_ARG_STRLEN (32 * PAGE_SIZE =
-      # 131_072 bytes) with E2BIG. See broker-source-budget.test.ts.
+      # It also guards a Linux-only spawn limit that no macOS run can reach:
+      # the broker ships as the single `-e` argument of a spawned node, and
+      # Linux rejects an execve whose individual argv string exceeds
+      # MAX_ARG_STRLEN (32 * PAGE_SIZE = 131_072 bytes) with E2BIG. See
+      # broker-source-budget.test.ts.
       - name: Test
         run: npm run test:unit
+
+  # Separate from the unit job on purpose: these suites spawn real processes,
+  # PTYs and sockets, so they need their own timeout and can be made
+  # non-required while their pass rate on ubuntu is still being established.
+  integration:
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      # Turns "17 cases were mysteriously skipped" into one named error before
+      # any test runs. Everything here ships in the ubuntu-latest image; if this
+      # step ever fails, install exactly what it names rather than guessing.
+      - name: Verify the binaries these suites drive
+        run: |
+          set -euo pipefail
+          for binary in /bin/ps /bin/sh /bin/stty /usr/bin/script \
+                        /usr/bin/env /usr/bin/python3 /usr/bin/yes /usr/bin/tail; do
+            test -x "$binary" || { echo "::error::missing $binary"; exit 1; }
+          done
+
+      - name: Integration tests
+        env:
+          # A missing binary must fail rather than skip: a green run that
+          # skipped everything is the defect these suites just stopped having.
+          TASKCHUTE_TEST_REQUIRE_BINARIES: "1"
+        run: npm run test:integration

--- a/src/features/ai-task/services/NodeProcessGateway.ts
+++ b/src/features/ai-task/services/NodeProcessGateway.ts
@@ -19,6 +19,7 @@ import {
   WorkspaceFileGateway,
 } from './WorkspaceFileService'
 import { stableTimeoutSource } from '../../../utils/stableTimer'
+import { parseDescendantSnapshot } from './process/parseDescendantSnapshot'
 
 // Ambient declarations for the Electron renderer runtime (no @types/node in
 // the src build). These shadow nothing at runtime; they only inform tsc.
@@ -399,36 +400,7 @@ function collectDescendantPids(rootPid: number): ProcessIdentitySnapshot[] {
       ['-axo', 'pid=,ppid=,lstart='],
       { encoding: 'utf8' },
     )
-    const childrenByParent = new Map<number, ProcessIdentitySnapshot[]>()
-    for (const line of output.split('\n')) {
-      const match = line
-        .trim()
-        .match(/^(\d+)\s+(\d+)\s+(.+)$/u)
-      if (!match) continue
-      const pid = Number(match[1])
-      const parentPid = Number(match[2])
-      const children = childrenByParent.get(parentPid) ?? []
-      children.push({ pid, birthToken: match[3].trim() })
-      childrenByParent.set(parentPid, children)
-    }
-
-    const descendants: ProcessIdentitySnapshot[] = []
-    const pending = [...(childrenByParent.get(rootPid) ?? [])]
-    const seen = new Set<number>()
-    while (pending.length > 0) {
-      const identity = pending.pop()
-      if (
-        identity === undefined ||
-        identity.pid < 1 ||
-        seen.has(identity.pid)
-      ) {
-        continue
-      }
-      seen.add(identity.pid)
-      descendants.push(identity)
-      pending.push(...(childrenByParent.get(identity.pid) ?? []))
-    }
-    return descendants
+    return parseDescendantSnapshot(output, rootPid)
   } catch {
     // Best effort: the inner PTY supervisor still covers the normal group.
     return []

--- a/src/features/ai-task/services/TerminalSessionBrokerSource.ts
+++ b/src/features/ai-task/services/TerminalSessionBrokerSource.ts
@@ -1,6 +1,7 @@
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from './TerminalSessionOwnerWatchdogSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from './TerminalSessionGuardSource'
 import { TERMINAL_BROKER_PURE_SOURCE } from './broker-source/TerminalBrokerPureSource'
+import { POSIX_PROCESS_SNAPSHOT_SOURCE } from './broker-source/PosixProcessSnapshotSource'
 import {
   gzipBase64,
   INFLATE_PROGRAM_SOURCE,
@@ -20,6 +21,7 @@ const cp = require('child_process');
 const crypto = require('crypto');
 const path = require('path');
 ${TERMINAL_BROKER_PURE_SOURCE}
+${POSIX_PROCESS_SNAPSHOT_SOURCE}
 ${INFLATE_PROGRAM_SOURCE}
 // Carried compressed: as plain string literals these two cost ~46KB of the
 // 131_072-byte Linux limit on a single argv string. See EmbeddedProgramSource.
@@ -590,54 +592,11 @@ function readOwnerPidRecords(session) {
     session.ownerTrackingUnknown = false;
   }
 }
-// macOS does not expose another process' environment through ps eww, while
-// the extra environment text makes every startup snapshot substantially
-// larger. Keep the environment-bearing form only on Linux, where it can
-// recover an already reparented cooperative descendant by its owner marker.
-const posixPsArgs = process.platform === 'linux'
-  ? ['axeww', '-o', 'pid=,ppid=,pgid=,lstart=,command=']
-  : ['-axo', 'pid=,ppid=,pgid=,lstart=,command='];
-const posixPsOptions = {
-  encoding: 'utf8',
-  maxBuffer: 16 * 1024 * 1024,
-  env: Object.assign({}, process.env, { LC_ALL: 'C', LANG: 'C' }),
-};
-function parsePosixProcessSnapshot(output) {
-  const snapshot = new Map();
-  for (const line of output.split('\n')) {
-    const match = line.match(
-      /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+\s+\S+\s+\d+\s+\d\d:\d\d:\d\d\s+\d{4})\s+(.*)$/,
-    );
-    if (!match) continue;
-    const startedAt = Date.parse(match[4]);
-    snapshot.set(Number(match[1]), {
-      ppid: Number(match[2]),
-      pgid: Number(match[3]),
-      startedAt: Number.isFinite(startedAt) ? startedAt : null,
-      command: match[5],
-    });
-  }
-  return snapshot;
-}
-function snapshotIdentity(entry) {
-  if (!entry || !Number.isFinite(entry.startedAt)) return null;
-  return {
-    lower: entry.startedAt,
-    upper: entry.startedAt,
-    kind: 'snapshot',
-    parentPid: entry.ppid,
-    processGroup: entry.pgid,
-    commandHint:
-      typeof entry.command === 'string'
-        ? entry.command.slice(0, 512)
-        : '',
-  };
-}
 function readPosixProcessSnapshot() {
   if (process.platform !== 'darwin' && process.platform !== 'linux') return null;
   try {
     return parsePosixProcessSnapshot(
-      cp.execFileSync('/bin/ps', posixPsArgs, posixPsOptions),
+      cp.execFileSync('/bin/ps', posixSnapshotPsArgs(process.platform), posixSnapshotPsOptions(process.env)),
     );
   } catch (_) { return null; }
 }
@@ -647,7 +606,7 @@ function readPosixProcessSnapshotAsync(callback) {
     return;
   }
   try {
-    cp.execFile('/bin/ps', posixPsArgs, posixPsOptions, (error, stdout) => {
+    cp.execFile('/bin/ps', posixSnapshotPsArgs(process.platform), posixSnapshotPsOptions(process.env), (error, stdout) => {
       if (error || typeof stdout !== 'string') {
         callback(null);
         return;
@@ -721,19 +680,13 @@ function pidOwnershipState(pid, identity, snapshot) {
     let actualStart;
     let entry = null;
     if (process.platform === 'win32') {
-      const root = process.env.SystemRoot || process.env.SYSTEMROOT || 'C:\\Windows';
-      const powershell =
-        root.replace(/[\\/]+$/, '') +
-        '\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+      const reader = windowsBirthReaderArgv(
+        pid,
+        process.env.SystemRoot || process.env.SYSTEMROOT,
+      );
       const value = cp.execFileSync(
-        powershell,
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          "(Get-Process -Id " + String(pid) +
-            " -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')",
-        ],
+        reader.command,
+        reader.args,
         { encoding: 'utf8', maxBuffer: 4096, windowsHide: true },
       ).trim();
       actualStart = Date.parse(value);
@@ -766,18 +719,9 @@ function pidOwnershipState(pid, identity, snapshot) {
         !entry.command.includes(identity.guardToken)
       )
     ) return 'mismatch';
-    // POSIX lstart is rounded down to seconds. The hook records the interval
-    // surrounding spawn(), so a paused/slow syscall remains a match without
-    // widening the PID-reuse window to several seconds.
     const matchesBirth = process.platform === 'win32'
-      ? (
-        actualStart >= identity.lower &&
-        actualStart <= identity.upper
-      )
-      : (
-        actualStart >= Math.floor(identity.lower / 1000) * 1000 &&
-        actualStart <= Math.floor(identity.upper / 1000) * 1000
-      );
+      ? windowsBirthWindowMatches(actualStart, identity.lower, identity.upper)
+      : posixBirthWindowMatches(actualStart, identity.lower, identity.upper);
     if (!matchesBirth) return 'mismatch';
     if (
       process.platform !== 'win32' &&
@@ -816,27 +760,11 @@ function pidOwnershipState(pid, identity, snapshot) {
 }
 function captureSnapshotDescendants(session, snapshot) {
   if (!snapshot || !session.child || !session.child.pid) return;
-  const children = new Map();
-  for (const [pid, entry] of snapshot.entries()) {
-    const siblings = children.get(entry.ppid) || [];
-    siblings.push(pid);
-    children.set(entry.ppid, siblings);
-  }
-  const pending = [session.child.pid];
-  const seen = new Set();
-  while (pending.length > 0) {
-    const parentPid = pending.pop();
-    if (!parentPid || seen.has(parentPid)) continue;
-    seen.add(parentPid);
-    const nested = children.get(parentPid);
-    if (!nested) continue;
-    for (const pid of nested) {
-      const entry = snapshot.get(pid);
-      const existing = session.ownedPids.get(pid);
-      if (entry && (!existing || existing.kind === 'snapshot')) {
-        session.ownedPids.set(pid, snapshotIdentity(entry));
-      }
-      pending.push(pid);
+  for (const pid of posixSnapshotDescendantPids(snapshot, [session.child.pid])) {
+    const entry = snapshot.get(pid);
+    const existing = session.ownedPids.get(pid);
+    if (entry && (!existing || existing.kind === 'snapshot')) {
+      session.ownedPids.set(pid, posixSnapshotIdentity(entry));
     }
   }
 }
@@ -905,7 +833,7 @@ function scanOwnedPids(session, providedSnapshot) {
     // shutdown unconfirmed instead of trusting a reusable numeric PID.
     const existing = session.ownedPids.get(pid);
     if (!existing || existing.kind === 'snapshot') {
-      session.ownedPids.set(pid, snapshotIdentity(entry));
+      session.ownedPids.set(pid, posixSnapshotIdentity(entry));
     }
     const nested = children.get(pid);
     if (nested) pending.push.apply(pending, nested);

--- a/src/features/ai-task/services/TerminalSessionBrokerSource.ts
+++ b/src/features/ai-task/services/TerminalSessionBrokerSource.ts
@@ -1,10 +1,6 @@
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from './TerminalSessionOwnerWatchdogSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from './TerminalSessionGuardSource'
-import {
-  FISH_TERMINAL_BOOTSTRAP,
-  POSIX_TERMINAL_BOOTSTRAP,
-  TERMINAL_ARGV_BOOTSTRAP_ARG_ZERO,
-} from './dispatchers/TerminalShellBootstrap'
+import { TERMINAL_BROKER_PURE_SOURCE } from './broker-source/TerminalBrokerPureSource'
 
 /**
  * Renderer-independent Node broker program.
@@ -19,17 +15,14 @@ const fs = require('fs');
 const cp = require('child_process');
 const crypto = require('crypto');
 const path = require('path');
+${TERMINAL_BROKER_PURE_SOURCE}
 const ownerWatchdogProgram = ${JSON.stringify(TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE)};
 const sessionGuardProgram = ${JSON.stringify(TERMINAL_SESSION_GUARD_SOURCE)};
-const terminalArgvBootstrapProgram = ${JSON.stringify(POSIX_TERMINAL_BOOTSTRAP)};
-const fishTerminalArgvBootstrapProgram = ${JSON.stringify(FISH_TERMINAL_BOOTSTRAP)};
-const terminalArgvBootstrapArgZero = ${JSON.stringify(TERMINAL_ARGV_BOOTSTRAP_ARG_ZERO)};
 const descriptorPath = process.env.TASKCHUTE_BROKER_DESCRIPTOR;
 const token = process.env.TASKCHUTE_BROKER_TOKEN;
 const idleTtlMs = Number(process.env.TASKCHUTE_BROKER_TTL_MS || 1800000);
 const replayLimit = 200 * 1024;
 const frameLimit = 1024 * 1024;
-const stderrPendingLimit = 64 * 1024;
 // Renderer clients destroy their socket when a frame exceeds 1MB; keep the
 // serialized 'attached' frame well under that with headroom for interleaved
 // data frames and the envelope.
@@ -49,7 +42,6 @@ const ownerRecordLimit = 2048;
 const ownerReadChunkLimit = 16 * 1024;
 const ownerReadScanLimit = 64 * 1024;
 const ownerTrackingFailureLimit = 3;
-const ownerPidFileEnvName = 'TASKCHUTE_BROKER_OWNER_PID_FILE';
 const ownerTokenPrefix = String(token || '').slice(0, 24);
 const ownerSessionPrefix =
   descriptorPath + '.owner-session-' + ownerTokenPrefix + '-';
@@ -1284,46 +1276,10 @@ function outcomeFor(session, code, signal) {
   };
 }
 function consumeStderr(session, text, flush) {
-  session.stderrPending += text;
-  let newline = session.stderrPending.indexOf('\n');
-  while (newline >= 0) {
-    const line = session.stderrPending.slice(0, newline + 1);
-    session.stderrPending = session.stderrPending.slice(newline + 1);
-    const match = line.match(new RegExp(marker + '(\\d+)'));
-    if (match) session.sentinelCode = Number(match[1]);
-    let visible = line.replace(new RegExp(marker + '\\d+\\r?\\n?'), '');
-    if (session.stderrDroppedChars > 0) {
-      visible = '…[+' + session.stderrDroppedChars + ' stderr chars truncated]\n' + visible;
-      session.stderrDroppedChars = 0;
-    }
-    if (visible) {
-      appendReplay(session, visible);
-      broadcast(session, { type: 'data', sessionId: session.id, data: visible });
-    }
-    newline = session.stderrPending.indexOf('\n');
-  }
-  if (flush && session.stderrPending) {
-    const tail = session.stderrPending;
-    session.stderrPending = '';
-    const match = tail.match(new RegExp(marker + '(\\d+)'));
-    if (match) session.sentinelCode = Number(match[1]);
-    let visible = tail.replace(new RegExp(marker + '\\d+'), '');
-    if (session.stderrDroppedChars > 0) {
-      visible = '…[+' + session.stderrDroppedChars + ' stderr chars truncated]\n' + visible;
-      session.stderrDroppedChars = 0;
-    }
-    if (visible) {
-      appendReplay(session, visible);
-      broadcast(session, { type: 'data', sessionId: session.id, data: visible });
-    }
-  }
-  if (!flush && session.stderrPending.length > stderrPendingLimit) {
-    const dropped = session.stderrPending.length - stderrPendingLimit;
-    session.stderrDroppedChars += dropped;
-    // JSON materialization avoids retaining the oversized concatenation as
-    // the parent of a short V8 SlicedString.
-    session.stderrPending = JSON.parse(JSON.stringify(session.stderrPending.slice(-stderrPendingLimit)));
-  }
+  consumeStderrInto(session, text, flush, marker, function (visible) {
+    appendReplay(session, visible);
+    broadcast(session, { type: 'data', sessionId: session.id, data: visible });
+  });
 }
 function finalizeSession(session) {
   if (session.completed) return;
@@ -1403,302 +1359,6 @@ function finish(session, code, signal, streamsClosed) {
     timer.unref();
   };
   awaitOwnedExit();
-}
-function executableName(value) {
-  return String(value || '').split(/[\\/]/).pop().toLowerCase();
-}
-function isPythonExecutable(value) {
-  return /^python(?:\d+(?:\.\d+)*)?$/.test(executableName(value));
-}
-function pythonArgsDisableOwnershipHook(args) {
-  for (let index = 0; index < args.length; index += 1) {
-    const token = String(args[index]);
-    if (token === '--') return false;
-    if (!token.startsWith('-') || token === '-') return false;
-    if (token === '-c' || token === '-m') return false;
-    if (/^-[^-]*[EIS]/.test(token)) return true;
-    // These interpreter options consume the next token. None disables the
-    // hook itself, and the consumed value must not be mistaken for a flag.
-    if (token === '-W' || token === '-X') index += 1;
-  }
-  return false;
-}
-function protectedOwnershipEnvName(value) {
-  const name = String(value || '').split('=', 1)[0].toUpperCase();
-  return (
-    name === 'NODE_OPTIONS' ||
-    name === 'PYTHONPATH' ||
-    name === ownerPidFileEnvName
-  );
-}
-function envLaunchDisablesPythonOwnershipHook(args) {
-  let commandIndex = 0;
-  while (commandIndex < args.length) {
-    const token = String(args[commandIndex]);
-    if (token === '--') {
-      commandIndex += 1;
-      break;
-    }
-    if (token === '-i' || token === '--ignore-environment') return true;
-    if (token === '-u' || token === '--unset') {
-      const name = args[commandIndex + 1];
-      if (protectedOwnershipEnvName(name)) return true;
-      commandIndex += 2;
-      continue;
-    }
-    if (token.startsWith('--unset=')) {
-      if (protectedOwnershipEnvName(token.slice('--unset='.length))) {
-        return true;
-      }
-      commandIndex += 1;
-      continue;
-    }
-    if (/^-u.+/.test(token)) {
-      if (protectedOwnershipEnvName(token.slice(2))) return true;
-      commandIndex += 1;
-      continue;
-    }
-    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
-      if (protectedOwnershipEnvName(token)) return true;
-      commandIndex += 1;
-      continue;
-    }
-    if (token.startsWith('-')) {
-      commandIndex += 1;
-      continue;
-    }
-    break;
-  }
-  return (
-    isPythonExecutable(args[commandIndex]) &&
-    pythonArgsDisableOwnershipHook(args.slice(commandIndex + 1))
-  );
-}
-function splitShellCommandSegments(source) {
-  const segments = [];
-  let current = '';
-  let quote = '';
-  let escaped = false;
-  for (let index = 0; index < source.length; index += 1) {
-    const character = source[index];
-    if (escaped) {
-      current += character;
-      escaped = false;
-      continue;
-    }
-    if (character === '\\' && quote !== "'") {
-      current += character;
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      current += character;
-      if (character === quote) quote = '';
-      continue;
-    }
-    if (character === "'" || character === '"') {
-      quote = character;
-      current += character;
-      continue;
-    }
-    const next = source[index + 1];
-    if (
-      character === ';' ||
-      character === '\n' ||
-      character === '|' ||
-      character === '&'
-    ) {
-      if (current.trim()) segments.push(current);
-      current = '';
-      if (
-        (character === '|' || character === '&') &&
-        next === character
-      ) index += 1;
-      continue;
-    }
-    current += character;
-  }
-  if (current.trim()) segments.push(current);
-  return segments;
-}
-function tokenizeShellWords(source) {
-  const words = [];
-  let current = '';
-  let quote = '';
-  let escaped = false;
-  const flush = () => {
-    if (!current) return;
-    words.push(current);
-    current = '';
-  };
-  for (const character of source) {
-    if (escaped) {
-      current += character;
-      escaped = false;
-      continue;
-    }
-    if (character === '\\' && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      if (character === quote) quote = '';
-      else current += character;
-      continue;
-    }
-    if (character === "'" || character === '"') {
-      quote = character;
-      continue;
-    }
-    if (/\s/.test(character)) {
-      flush();
-      continue;
-    }
-    current += character;
-  }
-  flush();
-  return words;
-}
-function shellSegmentDisablesPythonOwnershipHook(segment) {
-  const words = tokenizeShellWords(segment);
-  while (
-    words[0] === 'exec' ||
-    words[0] === 'command' ||
-    words[0] === 'then' ||
-    words[0] === 'do' ||
-    words[0] === 'else'
-  ) words.shift();
-  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[0] || '')) {
-    if (protectedOwnershipEnvName(words[0])) return true;
-    words.shift();
-  }
-  if (
-    (words[0] === 'unset' || words[0] === 'export') &&
-    words.slice(1).some(protectedOwnershipEnvName)
-  ) return true;
-  if (executableName(words[0]) === 'env') {
-    return envLaunchDisablesPythonOwnershipHook(words.slice(1));
-  }
-  return (
-    isPythonExecutable(words[0]) &&
-    pythonArgsDisableOwnershipHook(words.slice(1))
-  );
-}
-function executableLaunchDisablesPythonOwnershipHook(binary, args) {
-  const name = executableName(binary);
-  if (
-    isPythonExecutable(name) &&
-    pythonArgsDisableOwnershipHook(args)
-  ) return true;
-  return (
-    name === 'env' &&
-    envLaunchDisablesPythonOwnershipHook(args)
-  );
-}
-function terminalArgvBootstrapDisablesPythonHook(binary, binaryArgs) {
-  const name = executableName(binary);
-  const commandIndex = binaryArgs.indexOf('-c');
-  if (commandIndex < 0) return false;
-  const program = binaryArgs[commandIndex + 1];
-  let positionals;
-  if (name === 'fish') {
-    if (
-      program !== fishTerminalArgvBootstrapProgram ||
-      binaryArgs[commandIndex + 2] !== terminalArgvBootstrapProgram
-    ) return false;
-    positionals = binaryArgs.slice(commandIndex + 3);
-  } else {
-    if (
-      !/^(?:a|ba|da|k|mk|z)?sh$/.test(name) ||
-      program !== terminalArgvBootstrapProgram ||
-      binaryArgs[commandIndex + 2] !== terminalArgvBootstrapArgZero
-    ) return false;
-    positionals = binaryArgs.slice(commandIndex + 3);
-  }
-  // shell, resolved, command, fallback, prefixCount
-  if (positionals.length < 5) return true;
-  const resolved = positionals[1];
-  const command = positionals[2];
-  const fallback = positionals[3];
-  const prefixCountText = positionals[4];
-  const payload = positionals.slice(5);
-  if (
-    typeof resolved !== 'string' ||
-    typeof command !== 'string' ||
-    typeof fallback !== 'string' ||
-    typeof prefixCountText !== 'string' ||
-    !/^(?:0|[1-9][0-9]*)$/.test(prefixCountText)
-  ) return true;
-  const prefixCount = Number(prefixCountText);
-  if (
-    !Number.isSafeInteger(prefixCount) ||
-    prefixCount < 0 ||
-    prefixCount > payload.length
-  ) return true;
-  const commandArgs = payload.slice(prefixCount);
-  return (
-    executableLaunchDisablesPythonOwnershipHook(resolved, payload) ||
-    executableLaunchDisablesPythonOwnershipHook(command, commandArgs) ||
-    executableLaunchDisablesPythonOwnershipHook(fallback, commandArgs)
-  );
-}
-function taskChutePtyPositionalLaunchDisablesPythonHook(
-  request,
-  commandIndex,
-  shellProgram,
-) {
-  // The injection-safe PTY wrappers carry the transcript as outer shell $0
-  // and append the real binary/argv as unused validation positionals.
-  // Looking only at the fixed '-c' program therefore misses a direct Python
-  // -S launch even though the production request is statically identifiable.
-  if (
-    !shellProgram.includes('TASKCHUTE_AI_TTY_PATH="$0.tty"') ||
-    !shellProgram.includes('/usr/bin/script')
-  ) return false;
-  const binaryIndex = commandIndex + 3;
-  const binary = request.args[binaryIndex];
-  if (typeof binary !== 'string') return false;
-  const binaryArgs = request.args.slice(binaryIndex + 1);
-  return (
-    executableLaunchDisablesPythonOwnershipHook(binary, binaryArgs) ||
-    terminalArgvBootstrapDisablesPythonHook(binary, binaryArgs)
-  );
-}
-function launchDisablesPythonOwnershipHook(request, initialInput) {
-  const commandName = executableName(request.command);
-  if (
-    isPythonExecutable(commandName) &&
-    pythonArgsDisableOwnershipHook(request.args)
-  ) return true;
-  if (
-    commandName === 'env' &&
-    envLaunchDisablesPythonOwnershipHook(request.args)
-  ) return true;
-  if (!/^(?:ba|z|k)?sh$/.test(commandName)) return false;
-  const commandIndex = request.args.indexOf('-c');
-  if (commandIndex < 0 || typeof request.args[commandIndex + 1] !== 'string') {
-    return typeof initialInput === 'string' &&
-      splitShellCommandSegments(initialInput).some(
-        shellSegmentDisablesPythonOwnershipHook,
-      );
-  }
-  const shellProgram = request.args[commandIndex + 1];
-  return (
-    splitShellCommandSegments(shellProgram).some(
-      shellSegmentDisablesPythonOwnershipHook,
-    ) ||
-    taskChutePtyPositionalLaunchDisablesPythonHook(
-      request,
-      commandIndex,
-      shellProgram,
-    ) ||
-    (
-      typeof initialInput === 'string' &&
-      splitShellCommandSegments(initialInput).some(
-        shellSegmentDisablesPythonOwnershipHook,
-      )
-    )
-  );
 }
 function spawnSession(message, socket) {
   if (

--- a/src/features/ai-task/services/TerminalSessionBrokerSource.ts
+++ b/src/features/ai-task/services/TerminalSessionBrokerSource.ts
@@ -1,6 +1,10 @@
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from './TerminalSessionOwnerWatchdogSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from './TerminalSessionGuardSource'
 import { TERMINAL_BROKER_PURE_SOURCE } from './broker-source/TerminalBrokerPureSource'
+import {
+  gzipBase64,
+  INFLATE_PROGRAM_SOURCE,
+} from './broker-source/EmbeddedProgramSource'
 
 /**
  * Renderer-independent Node broker program.
@@ -16,8 +20,11 @@ const cp = require('child_process');
 const crypto = require('crypto');
 const path = require('path');
 ${TERMINAL_BROKER_PURE_SOURCE}
-const ownerWatchdogProgram = ${JSON.stringify(TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE)};
-const sessionGuardProgram = ${JSON.stringify(TERMINAL_SESSION_GUARD_SOURCE)};
+${INFLATE_PROGRAM_SOURCE}
+// Carried compressed: as plain string literals these two cost ~46KB of the
+// 131_072-byte Linux limit on a single argv string. See EmbeddedProgramSource.
+const ownerWatchdogProgram = inflateProgram(${JSON.stringify(gzipBase64(TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE))});
+const sessionGuardProgram = inflateProgram(${JSON.stringify(gzipBase64(TERMINAL_SESSION_GUARD_SOURCE))});
 const descriptorPath = process.env.TASKCHUTE_BROKER_DESCRIPTOR;
 const token = process.env.TASKCHUTE_BROKER_TOKEN;
 const idleTtlMs = Number(process.env.TASKCHUTE_BROKER_TTL_MS || 1800000);

--- a/src/features/ai-task/services/TerminalSessionGuardSource.ts
+++ b/src/features/ai-task/services/TerminalSessionGuardSource.ts
@@ -1,3 +1,5 @@
+import { POSIX_PROCESS_SNAPSHOT_SOURCE } from './broker-source/PosixProcessSnapshotSource'
+
 /**
  * Per-session supervisor used by the renderer-independent terminal broker.
  *
@@ -11,6 +13,7 @@ export const TERMINAL_SESSION_GUARD_SOURCE = String.raw`
 const cp = require('child_process');
 const fs = require('fs');
 const net = require('net');
+${POSIX_PROCESS_SNAPSHOT_SOURCE}
 const encoded = process.env.TASKCHUTE_SESSION_GUARD_REQUEST || '';
 const ownerPidFile =
   process.env.TASKCHUTE_BROKER_OWNER_PID_FILE || '';
@@ -188,48 +191,20 @@ function readSnapshot() {
     return null;
   }
   try {
+    // Deliberately the non-environment form on every platform, unlike the
+    // broker and watchdog which switch to 'axeww' on Linux. The guard only
+    // matches by pid/ppid/pgid and birth time, never by an environment marker,
+    // so the extra text would cost snapshot size for nothing. Whether the three
+    // should agree is a separate question from sharing the parser.
     const output = cp.execFileSync(
       '/bin/ps',
-      ['-axo', 'pid=,ppid=,pgid=,lstart=,command='],
-      {
-        encoding: 'utf8',
-        maxBuffer: 16 * 1024 * 1024,
-        env: Object.assign({}, process.env, { LC_ALL: 'C', LANG: 'C' }),
-      },
+      posixSnapshotPsArgs('darwin'),
+      posixSnapshotPsOptions(process.env),
     );
-    const snapshot = new Map();
-    for (const line of output.split('\n')) {
-      const match = line.match(
-        /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+\s+\S+\s+\d+\s+\d\d:\d\d:\d\d\s+\d{4})(?:\s+(.*))?\s*$/,
-      );
-      if (!match) continue;
-      const startedAt = Date.parse(match[4]);
-      snapshot.set(Number(match[1]), {
-        ppid: Number(match[2]),
-        pgid: Number(match[3]),
-        startedAt: Number.isFinite(startedAt) ? startedAt : null,
-        command: match[5] || '',
-      });
-    }
-    return snapshot;
+    return parsePosixProcessSnapshot(output);
   } catch (_) {
     return null;
   }
-}
-
-function snapshotIdentity(entry) {
-  if (!entry || !Number.isFinite(entry.startedAt)) return null;
-  return {
-    lower: entry.startedAt,
-    upper: entry.startedAt,
-    kind: 'snapshot',
-    parentPid: entry.ppid,
-    processGroup: entry.pgid,
-    commandHint:
-      typeof entry.command === 'string'
-        ? entry.command.slice(0, 512)
-        : '',
-  };
 }
 
 function captureTargetTree(snapshot) {
@@ -247,40 +222,24 @@ function captureTargetTree(snapshot) {
     !rootEntry ||
     rootEntry.ppid !== process.pid ||
     !Number.isFinite(rootEntry.startedAt) ||
-    rootEntry.startedAt <
-      Math.floor(targetStartedAtLower / 1000) * 1000 ||
-    rootEntry.startedAt >
-      Math.floor(targetStartedAtUpper / 1000) * 1000
+    !posixBirthWindowMatches(
+      rootEntry.startedAt,
+      targetStartedAtLower,
+      targetStartedAtUpper,
+    )
   ) return;
-  const children = new Map();
-  for (const [pid, entry] of snapshot.entries()) {
-    const nested = children.get(entry.ppid) || [];
-    nested.push(pid);
-    children.set(entry.ppid, nested);
-  }
-  const pending = [target.pid];
-  const seen = new Set();
   if (!captured.has(target.pid)) {
     captured.set(target.pid, {
       lower: targetStartedAtLower,
       upper: targetStartedAtUpper,
     });
   }
-  while (pending.length > 0) {
-    const parent = pending.pop();
-    if (!parent || seen.has(parent)) continue;
-    seen.add(parent);
-    const entry = snapshot.get(parent);
-    const existing = captured.get(parent);
-    if (
-      entry &&
-      Number.isFinite(entry.startedAt) &&
-      (!existing || existing.kind === 'snapshot')
-    ) {
-      captured.set(parent, snapshotIdentity(entry));
+  for (const pid of posixSnapshotDescendantPids(snapshot, [target.pid])) {
+    const identity = posixSnapshotIdentity(snapshot.get(pid));
+    const existing = captured.get(pid);
+    if (identity && (!existing || existing.kind === 'snapshot')) {
+      captured.set(pid, identity);
     }
-    const nested = children.get(parent) || [];
-    for (const pid of nested) pending.push(pid);
   }
 }
 
@@ -292,12 +251,12 @@ function captureOriginalGroupMembers(snapshot) {
       pid === target.pid ||
       entry.pgid !== target.pid ||
       !Number.isFinite(entry.startedAt) ||
-      entry.startedAt < Math.floor(targetStartedAtLower / 1000) * 1000
+      entry.startedAt < posixBirthFloor(targetStartedAtLower)
     ) continue;
     found += 1;
     const existing = captured.get(pid);
     if (!existing || existing.kind === 'snapshot') {
-      captured.set(pid, snapshotIdentity(entry));
+      captured.set(pid, posixSnapshotIdentity(entry));
     }
   }
   return found;
@@ -316,10 +275,11 @@ function verifyDirectTargetIdentity(snapshot) {
     entry &&
     entry.ppid === process.pid &&
     Number.isFinite(entry.startedAt) &&
-    entry.startedAt >=
-      Math.floor(targetStartedAtLower / 1000) * 1000 &&
-    entry.startedAt <=
-      Math.floor(targetStartedAtUpper / 1000) * 1000,
+    posixBirthWindowMatches(
+      entry.startedAt,
+      targetStartedAtLower,
+      targetStartedAtUpper,
+    ),
   );
 }
 
@@ -337,21 +297,13 @@ function scheduleTargetIdentityBurst() {
 
 function windowsStartedAt(pid) {
   try {
-    const root = process.env.SystemRoot ||
-      process.env.SYSTEMROOT ||
-      'C:\\Windows';
-    const powershell =
-      root.replace(/[\\/]+$/, '') +
-      '\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+    const reader = windowsBirthReaderArgv(
+      pid,
+      process.env.SystemRoot || process.env.SYSTEMROOT,
+    );
     const value = cp.execFileSync(
-      powershell,
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        "(Get-Process -Id " + String(pid) +
-          " -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')",
-      ],
+      reader.command,
+      reader.args,
       {
         encoding: 'utf8',
         maxBuffer: 4096,
@@ -438,15 +390,12 @@ function ownershipState(pid, identity, snapshot) {
     !Number.isFinite(actualStart)
   ) return 'unknown';
   if (process.platform === 'win32') {
-    return (
-      actualStart >= identity.lower &&
-      actualStart <= identity.upper
-    ) ? 'match' : 'mismatch';
+    return windowsBirthWindowMatches(actualStart, identity.lower, identity.upper)
+      ? 'match'
+      : 'mismatch';
   }
-  const birthMatches = (
-    actualStart >= Math.floor(identity.lower / 1000) * 1000 &&
-    actualStart <= Math.floor(identity.upper / 1000) * 1000
-  );
+  const birthMatches =
+    posixBirthWindowMatches(actualStart, identity.lower, identity.upper);
   if (!birthMatches) return 'mismatch';
   if (identity.kind === 'process') {
     const sentinel = sentinelState(pid, identity);

--- a/src/features/ai-task/services/TerminalSessionOwnerWatchdogSource.ts
+++ b/src/features/ai-task/services/TerminalSessionOwnerWatchdogSource.ts
@@ -1,3 +1,5 @@
+import { POSIX_PROCESS_SNAPSHOT_SOURCE } from './broker-source/PosixProcessSnapshotSource'
+
 /**
  * Broker-independent process owner watchdog.
  *
@@ -12,6 +14,7 @@ export const TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE = String.raw`
 const fs = require('fs');
 const cp = require('child_process');
 const path = require('path');
+${POSIX_PROCESS_SNAPSHOT_SOURCE}
 const ownerPrefix = process.env.TASKCHUTE_OWNER_WATCH_PREFIX || '';
 const descriptorPath = process.env.TASKCHUTE_OWNER_WATCH_DESCRIPTOR || '';
 const descriptorToken = process.env.TASKCHUTE_OWNER_WATCH_TOKEN || '';
@@ -225,56 +228,16 @@ function readOwnedRecords() {
   return { active, files, trustworthy };
 }
 
-function parsePosixSnapshot(output) {
-  const snapshot = new Map();
-  for (const line of String(output).split('\n')) {
-    const match = line.match(
-      /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+\s+\S+\s+\d+\s+\d\d:\d\d:\d\d\s+\d{4})\s+(.*)$/,
-    );
-    if (!match) continue;
-    const startedAt = Date.parse(match[4]);
-    snapshot.set(Number(match[1]), {
-      ppid: Number(match[2]),
-      pgid: Number(match[3]),
-      startedAt: Number.isFinite(startedAt) ? startedAt : null,
-      command: match[5],
-    });
-  }
-  return snapshot;
-}
-
-function snapshotIdentity(entry) {
-  if (!entry || !Number.isFinite(entry.startedAt)) return null;
-  return {
-    lower: entry.startedAt,
-    upper: entry.startedAt,
-    kind: 'snapshot',
-    parentPid: entry.ppid,
-    processGroup: entry.pgid,
-    commandHint:
-      typeof entry.command === 'string'
-        ? entry.command.slice(0, 512)
-        : '',
-  };
-}
-
 function readPosixSnapshot() {
   if (process.platform !== 'darwin' && process.platform !== 'linux') {
     return null;
   }
   if (forcePsFailure) return null;
   try {
-    const args = process.platform === 'linux'
-      ? ['axeww', '-o', 'pid=,ppid=,pgid=,lstart=,command=']
-      : ['-axo', 'pid=,ppid=,pgid=,lstart=,command='];
-    return parsePosixSnapshot(cp.execFileSync(
+    return parsePosixProcessSnapshot(cp.execFileSync(
       '/bin/ps',
-      args,
-      {
-        encoding: 'utf8',
-        maxBuffer: 16 * 1024 * 1024,
-        env: Object.assign({}, process.env, { LC_ALL: 'C', LANG: 'C' }),
-      },
+      posixSnapshotPsArgs(process.platform),
+      posixSnapshotPsOptions(process.env),
     ));
   } catch (_) {
     return null;
@@ -283,19 +246,13 @@ function readPosixSnapshot() {
 
 function windowsStartedAt(pid) {
   try {
-    const root = process.env.SystemRoot || process.env.SYSTEMROOT || 'C:\\Windows';
-    const powershell =
-      root.replace(/[\\/]+$/, '') +
-      '\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+    const reader = windowsBirthReaderArgv(
+      pid,
+      process.env.SystemRoot || process.env.SYSTEMROOT,
+    );
     const value = cp.execFileSync(
-      powershell,
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        "(Get-Process -Id " + String(pid) +
-          " -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')",
-      ],
+      reader.command,
+      reader.args,
       {
         encoding: 'utf8',
         maxBuffer: 4096,
@@ -393,15 +350,12 @@ function ownershipState(pid, identity, snapshot) {
     !Number.isFinite(actualStart)
   ) return 'unknown';
   if (process.platform === 'win32') {
-    return (
-      actualStart >= identity.lower &&
-      actualStart <= identity.upper
-    ) ? 'match' : 'mismatch';
+    return windowsBirthWindowMatches(actualStart, identity.lower, identity.upper)
+      ? 'match'
+      : 'mismatch';
   }
-  const birthMatches = (
-    actualStart >= Math.floor(identity.lower / 1000) * 1000 &&
-    actualStart <= Math.floor(identity.upper / 1000) * 1000
-  );
+  const birthMatches =
+    posixBirthWindowMatches(actualStart, identity.lower, identity.upper);
   if (!birthMatches) return 'mismatch';
   if (identity.kind === 'process') {
     const sentinel = sentinelState(pid, identity);
@@ -422,26 +376,13 @@ function ownershipState(pid, identity, snapshot) {
 function expandOwned(active, snapshot) {
   const expanded = new Map(active);
   if (!snapshot) return expanded;
-  const children = new Map();
-  for (const [pid, entry] of snapshot.entries()) {
-    const nested = children.get(entry.ppid) || [];
-    nested.push(pid);
-    children.set(entry.ppid, nested);
-  }
-  const pending = Array.from(active.keys());
-  const seen = new Set();
-  while (pending.length > 0) {
-    const parentPid = pending.pop();
-    if (!parentPid || seen.has(parentPid)) continue;
-    seen.add(parentPid);
-    const nested = children.get(parentPid) || [];
-    for (const pid of nested) {
-      const entry = snapshot.get(pid);
-      if (!expanded.has(pid)) {
-        expanded.set(pid, snapshotIdentity(entry));
-      }
-      pending.push(pid);
-    }
+  const descendants = posixSnapshotDescendantPids(
+    snapshot,
+    Array.from(active.keys()),
+  );
+  for (const pid of descendants) {
+    if (expanded.has(pid)) continue;
+    expanded.set(pid, posixSnapshotIdentity(snapshot.get(pid)));
   }
   return expanded;
 }

--- a/src/features/ai-task/services/broker-source/EmbeddedProgramSource.ts
+++ b/src/features/ai-task/services/broker-source/EmbeddedProgramSource.ts
@@ -1,0 +1,48 @@
+/**
+ * Transport for the sibling programs the broker carries.
+ *
+ * The broker starts as `spawn(node, ['-e', TERMINAL_BROKER_SOURCE])`, and Linux
+ * caps a single argv string at MAX_ARG_STRLEN = 32 * PAGE_SIZE = 131_072 bytes.
+ * Exceeding it fails the execve with E2BIG, so the broker never starts at all —
+ * on Linux only, which is why macOS never noticed. The guard and watchdog
+ * programs the broker has to hand to its own children accounted for ~46 KB of
+ * that budget when embedded as JSON string literals; gzipped and base64'd they
+ * cost ~16 KB.
+ *
+ * Compression happens at module init on the user's machine and costs ~1 ms; the
+ * broker inflates in ~0.1 ms. The encoded text still travels inside argv, so
+ * this buys the headroom without moving anything into the environment (where
+ * Linux `ps axeww` would expose it and every descendant would inherit it) or
+ * onto disk.
+ */
+
+// Matches the lazy-require boundary used by the other Node-touching services;
+// a static `import` of a builtin is rejected by the plugin lint rules.
+declare function require(moduleId: string): unknown
+
+interface NodeBufferLike {
+  toString(encoding: string): string
+}
+
+interface ZlibModuleLike {
+  gzipSync(data: string, options: { level: number }): NodeBufferLike
+}
+
+function zlibModule(): ZlibModuleLike {
+  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only broker; the carried programs are compressed to fit one Linux argv string
+  return require('zlib') as ZlibModuleLike
+}
+
+export function gzipBase64(source: string): string {
+  // gzipSync encodes a string argument as UTF-8, so no Buffer is needed here.
+  return zlibModule().gzipSync(source, { level: 9 }).toString('base64')
+}
+
+/**
+ * Splice ahead of the first `inflateProgram(...)` call site. Kept plain ES2018
+ * for the same reason as the rest of the broker program.
+ */
+export const INFLATE_PROGRAM_SOURCE =
+  String.raw`function inflateProgram(encoded) {
+  return require('zlib').gunzipSync(Buffer.from(encoded, 'base64')).toString('utf8');
+}`

--- a/src/features/ai-task/services/broker-source/PosixProcessSnapshotSource.ts
+++ b/src/features/ai-task/services/broker-source/PosixProcessSnapshotSource.ts
@@ -1,0 +1,150 @@
+/**
+ * The process-table half of the broker, guard and watchdog programs: the part
+ * whose result depends only on its arguments.
+ *
+ * All three run as `node -e <one string>` and cannot require siblings at
+ * runtime, so this fragment is spliced into each of them verbatim. It is not a
+ * runtime boundary — the composed string is what executes. What the split buys
+ * is a testing boundary. Until it existed, every line of `ps` parsing in this
+ * codebase existed in triplicate and was reachable only by spawning real
+ * processes, which meant the `ps` dialect under test was whichever one the
+ * developer's machine happened to speak. A macOS checkout could not execute the
+ * Linux branch at all.
+ *
+ * Composition tests assert that all three programs still contain this string
+ * byte for byte, and that none of them has grown a private copy again.
+ *
+ * Two deliberate properties:
+ *
+ * - `posixSnapshotPsArgs` takes the platform as an ARGUMENT rather than reading
+ *   `process.platform`. That is what lets a test build both dialects from
+ *   either host, and it is why nothing here touches `process`.
+ * - Everything is a `function` declaration, never a top-level `const`. These
+ *   are spliced into three programs that declare their own names around them;
+ *   function declarations hoist and tolerate ordering, whereas a duplicated
+ *   top-level `const` is a SyntaxError that would kill the program at startup
+ *   with no output.
+ *
+ * Keep this plain ES2018 — nothing transpiles the contents of this template.
+ */
+export const POSIX_PROCESS_SNAPSHOT_SOURCE =
+  String.raw`function posixSnapshotPsArgs(platform) {
+  // macOS does not expose another process' environment through ps eww, while
+  // the extra environment text makes every startup snapshot substantially
+  // larger. Keep the environment-bearing form only on Linux, where it can
+  // recover an already reparented cooperative descendant by its owner marker.
+  return platform === 'linux'
+    ? ['axeww', '-o', 'pid=,ppid=,pgid=,lstart=,command=']
+    : ['-axo', 'pid=,ppid=,pgid=,lstart=,command='];
+}
+function posixSnapshotPsOptions(baseEnv) {
+  // LC_ALL/LANG pin lstart to the C-locale "Www Mmm dd HH:MM:SS YYYY" shape the
+  // parser below expects; under another locale Date.parse yields NaN and every
+  // birth comparison silently degrades to 'unknown'.
+  return {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    env: Object.assign({}, baseEnv, { LC_ALL: 'C', LANG: 'C' }),
+  };
+}
+function parsePosixProcessSnapshot(output) {
+  const snapshot = new Map();
+  for (const line of String(output).split('\n')) {
+    // The command column is optional: a process whose command ps renders empty
+    // still has a pid, a ppid and a birth time, and dropping the line would
+    // hide it from the descendant walk. It can never be claimed as an owner,
+    // because every owner check requires a non-empty command hint.
+    const match = line.match(
+      /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+\s+\S+\s+\d+\s+\d\d:\d\d:\d\d\s+\d{4})(?:\s+(.*))?\s*$/,
+    );
+    if (!match) continue;
+    const startedAt = Date.parse(match[4]);
+    snapshot.set(Number(match[1]), {
+      ppid: Number(match[2]),
+      pgid: Number(match[3]),
+      startedAt: Number.isFinite(startedAt) ? startedAt : null,
+      command: match[5] || '',
+    });
+  }
+  return snapshot;
+}
+function posixSnapshotIdentity(entry) {
+  if (!entry || !Number.isFinite(entry.startedAt)) return null;
+  return {
+    lower: entry.startedAt,
+    upper: entry.startedAt,
+    kind: 'snapshot',
+    parentPid: entry.ppid,
+    processGroup: entry.pgid,
+    commandHint:
+      typeof entry.command === 'string'
+        ? entry.command.slice(0, 512)
+        : '',
+  };
+}
+// POSIX lstart is rounded down to seconds, so a recorded millisecond bound has
+// to be floored the same way before it is compared against one.
+function posixBirthFloor(ms) {
+  return Math.floor(ms / 1000) * 1000;
+}
+// The owner record stores the interval surrounding spawn(), so both ends are
+// floored: a paused or slow syscall stays a match without widening the
+// PID-reuse window to several seconds.
+function posixBirthWindowMatches(actualStart, lower, upper) {
+  return (
+    actualStart >= posixBirthFloor(lower) &&
+    actualStart <= posixBirthFloor(upper)
+  );
+}
+// Windows reports sub-second precision, so the recorded interval is used as-is.
+function windowsBirthWindowMatches(actualStart, lower, upper) {
+  return actualStart >= lower && actualStart <= upper;
+}
+function windowsBirthReaderArgv(pid, systemRoot) {
+  const root = systemRoot || 'C:\\Windows';
+  return {
+    command:
+      String(root).replace(/[\\/]+$/, '') +
+      '\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+    args: [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      "(Get-Process -Id " + String(pid) +
+        " -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')",
+    ],
+  };
+}
+function posixSnapshotChildren(snapshot) {
+  const children = new Map();
+  for (const [pid, entry] of snapshot.entries()) {
+    const siblings = children.get(entry.ppid) || [];
+    siblings.push(pid);
+    children.set(entry.ppid, siblings);
+  }
+  return children;
+}
+// Transitive descendants of every root, in visit order. The roots themselves
+// are never included, and the seen set keeps a ppid cycle (a self-parenting or
+// reparented entry) from looping forever. Takes a list because the watchdog
+// walks from every owner record it holds, not from a single process.
+function posixSnapshotDescendantPids(snapshot, rootPids) {
+  const roots = new Set(rootPids);
+  const children = posixSnapshotChildren(snapshot);
+  const pending = Array.from(roots);
+  const seen = new Set();
+  const descendants = [];
+  while (pending.length > 0) {
+    const parentPid = pending.pop();
+    if (!parentPid || seen.has(parentPid)) continue;
+    seen.add(parentPid);
+    const nested = children.get(parentPid);
+    if (!nested) continue;
+    for (const pid of nested) {
+      if (roots.has(pid) || seen.has(pid)) continue;
+      descendants.push(pid);
+      pending.push(pid);
+    }
+  }
+  return descendants;
+}`

--- a/src/features/ai-task/services/broker-source/TerminalBrokerPureSource.ts
+++ b/src/features/ai-task/services/broker-source/TerminalBrokerPureSource.ts
@@ -1,0 +1,379 @@
+import {
+  FISH_TERMINAL_BOOTSTRAP,
+  POSIX_TERMINAL_BOOTSTRAP,
+  TERMINAL_ARGV_BOOTSTRAP_ARG_ZERO,
+} from '../dispatchers/TerminalShellBootstrap'
+
+/**
+ * Free-standing half of the broker program: functions whose result depends only
+ * on their arguments.
+ *
+ * The broker runs as `node -e <one string>`, so it cannot require sibling files
+ * at runtime. This module is therefore not a runtime boundary — it is spliced
+ * into TERMINAL_BROKER_SOURCE verbatim and the composed string is what actually
+ * executes. What the split buys is a *testing* boundary: tests can evaluate this
+ * fragment on its own, because nothing in here touches fs, child_process, net,
+ * process, or broker globals. A composition test asserts that the broker source
+ * still contains this string byte for byte, so the code under test and the code
+ * that ships can never drift apart.
+ *
+ * Splice it ahead of everything else: the declarations below are read by the
+ * rest of the program, and keeping them first means the fragment never depends
+ * on a name the broker introduces later.
+ *
+ * Keep this plain ES2018 — nothing transpiles the contents of this template.
+ */
+export const TERMINAL_BROKER_PURE_SOURCE = String.raw`const ownerPidFileEnvName = 'TASKCHUTE_BROKER_OWNER_PID_FILE';
+const terminalArgvBootstrapProgram = ${JSON.stringify(POSIX_TERMINAL_BOOTSTRAP)};
+const fishTerminalArgvBootstrapProgram = ${JSON.stringify(FISH_TERMINAL_BOOTSTRAP)};
+const terminalArgvBootstrapArgZero = ${JSON.stringify(TERMINAL_ARGV_BOOTSTRAP_ARG_ZERO)};
+function executableName(value) {
+  return String(value || '').split(/[\\/]/).pop().toLowerCase();
+}
+function isPythonExecutable(value) {
+  return /^python(?:\d+(?:\.\d+)*)?$/.test(executableName(value));
+}
+function pythonArgsDisableOwnershipHook(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const token = String(args[index]);
+    if (token === '--') return false;
+    if (!token.startsWith('-') || token === '-') return false;
+    if (token === '-c' || token === '-m') return false;
+    if (/^-[^-]*[EIS]/.test(token)) return true;
+    // These interpreter options consume the next token. None disables the
+    // hook itself, and the consumed value must not be mistaken for a flag.
+    if (token === '-W' || token === '-X') index += 1;
+  }
+  return false;
+}
+function protectedOwnershipEnvName(value) {
+  const name = String(value || '').split('=', 1)[0].toUpperCase();
+  return (
+    name === 'NODE_OPTIONS' ||
+    name === 'PYTHONPATH' ||
+    name === ownerPidFileEnvName
+  );
+}
+function envLaunchDisablesPythonOwnershipHook(args) {
+  let commandIndex = 0;
+  while (commandIndex < args.length) {
+    const token = String(args[commandIndex]);
+    if (token === '--') {
+      commandIndex += 1;
+      break;
+    }
+    if (token === '-i' || token === '--ignore-environment') return true;
+    if (token === '-u' || token === '--unset') {
+      const name = args[commandIndex + 1];
+      if (protectedOwnershipEnvName(name)) return true;
+      commandIndex += 2;
+      continue;
+    }
+    if (token.startsWith('--unset=')) {
+      if (protectedOwnershipEnvName(token.slice('--unset='.length))) {
+        return true;
+      }
+      commandIndex += 1;
+      continue;
+    }
+    if (/^-u.+/.test(token)) {
+      if (protectedOwnershipEnvName(token.slice(2))) return true;
+      commandIndex += 1;
+      continue;
+    }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+      if (protectedOwnershipEnvName(token)) return true;
+      commandIndex += 1;
+      continue;
+    }
+    if (token.startsWith('-')) {
+      commandIndex += 1;
+      continue;
+    }
+    break;
+  }
+  return (
+    isPythonExecutable(args[commandIndex]) &&
+    pythonArgsDisableOwnershipHook(args.slice(commandIndex + 1))
+  );
+}
+function splitShellCommandSegments(source) {
+  const segments = [];
+  let current = '';
+  let quote = '';
+  let escaped = false;
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+    if (character === '\\' && quote !== "'") {
+      current += character;
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      current += character;
+      if (character === quote) quote = '';
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      current += character;
+      continue;
+    }
+    const next = source[index + 1];
+    if (
+      character === ';' ||
+      character === '\n' ||
+      character === '|' ||
+      character === '&'
+    ) {
+      if (current.trim()) segments.push(current);
+      current = '';
+      if (
+        (character === '|' || character === '&') &&
+        next === character
+      ) index += 1;
+      continue;
+    }
+    current += character;
+  }
+  if (current.trim()) segments.push(current);
+  return segments;
+}
+function tokenizeShellWords(source) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let escaped = false;
+  const flush = () => {
+    if (!current) return;
+    words.push(current);
+    current = '';
+  };
+  for (const character of source) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+    if (character === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = '';
+      else current += character;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      flush();
+      continue;
+    }
+    current += character;
+  }
+  flush();
+  return words;
+}
+function shellSegmentDisablesPythonOwnershipHook(segment) {
+  const words = tokenizeShellWords(segment);
+  while (
+    words[0] === 'exec' ||
+    words[0] === 'command' ||
+    words[0] === 'then' ||
+    words[0] === 'do' ||
+    words[0] === 'else'
+  ) words.shift();
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[0] || '')) {
+    if (protectedOwnershipEnvName(words[0])) return true;
+    words.shift();
+  }
+  if (
+    (words[0] === 'unset' || words[0] === 'export') &&
+    words.slice(1).some(protectedOwnershipEnvName)
+  ) return true;
+  if (executableName(words[0]) === 'env') {
+    return envLaunchDisablesPythonOwnershipHook(words.slice(1));
+  }
+  return (
+    isPythonExecutable(words[0]) &&
+    pythonArgsDisableOwnershipHook(words.slice(1))
+  );
+}
+function executableLaunchDisablesPythonOwnershipHook(binary, args) {
+  const name = executableName(binary);
+  if (
+    isPythonExecutable(name) &&
+    pythonArgsDisableOwnershipHook(args)
+  ) return true;
+  return (
+    name === 'env' &&
+    envLaunchDisablesPythonOwnershipHook(args)
+  );
+}
+function terminalArgvBootstrapDisablesPythonHook(binary, binaryArgs) {
+  const name = executableName(binary);
+  const commandIndex = binaryArgs.indexOf('-c');
+  if (commandIndex < 0) return false;
+  const program = binaryArgs[commandIndex + 1];
+  let positionals;
+  if (name === 'fish') {
+    if (
+      program !== fishTerminalArgvBootstrapProgram ||
+      binaryArgs[commandIndex + 2] !== terminalArgvBootstrapProgram
+    ) return false;
+    positionals = binaryArgs.slice(commandIndex + 3);
+  } else {
+    if (
+      !/^(?:a|ba|da|k|mk|z)?sh$/.test(name) ||
+      program !== terminalArgvBootstrapProgram ||
+      binaryArgs[commandIndex + 2] !== terminalArgvBootstrapArgZero
+    ) return false;
+    positionals = binaryArgs.slice(commandIndex + 3);
+  }
+  // shell, resolved, command, fallback, prefixCount
+  if (positionals.length < 5) return true;
+  const resolved = positionals[1];
+  const command = positionals[2];
+  const fallback = positionals[3];
+  const prefixCountText = positionals[4];
+  const payload = positionals.slice(5);
+  if (
+    typeof resolved !== 'string' ||
+    typeof command !== 'string' ||
+    typeof fallback !== 'string' ||
+    typeof prefixCountText !== 'string' ||
+    !/^(?:0|[1-9][0-9]*)$/.test(prefixCountText)
+  ) return true;
+  const prefixCount = Number(prefixCountText);
+  if (
+    !Number.isSafeInteger(prefixCount) ||
+    prefixCount < 0 ||
+    prefixCount > payload.length
+  ) return true;
+  const commandArgs = payload.slice(prefixCount);
+  return (
+    executableLaunchDisablesPythonOwnershipHook(resolved, payload) ||
+    executableLaunchDisablesPythonOwnershipHook(command, commandArgs) ||
+    executableLaunchDisablesPythonOwnershipHook(fallback, commandArgs)
+  );
+}
+function taskChutePtyPositionalLaunchDisablesPythonHook(
+  request,
+  commandIndex,
+  shellProgram,
+) {
+  // The injection-safe PTY wrappers carry the transcript as outer shell $0
+  // and append the real binary/argv as unused validation positionals.
+  // Looking only at the fixed '-c' program therefore misses a direct Python
+  // -S launch even though the production request is statically identifiable.
+  if (
+    !shellProgram.includes('TASKCHUTE_AI_TTY_PATH="$0.tty"') ||
+    !shellProgram.includes('/usr/bin/script')
+  ) return false;
+  const binaryIndex = commandIndex + 3;
+  const binary = request.args[binaryIndex];
+  if (typeof binary !== 'string') return false;
+  const binaryArgs = request.args.slice(binaryIndex + 1);
+  return (
+    executableLaunchDisablesPythonOwnershipHook(binary, binaryArgs) ||
+    terminalArgvBootstrapDisablesPythonHook(binary, binaryArgs)
+  );
+}
+function launchDisablesPythonOwnershipHook(request, initialInput) {
+  const commandName = executableName(request.command);
+  if (
+    isPythonExecutable(commandName) &&
+    pythonArgsDisableOwnershipHook(request.args)
+  ) return true;
+  if (
+    commandName === 'env' &&
+    envLaunchDisablesPythonOwnershipHook(request.args)
+  ) return true;
+  if (!/^(?:ba|z|k)?sh$/.test(commandName)) return false;
+  const commandIndex = request.args.indexOf('-c');
+  if (commandIndex < 0 || typeof request.args[commandIndex + 1] !== 'string') {
+    return typeof initialInput === 'string' &&
+      splitShellCommandSegments(initialInput).some(
+        shellSegmentDisablesPythonOwnershipHook,
+      );
+  }
+  const shellProgram = request.args[commandIndex + 1];
+  return (
+    splitShellCommandSegments(shellProgram).some(
+      shellSegmentDisablesPythonOwnershipHook,
+    ) ||
+    taskChutePtyPositionalLaunchDisablesPythonHook(
+      request,
+      commandIndex,
+      shellProgram,
+    ) ||
+    (
+      typeof initialInput === 'string' &&
+      splitShellCommandSegments(initialInput).some(
+        shellSegmentDisablesPythonOwnershipHook,
+      )
+    )
+  );
+}
+const stderrPendingLimit = 64 * 1024;
+// Drops the front of the newline-free head of stderrPending so it stays within
+// stderrPendingLimit, accounting the loss on session.stderrDroppedChars. The
+// head is what the next iteration emits as one line, so this has to run before
+// that emit: trimming only afterwards bounds the retained buffer but lets a
+// single emitted line reach stderrPendingLimit + the length of one pipe read.
+function boundStderrHead(session) {
+  const newline = session.stderrPending.indexOf('\n');
+  const headLength = newline < 0 ? session.stderrPending.length : newline;
+  if (headLength <= stderrPendingLimit) return;
+  const dropped = headLength - stderrPendingLimit;
+  session.stderrDroppedChars += dropped;
+  // JSON materialization avoids retaining the oversized concatenation as
+  // the parent of a short V8 SlicedString.
+  session.stderrPending = JSON.parse(JSON.stringify(session.stderrPending.slice(dropped)));
+}
+// Splits pending stderr into lines, strips the exit sentinel onto
+// session.sentinelCode, and hands every visible chunk to emit. The broker binds
+// emit to its replay buffer and its sockets; taking it as an argument is what
+// keeps this half free of broker state.
+function consumeStderrInto(session, text, flush, marker, emit) {
+  session.stderrPending += text;
+  boundStderrHead(session);
+  let newline = session.stderrPending.indexOf('\n');
+  while (newline >= 0) {
+    const line = session.stderrPending.slice(0, newline + 1);
+    session.stderrPending = session.stderrPending.slice(newline + 1);
+    const match = line.match(new RegExp(marker + '(\\d+)'));
+    if (match) session.sentinelCode = Number(match[1]);
+    let visible = line.replace(new RegExp(marker + '\\d+\\r?\\n?'), '');
+    if (session.stderrDroppedChars > 0) {
+      visible = '…[+' + session.stderrDroppedChars + ' stderr chars truncated]\n' + visible;
+      session.stderrDroppedChars = 0;
+    }
+    if (visible) emit(visible);
+    newline = session.stderrPending.indexOf('\n');
+  }
+  if (flush && session.stderrPending) {
+    const tail = session.stderrPending;
+    session.stderrPending = '';
+    const match = tail.match(new RegExp(marker + '(\\d+)'));
+    if (match) session.sentinelCode = Number(match[1]);
+    let visible = tail.replace(new RegExp(marker + '\\d+'), '');
+    if (session.stderrDroppedChars > 0) {
+      visible = '…[+' + session.stderrDroppedChars + ' stderr chars truncated]\n' + visible;
+      session.stderrDroppedChars = 0;
+    }
+    if (visible) emit(visible);
+  }
+  // The loop above consumed every newline, so what remains is a newline-free
+  // tail that no emit has bounded yet.
+  if (!flush) boundStderrHead(session);
+}
+`

--- a/src/features/ai-task/services/process/parseDescendantSnapshot.ts
+++ b/src/features/ai-task/services/process/parseDescendantSnapshot.ts
@@ -1,0 +1,54 @@
+import type { ProcessIdentitySnapshot } from '../NodeProcessGateway'
+
+/**
+ * The `ps` parsing the renderer-side gateway does, separated from the syscall
+ * that produces the text so it can be tested without spawning anything.
+ *
+ * Deliberately NOT shared with `parsePosixProcessSnapshot` in
+ * broker-source/PosixProcessSnapshotSource.ts. The two read different `ps`
+ * invocations (three columns here, five there), produce different shapes (a
+ * raw birth token to compare as a string vs. a parsed millisecond timestamp),
+ * and live on opposite sides of the TS / spliced-program-string boundary — the
+ * broker cannot import this file at runtime. Unifying them would mean widening
+ * one of the two callers' contract to fit the other.
+ */
+
+/**
+ * Transitive descendants of `rootPid` from `ps -axo pid=,ppid=,lstart=`
+ * output, in visit order, each carrying its raw `lstart` text as a birth token.
+ *
+ * The token is only ever compared as an opaque string against another reading
+ * taken on the same machine, so its format does not have to be stable across
+ * hosts. Malformed lines are skipped and `rootPid` is never included.
+ */
+export function parseDescendantSnapshot(
+  output: string,
+  rootPid: number,
+): ProcessIdentitySnapshot[] {
+  const childrenByParent = new Map<number, ProcessIdentitySnapshot[]>()
+  for (const line of output.split('\n')) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/u)
+    if (!match) continue
+    const pid = Number(match[1])
+    const parentPid = Number(match[2])
+    const children = childrenByParent.get(parentPid) ?? []
+    children.push({ pid, birthToken: match[3].trim() })
+    childrenByParent.set(parentPid, children)
+  }
+
+  const descendants: ProcessIdentitySnapshot[] = []
+  const pending = [...(childrenByParent.get(rootPid) ?? [])]
+  // A ppid cycle — a self-parenting entry, or one reparented back onto the
+  // walk — would otherwise loop forever.
+  const seen = new Set<number>([rootPid])
+  while (pending.length > 0) {
+    const identity = pending.pop()
+    if (identity === undefined || identity.pid < 1 || seen.has(identity.pid)) {
+      continue
+    }
+    seen.add(identity.pid)
+    descendants.push(identity)
+    pending.push(...(childrenByParent.get(identity.pid) ?? []))
+  }
+  return descendants
+}

--- a/tests/features/ai-task/broker-source/broker-source-budget.test.ts
+++ b/tests/features/ai-task/broker-source/broker-source-budget.test.ts
@@ -22,11 +22,16 @@ import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../../src/features
 const MAX_ARG_STRLEN = 32 * 4096
 
 /**
- * Deliberately far below the hard limit. A program that has crept to within a
- * few hundred bytes is already broken for the next person who adds a feature,
- * so the budget has to fail while there is still room to land a fix.
+ * Deliberately below the hard limit. A program that has crept to within a few
+ * hundred bytes is already broken for the next person who adds a feature, so
+ * the budget has to fail while there is still room to land a fix.
+ *
+ * ~11KB of cushion. Because the guard and watchdog reach the broker compressed,
+ * roughly 3KB of growth in either of them costs the broker 1KB, so this covers
+ * a substantial feature in any of the three before anyone has to think about
+ * the transport again.
  */
-const PROGRAM_BUDGET = 110_000
+const PROGRAM_BUDGET = 120_000
 
 describe('broker program size budget', () => {
   test.each([

--- a/tests/features/ai-task/broker-source/broker-source-budget.test.ts
+++ b/tests/features/ai-task/broker-source/broker-source-budget.test.ts
@@ -1,0 +1,80 @@
+import { gunzipSync } from 'zlib'
+
+import {
+  gzipBase64,
+  INFLATE_PROGRAM_SOURCE,
+} from '../../../../src/features/ai-task/services/broker-source/EmbeddedProgramSource'
+import { TERMINAL_BROKER_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { TERMINAL_SESSION_GUARD_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionGuardSource'
+import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
+
+/**
+ * Every one of these programs ships as the single `-e` argument of a spawned
+ * node, and Linux rejects an execve whose individual argv string exceeds
+ * MAX_ARG_STRLEN — 32 * PAGE_SIZE, i.e. 131_072 bytes on every runner and
+ * desktop that matters. Past that the broker does not misbehave, it never
+ * starts: spawn fails with E2BIG and the terminal is simply unavailable.
+ *
+ * macOS has no per-argument cap (only a ~1MB total ARG_MAX), so nothing on a
+ * developer machine reports this. The broker reached 99.9% of the limit before
+ * anyone measured it. That is what this file exists to stop.
+ */
+const MAX_ARG_STRLEN = 32 * 4096
+
+/**
+ * Deliberately far below the hard limit. A program that has crept to within a
+ * few hundred bytes is already broken for the next person who adds a feature,
+ * so the budget has to fail while there is still room to land a fix.
+ */
+const PROGRAM_BUDGET = 110_000
+
+describe('broker program size budget', () => {
+  test.each([
+    ['broker', TERMINAL_BROKER_SOURCE],
+    ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
+    ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
+  ])('the %s program fits in one Linux execve argument', (_name, source) => {
+    expect(Buffer.byteLength(source, 'utf8')).toBeLessThan(PROGRAM_BUDGET)
+  })
+
+  test('the budget leaves real headroom under the kernel limit', () => {
+    expect(PROGRAM_BUDGET).toBeLessThan(MAX_ARG_STRLEN)
+  })
+})
+
+describe('compressed program transport', () => {
+  test.each([
+    ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
+    ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
+  ])('the %s program survives the gzip round trip', (_name, source) => {
+    const encoded = gzipBase64(source)
+
+    expect(gunzipSync(Buffer.from(encoded, 'base64')).toString('utf8')).toBe(
+      source,
+    )
+  })
+
+  test('encoding the same program twice yields the same text', () => {
+    // The encoded text is embedded in the broker program, so a non-deterministic
+    // encoder would make the program's bytes — and this file's budget — drift
+    // between runs.
+    expect(gzipBase64(TERMINAL_SESSION_GUARD_SOURCE)).toBe(
+      gzipBase64(TERMINAL_SESSION_GUARD_SOURCE),
+    )
+  })
+
+  test.each([
+    ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
+    ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
+  ])('the broker carries the %s program compressed, not inline', (_name, source) => {
+    expect(TERMINAL_BROKER_SOURCE).toContain(gzipBase64(source))
+    expect(TERMINAL_BROKER_SOURCE).not.toContain(JSON.stringify(source))
+  })
+
+  test('the broker defines the inflater before it is called', () => {
+    expect(TERMINAL_BROKER_SOURCE).toContain(INFLATE_PROGRAM_SOURCE)
+    expect(TERMINAL_BROKER_SOURCE.indexOf(INFLATE_PROGRAM_SOURCE)).toBeLessThan(
+      TERMINAL_BROKER_SOURCE.indexOf('inflateProgram('.concat('"')),
+    )
+  })
+})

--- a/tests/features/ai-task/broker-source/posix-process-snapshot-source.test.ts
+++ b/tests/features/ai-task/broker-source/posix-process-snapshot-source.test.ts
@@ -1,0 +1,355 @@
+import { createContext, runInContext } from 'vm'
+
+import { POSIX_PROCESS_SNAPSHOT_SOURCE } from '../../../../src/features/ai-task/services/broker-source/PosixProcessSnapshotSource'
+import { TERMINAL_BROKER_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { TERMINAL_SESSION_GUARD_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionGuardSource'
+import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
+import {
+  DARWIN_PS_AXO_TEXT,
+  DESCENDANT_TREE_TEXT,
+  LINUX_PS_AXEWW_TEXT,
+  LSTART,
+  LSTART_EPOCH_MS,
+  LSTART_SINGLE_DIGIT_DAY_EPOCH_MS,
+  PS_DIALECTS,
+} from './psSnapshots'
+
+/**
+ * The broker, guard and watchdog each ship as `node -e <one string>`, so this
+ * code cannot be imported at runtime — it is spliced into all three. Evaluating
+ * the fragment in a bare context is what lets the `ps` dialects be exercised
+ * from either host: until this existed, the Linux `axeww` branch was
+ * unreachable from a macOS checkout, and none of this parsing had a single
+ * unit test.
+ */
+type SnapshotEntry = {
+  ppid: number
+  pgid: number
+  startedAt: number | null
+  command: string
+}
+
+type Identity = {
+  lower: number
+  upper: number
+  kind: string
+  parentPid: number
+  processGroup: number
+  commandHint: string
+}
+
+const context = createContext({ JSON, Map, Set, Date, Math, Number, String })
+runInContext(POSIX_PROCESS_SNAPSHOT_SOURCE, context)
+
+const posix = context as unknown as {
+  parsePosixProcessSnapshot: (output: string) => Map<number, SnapshotEntry>
+  posixBirthFloor: (ms: number) => number
+  posixBirthWindowMatches: (
+    actualStart: number,
+    lower: number,
+    upper: number,
+  ) => boolean
+  posixSnapshotChildren: (
+    snapshot: Map<number, SnapshotEntry>,
+  ) => Map<number, number[]>
+  posixSnapshotDescendantPids: (
+    snapshot: Map<number, SnapshotEntry>,
+    rootPids: number[],
+  ) => number[]
+  posixSnapshotIdentity: (entry: SnapshotEntry | undefined) => Identity | null
+  posixSnapshotPsArgs: (platform: string) => string[]
+  posixSnapshotPsOptions: (baseEnv: Record<string, string>) => {
+    encoding: string
+    maxBuffer: number
+    env: Record<string, string>
+  }
+  windowsBirthReaderArgv: (
+    pid: number,
+    systemRoot?: string,
+  ) => { command: string; args: string[] }
+  windowsBirthWindowMatches: (
+    actualStart: number,
+    lower: number,
+    upper: number,
+  ) => boolean
+}
+
+const PROGRAMS = [
+  ['broker', TERMINAL_BROKER_SOURCE],
+  ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
+  ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
+] as const
+
+describe('posix snapshot fragment composition', () => {
+  test.each(PROGRAMS)(
+    'the shipped %s program embeds the fragment verbatim',
+    (_name, source) => {
+      expect(source).toContain(POSIX_PROCESS_SNAPSHOT_SOURCE)
+    },
+  )
+
+  test('the fragment reaches no host facility, so it can run detached', () => {
+    // Comments stripped first: they discuss `process`es and `ps` in prose, and
+    // the claim being made here is about the code.
+    const code = POSIX_PROCESS_SNAPSHOT_SOURCE.replace(/^\s*\/\/.*$/gmu, '')
+
+    expect(code).not.toMatch(/\b(?:require|__dirname|globalThis)\b/u)
+    expect(code).not.toMatch(/\b(?:process|cp|fs|net)\s*\./u)
+  })
+
+  // `toContain` alone would still pass if a program grew a second, private copy
+  // beside the shared one, which is exactly how the three drifted apart before.
+  test.each(PROGRAMS)('%s keeps no private copy of the parser', (_name, source) => {
+    const outsideFragment = source.replace(POSIX_PROCESS_SNAPSHOT_SOURCE, '')
+
+    expect(outsideFragment).not.toMatch(
+      /function\s+(?:snapshotIdentity|parsePosixSnapshot)\b/u,
+    )
+    expect(outsideFragment).not.toMatch(/const\s+posixPsArgs\b/u)
+    // The floor-to-the-second rule now lives in posixBirthFloor. Any surviving
+    // copy is a birth comparison that will drift the next time it is tuned.
+    expect(
+      outsideFragment.match(/Math\.floor\([^)]*\/\s*1000\)\s*\*\s*1000/gu) ?? [],
+    ).toEqual([])
+  })
+})
+
+describe('posixSnapshotPsArgs', () => {
+  // The Linux form is what no macOS test run could ever produce before.
+  test('asks Linux for the environment-bearing form', () => {
+    expect(posix.posixSnapshotPsArgs('linux')).toEqual([
+      'axeww',
+      '-o',
+      'pid=,ppid=,pgid=,lstart=,command=',
+    ])
+  })
+
+  test.each(['darwin', 'win32', 'freebsd'])(
+    'asks %s for the plain form',
+    (platform) => {
+      expect(posix.posixSnapshotPsArgs(platform)).toEqual([
+        '-axo',
+        'pid=,ppid=,pgid=,lstart=,command=',
+      ])
+    },
+  )
+
+  test('pins the locale so lstart stays parseable', () => {
+    const options = posix.posixSnapshotPsOptions({ LANG: 'ja_JP.UTF-8', HOME: '/home/x' })
+
+    expect(options.env.LC_ALL).toBe('C')
+    expect(options.env.LANG).toBe('C')
+    expect(options.env.HOME).toBe('/home/x')
+  })
+})
+
+describe('parsePosixProcessSnapshot', () => {
+  test.each(PS_DIALECTS)('reads the %s dialect', (_platform, text) => {
+    const snapshot = posix.parsePosixProcessSnapshot(text)
+
+    expect(snapshot.get(501)).toMatchObject({
+      ppid: 1,
+      pgid: 501,
+      startedAt: LSTART_EPOCH_MS,
+    })
+    expect(snapshot.get(502)?.ppid).toBe(501)
+    expect(snapshot.get(503)?.ppid).toBe(502)
+  })
+
+  test.each(PS_DIALECTS)(
+    'keeps a single-digit lstart day in the %s dialect',
+    (_platform, text) => {
+      // `Aug  4` carries two spaces, which is where a naive
+      // `\S+\s+\S+\s+\d+` split loses the year.
+      expect(posix.parsePosixProcessSnapshot(text).get(601)?.startedAt).toBe(
+        LSTART_SINGLE_DIGIT_DAY_EPOCH_MS,
+      )
+    },
+  )
+
+  test.each(PS_DIALECTS)(
+    'keeps an empty command column in the %s dialect',
+    (_platform, text) => {
+      const entry = posix.parsePosixProcessSnapshot(text).get(602)
+
+      expect(entry).toBeDefined()
+      expect(entry?.command).toBe('')
+    },
+  )
+
+  test('preserves runs of whitespace inside a command', () => {
+    expect(posix.parsePosixProcessSnapshot(DARWIN_PS_AXO_TEXT).get(123456)?.command).toBe(
+      '/usr/bin/python3   -c   print(1)',
+    )
+  })
+
+  test('keeps the environment Linux appends after the argv', () => {
+    const entry = posix.parsePosixProcessSnapshot(LINUX_PS_AXEWW_TEXT).get(801)
+
+    expect(entry?.command).toContain(
+      'TASKCHUTE_BROKER_OWNER_PID_FILE=/tmp/owner-a.jsonl',
+    )
+  })
+
+  test('reads a bracketed kernel thread', () => {
+    expect(posix.parsePosixProcessSnapshot(LINUX_PS_AXEWW_TEXT).get(9)).toMatchObject({
+      ppid: 2,
+      pgid: 0,
+      command: '[kworker/0:1]',
+    })
+  })
+
+  test.each(PS_DIALECTS)('skips the header line in the %s dialect', (_platform, text) => {
+    const snapshot = posix.parsePosixProcessSnapshot(text)
+
+    for (const pid of snapshot.keys()) expect(Number.isFinite(pid)).toBe(true)
+    expect(snapshot.has(Number.NaN)) .toBe(false)
+  })
+
+  test('records an unparseable lstart as null rather than trusting it', () => {
+    // A non-C locale renders the month in the local language; Date.parse then
+    // yields NaN and the entry must not claim a birth time.
+    const snapshot = posix.parsePosixProcessSnapshot(
+      `  501     1   501 lun. aoû  4 09:14:07 2025 sleep 10\n`,
+    )
+
+    expect(snapshot.get(501)?.startedAt ?? 'absent').not.toBe(LSTART_EPOCH_MS)
+  })
+})
+
+describe('posixSnapshotIdentity', () => {
+  test('describes a snapshot entry by group and command prefix', () => {
+    const snapshot = posix.parsePosixProcessSnapshot(DARWIN_PS_AXO_TEXT)
+
+    expect(posix.posixSnapshotIdentity(snapshot.get(502))).toEqual({
+      lower: LSTART_EPOCH_MS,
+      upper: LSTART_EPOCH_MS,
+      kind: 'snapshot',
+      parentPid: 501,
+      processGroup: 501,
+      commandHint: 'sleep 10',
+    })
+  })
+
+  test('refuses an entry with no usable birth time', () => {
+    expect(posix.posixSnapshotIdentity(undefined)).toBeNull()
+    expect(
+      posix.posixSnapshotIdentity({
+        ppid: 1,
+        pgid: 1,
+        startedAt: null,
+        command: 'sleep 10',
+      }),
+    ).toBeNull()
+  })
+
+  test('caps the command hint so a Linux environment cannot bloat the record', () => {
+    const identity = posix.posixSnapshotIdentity({
+      ppid: 1,
+      pgid: 1,
+      startedAt: LSTART_EPOCH_MS,
+      command: 'x'.repeat(4096),
+    })
+
+    expect(identity?.commandHint).toHaveLength(512)
+  })
+})
+
+describe('birth windows', () => {
+  const second = Date.parse(LSTART)
+
+  test('floors a millisecond bound to the second ps reports', () => {
+    expect(posix.posixBirthFloor(second + 999)).toBe(second)
+    expect(posix.posixBirthFloor(second)).toBe(second)
+  })
+
+  test('matches a birth recorded mid-second on either side of the spawn', () => {
+    // The owner record brackets spawn(); ps only ever reports the floor.
+    expect(posix.posixBirthWindowMatches(second, second + 120, second + 880)).toBe(true)
+  })
+
+  test('rejects the neighbouring seconds', () => {
+    expect(posix.posixBirthWindowMatches(second - 1000, second, second + 500)).toBe(false)
+    expect(posix.posixBirthWindowMatches(second + 1000, second, second + 500)).toBe(false)
+  })
+
+  test('accepts a zero-width window', () => {
+    expect(posix.posixBirthWindowMatches(second, second, second)).toBe(true)
+  })
+
+  test('rejects an unusable birth time instead of matching everything', () => {
+    expect(posix.posixBirthWindowMatches(Number.NaN, second, second)).toBe(false)
+  })
+
+  test('uses full precision on Windows, which reports sub-second starts', () => {
+    expect(posix.windowsBirthWindowMatches(second + 500, second, second + 900)).toBe(true)
+    expect(posix.windowsBirthWindowMatches(second, second + 100, second + 900)).toBe(false)
+  })
+})
+
+describe('posixSnapshotDescendantPids', () => {
+  const snapshot = () => posix.parsePosixProcessSnapshot(DESCENDANT_TREE_TEXT)
+
+  test('walks past the first level and stops at the tree it was given', () => {
+    expect(posix.posixSnapshotDescendantPids(snapshot(), [100]).sort()).toEqual([
+      101, 102, 103,
+    ])
+  })
+
+  test('never returns a root', () => {
+    expect(posix.posixSnapshotDescendantPids(snapshot(), [100])).not.toContain(100)
+  })
+
+  test('walks from every root at once', () => {
+    expect(
+      posix.posixSnapshotDescendantPids(snapshot(), [100, 200]).sort(),
+    ).toEqual([101, 102, 103, 201])
+  })
+
+  test('terminates on a self-parenting entry', () => {
+    expect(posix.posixSnapshotDescendantPids(snapshot(), [104])).toEqual([])
+  })
+
+  test('returns nothing for a root that is not in the snapshot', () => {
+    expect(posix.posixSnapshotDescendantPids(snapshot(), [99_999])).toEqual([])
+  })
+
+  test('does not treat pid 0 as a parent of everything', () => {
+    expect(posix.posixSnapshotDescendantPids(snapshot(), [0])).toEqual([])
+  })
+
+  test('indexes children by parent', () => {
+    expect(posix.posixSnapshotChildren(snapshot()).get(100)?.sort()).toEqual([101, 102])
+  })
+})
+
+describe('windowsBirthReaderArgv', () => {
+  // Buildable and assertable from a POSIX checkout, which is the point: no
+  // Windows machine has ever run this construction under test.
+  test('builds the PowerShell path from SystemRoot', () => {
+    expect(posix.windowsBirthReaderArgv(1234, 'D:\\Win').command).toBe(
+      'D:\\Win\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+    )
+  })
+
+  test('strips trailing separators from SystemRoot', () => {
+    expect(posix.windowsBirthReaderArgv(1234, 'D:\\Win\\\\').command).toBe(
+      'D:\\Win\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+    )
+  })
+
+  test('falls back when SystemRoot is unset', () => {
+    expect(posix.windowsBirthReaderArgv(1234, undefined).command).toBe(
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+    )
+  })
+
+  test('asks for the start time of one pid in a round-trippable format', () => {
+    expect(posix.windowsBirthReaderArgv(1234, 'C:\\Windows').args).toEqual([
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      "(Get-Process -Id 1234 -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')",
+    ])
+  })
+})

--- a/tests/features/ai-task/broker-source/psSnapshots.ts
+++ b/tests/features/ai-task/broker-source/psSnapshots.ts
@@ -1,0 +1,97 @@
+/**
+ * `ps` output the broker, guard and watchdog have to survive.
+ *
+ * Handwritten rather than captured, so every line states which property it
+ * pins and a reviewer can see the difference a change makes. Kept as a .ts
+ * module because the column alignment is significant and a plain .txt fixture
+ * loses trailing whitespace to editors and formatters.
+ *
+ * Column layout is `pid=,ppid=,pgid=,lstart=,command=`, which ps renders with
+ * the numeric columns right-aligned and lstart in the C locale.
+ */
+
+/** `Www Mmm dd HH:MM:SS YYYY` — the only lstart shape the parser accepts. */
+export const LSTART = 'Mon Aug 25 09:14:07 2025'
+
+/** Single-digit days are padded to two spaces, not one. */
+export const LSTART_SINGLE_DIGIT_DAY = 'Mon Aug  4 09:14:07 2025'
+
+export const LSTART_EPOCH_MS = Date.parse(LSTART)
+export const LSTART_SINGLE_DIGIT_DAY_EPOCH_MS = Date.parse(
+  LSTART_SINGLE_DIGIT_DAY,
+)
+
+/**
+ * BSD `ps -axo pid=,ppid=,pgid=,lstart=,command=` as macOS renders it. Also
+ * what the guard reads on every platform.
+ */
+export const DARWIN_PS_AXO_LINES: readonly string[] = [
+  // A group leader: pgid equals pid.
+  `  501     1   501 ${LSTART} /bin/sh -c while :; do sleep 10; done`,
+  // A child of the leader, in the leader's group.
+  `  502   501   501 ${LSTART} sleep 10`,
+  // A grandchild, so the descendant walk has more than one level to follow.
+  `  503   502   501 ${LSTART} sleep 10`,
+  // Six-digit pid, and a command carrying runs of whitespace that must survive.
+  `123456     1 123456 ${LSTART} /usr/bin/python3   -c   print(1)`,
+  // Single-digit day: the classic breaker for `\\S+\\s+\\S+\\s+\\d+`.
+  `  601     1   601 ${LSTART_SINGLE_DIGIT_DAY} /usr/bin/tail -f /dev/null`,
+  // Empty command column. Keeps its pid/ppid so the walk can see it, but can
+  // never be claimed as an owner, because owner checks need a command hint.
+  `  602     1   602 ${LSTART} `,
+  // Reparented orphan: ppid 1 while its original parent is gone.
+  `  701     1   701 ${LSTART} /bin/sh -c orphaned`,
+  // Not a process line at all. Must be skipped rather than half-parsed.
+  '  PID  PPID  PGID STARTED COMMAND',
+  '',
+]
+
+export const DARWIN_PS_AXO_TEXT = `${DARWIN_PS_AXO_LINES.join('\n')}\n`
+
+/**
+ * Linux `ps axeww -o pid=,ppid=,pgid=,lstart=,command=`. The `e` appends each
+ * process's environment to the command column, which is what lets an already
+ * reparented cooperative descendant be recovered by its owner marker — and
+ * also what makes the column contain `=` signs, spaces and arbitrary text.
+ */
+export const LINUX_PS_AXEWW_LINES: readonly string[] = [
+  `  501     1   501 ${LSTART} /bin/sh -c while :; do sleep 10; done LANG=C PATH=/usr/bin:/bin`,
+  `  502   501   501 ${LSTART} sleep 10 LANG=C PATH=/usr/bin:/bin`,
+  `  503   502   501 ${LSTART} sleep 10 LANG=C PATH=/usr/bin:/bin`,
+  // The environment-marker recovery case: an unrelated process whose command is
+  // short but whose environment is long.
+  `  801     1   801 ${LSTART} sleep 30 TASKCHUTE_BROKER_OWNER_PID_FILE=/tmp/owner-a.jsonl LANG=C`,
+  // A kernel thread: bracketed, no environment.
+  `    9     2     0 ${LSTART} [kworker/0:1]`,
+  `  601     1   601 ${LSTART_SINGLE_DIGIT_DAY} /usr/bin/tail -f /dev/null LANG=C`,
+  `  602     1   602 ${LSTART} `,
+  '  PID  PPID  PGID STARTED COMMAND',
+  '',
+]
+
+export const LINUX_PS_AXEWW_TEXT = `${LINUX_PS_AXEWW_LINES.join('\n')}\n`
+
+export const PS_DIALECTS = [
+  ['darwin', DARWIN_PS_AXO_TEXT],
+  ['linux', LINUX_PS_AXEWW_TEXT],
+] as const
+
+/**
+ * A tree with the shapes a descendant walk has to tolerate: a grandchild, a
+ * self-parenting entry, a pid whose parent is 0, and an orphan reparented onto
+ * pid 1 while the walk root is still alive.
+ */
+export const DESCENDANT_TREE_TEXT = [
+  `  100     1   100 ${LSTART} root`,
+  `  101   100   100 ${LSTART} child-a`,
+  `  102   100   100 ${LSTART} child-b`,
+  `  103   101   100 ${LSTART} grandchild`,
+  // Self-parenting. A naive walk loops here forever.
+  `  104   104   104 ${LSTART} self-parent`,
+  // Parent is pid 0, which is not in the snapshot at all.
+  `  105     0   105 ${LSTART} orphan-of-zero`,
+  // Unrelated tree that must not be pulled in.
+  `  200     1   200 ${LSTART} unrelated`,
+  `  201   200   200 ${LSTART} unrelated-child`,
+  '',
+].join('\n')

--- a/tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts
+++ b/tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts
@@ -1,0 +1,226 @@
+import { createContext, runInContext } from 'vm'
+
+import { TERMINAL_BROKER_PURE_SOURCE } from '../../../../src/features/ai-task/services/broker-source/TerminalBrokerPureSource'
+import { TERMINAL_BROKER_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { buildTerminalShellLaunch } from '../../../../src/features/ai-task/services/dispatchers/TerminalShellBootstrap'
+import { NodeProcessGateway } from '../../../../src/features/ai-task/services/NodeProcessGateway'
+
+/**
+ * The broker ships as `node -e <one string>`, so these functions cannot be
+ * imported at runtime — they are spliced into TERMINAL_BROKER_SOURCE. The
+ * fragment is free of fs, child_process, net and process, which is what lets it
+ * be exercised here instead of through a spawned broker: the cases below used
+ * to require real pipes, and their outcome then depended on how much a single
+ * pipe read happened to deliver, which differs between macOS and Linux.
+ */
+const context = createContext({ JSON })
+runInContext(TERMINAL_BROKER_PURE_SOURCE, context)
+
+const broker = context as unknown as {
+  boundStderrHead: (session: StderrSession) => void
+  consumeStderrInto: (
+    session: StderrSession,
+    text: string,
+    flush: boolean,
+    marker: string,
+    emit: (visible: string) => void,
+  ) => void
+  launchDisablesPythonOwnershipHook: (
+    request: { command: string; args: string[] },
+    initialInput?: string,
+  ) => boolean
+}
+
+const stderrPendingLimit = runInContext(
+  'stderrPendingLimit',
+  context,
+) as number
+
+type StderrSession = {
+  stderrPending: string
+  stderrDroppedChars: number
+  sentinelCode?: number
+}
+
+const MARKER = '__TASKCHUTE_AI_EXIT__'
+
+function makeSession(): StderrSession {
+  return { stderrPending: '', stderrDroppedChars: 0 }
+}
+
+function feed(
+  session: StderrSession,
+  text: string,
+  chunkSize: number,
+): string {
+  let output = ''
+  for (let offset = 0; offset < text.length; offset += chunkSize) {
+    broker.consumeStderrInto(
+      session,
+      text.slice(offset, offset + chunkSize),
+      false,
+      MARKER,
+      (visible) => {
+        output += visible
+      },
+    )
+  }
+  return output
+}
+
+describe('broker pure fragment composition', () => {
+  test('the shipped broker program embeds the fragment verbatim', () => {
+    expect(TERMINAL_BROKER_SOURCE).toContain(TERMINAL_BROKER_PURE_SOURCE)
+  })
+
+  test('the fragment reaches no host facility, so it can run detached', () => {
+    expect(TERMINAL_BROKER_PURE_SOURCE).not.toMatch(
+      /\b(?:require|process|__dirname|globalThis)\b/,
+    )
+  })
+})
+
+describe('stderr bounding', () => {
+  // The read size is exactly what differed between runners: macOS delivered
+  // small chunks and stayed under the cap by luck, Linux delivered ~24KB at a
+  // time and blew past it. Pinning it as a parameter removes the platform from
+  // the equation.
+  const chunkSizes = [128, 4096, 24 * 1024, 64 * 1024]
+
+  test.each(chunkSizes)(
+    'bounds a newline-free run while preserving its tail and exit sentinel (%i-byte reads)',
+    (chunkSize) => {
+      const session = makeSession()
+      const noise = 'e'.repeat(4 * 64 * 1024)
+      const output =
+        feed(session, `${noise}TAIL\n${MARKER}0\n`, chunkSize)
+
+      expect(output).toMatch(/^…\[\+\d+ stderr chars truncated\]\n/)
+      expect(output).toContain('TAIL\n')
+      expect(output).not.toContain(MARKER)
+      expect(output.length).toBeLessThanOrEqual(stderrPendingLimit + 128)
+      expect(session.sentinelCode).toBe(0)
+    },
+  )
+
+  test('a run shorter than the limit survives intact', () => {
+    const session = makeSession()
+    const line = 'x'.repeat(1024)
+
+    expect(feed(session, `${line}\n`, 128)).toBe(`${line}\n`)
+    expect(session.stderrDroppedChars).toBe(0)
+  })
+
+  test('bounding trims the head, not the tail that follows a newline', () => {
+    const session = makeSession()
+    session.stderrPending = `${'a'.repeat(stderrPendingLimit + 10)}\nkeep me`
+    broker.boundStderrHead(session)
+
+    expect(session.stderrDroppedChars).toBe(10)
+    expect(session.stderrPending).toHaveLength(
+      stderrPendingLimit + '\nkeep me'.length,
+    )
+    expect(session.stderrPending.endsWith('\nkeep me')).toBe(true)
+  })
+
+  test('a flush emits the newline-free tail and strips a bare sentinel', () => {
+    const session = makeSession()
+    let output = ''
+    broker.consumeStderrInto(
+      session,
+      `bye${MARKER}7`,
+      true,
+      MARKER,
+      (visible) => {
+        output += visible
+      },
+    )
+
+    expect(output).toBe('bye')
+    expect(session.sentinelCode).toBe(7)
+    expect(session.stderrPending).toBe('')
+  })
+})
+
+describe('python ownership-hook detection', () => {
+  const disables = (command: string, args: string[], initialInput?: string) =>
+    broker.launchDisablesPythonOwnershipHook({ command, args }, initialInput)
+  const toRequest = (pty: { command: string; args: string[] }): [string, string[]] => [
+    pty.command,
+    pty.args,
+  ]
+
+  test('accepts an ordinary python launch', () => {
+    expect(disables('/usr/bin/python3', ['script.py'])).toBe(false)
+  })
+
+  test.each([['-S'], ['-E'], ['-I']])(
+    'rejects python launched with %s',
+    (flag) => {
+      expect(disables('/usr/bin/python3', [flag, 'script.py'])).toBe(true)
+    },
+  )
+
+  test('sees through an env(1) prefix but not through its assignments', () => {
+    expect(disables('/usr/bin/env', ['python3', '-S'])).toBe(true)
+    expect(disables('/usr/bin/env', ['FOO=bar', 'python3', 'script.py'])).toBe(
+      false,
+    )
+  })
+
+  test('rejects NODE_OPTIONS being overwritten through env(1)', () => {
+    expect(
+      disables('/usr/bin/env', ['NODE_OPTIONS=--x', 'python3', 'script.py']),
+    ).toBe(true)
+  })
+
+  test('sees a hook-disabling python inside a shell -c program', () => {
+    expect(disables('/bin/sh', ['-c', 'echo hi; python3 -S -c pass'])).toBe(
+      true,
+    )
+    expect(disables('/bin/sh', ['-c', 'echo hi; python3 script.py'])).toBe(
+      false,
+    )
+  })
+
+  test('does not reject quoted -S text that is not a command', () => {
+    expect(disables('/bin/sh', ['-c', 'echo "python3 -S"'])).toBe(false)
+  })
+
+  test('sees it in the initial input typed into a plain shell', () => {
+    expect(disables('/bin/zsh', [], 'python3 -S\n')).toBe(true)
+  })
+
+  // The production launch nests the real binary inside the PTY wrapper and the
+  // argv bootstrap, where a naive reader sees only shell text. Both wrapper
+  // dialects are built here from an injected platform, so a macOS checkout
+  // covers the Linux shape and the reverse.
+  test.each([['darwin'], ['linux']])(
+    'sees it hidden in the %s PTY wrapper and argv bootstrap',
+    (platform) => {
+      const gateway = new NodeProcessGateway(undefined, platform)
+      const ptyCommandFor = (args: string[], commandArgs: string[]) => {
+        const launch = buildTerminalShellLaunch(
+          '/bin/sh',
+          '/usr/bin/python3',
+          args,
+          commandArgs,
+        )
+        return gateway.buildPtyCommand({
+          binaryPath: launch.binaryPath,
+          args: launch.args,
+          rows: 24,
+          cols: 80,
+          transcriptPath: '/tmp/taskchute-broker-test.log',
+        })
+      }
+
+      expect(
+        disables(...toRequest(ptyCommandFor(['-S'], ['-c', 'print(1)']))),
+      ).toBe(true)
+      expect(disables(...toRequest(ptyCommandFor(['script.py'], [])))).toBe(
+        false,
+      )
+    },
+  )
+})

--- a/tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts
+++ b/tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts
@@ -154,12 +154,28 @@ describe('python ownership-hook detection', () => {
     expect(disables('/usr/bin/python3', ['script.py'])).toBe(false)
   })
 
-  test.each([['-S'], ['-E'], ['-I']])(
-    'rejects python launched with %s',
-    (flag) => {
-      expect(disables('/usr/bin/python3', [flag, 'script.py'])).toBe(true)
-    },
-  )
+  // The launch shapes below used to be verified by spawning a real interpreter,
+  // behind `if (!existsSync('/usr/bin/python3')) return` — which reported a
+  // pass, not a skip, on any machine without it. What they actually assert is
+  // this decision function, so they belong here where nothing has to be
+  // installed. One spawned case still guards that the rejection happens before
+  // the process starts; see the integration suite.
+  test.each([
+    ['direct', '/usr/bin/python3', ['-S']],
+    ['ignore environment', '/usr/bin/python3', ['-E']],
+    ['isolated mode', '/usr/bin/python3', ['-I']],
+    ['combined flags', '/usr/bin/python3', ['-ES']],
+    ['env launcher', '/usr/bin/env', ['python3', '-B', '-S']],
+    ['env clear', '/usr/bin/env', ['-i', '/usr/bin/python3']],
+    ['env unset Python path', '/usr/bin/env', ['-u', 'PYTHONPATH', '/usr/bin/python3']],
+    ['env replace Python path', '/usr/bin/env', ['PYTHONPATH=', '/usr/bin/python3']],
+  ])('rejects a %s hook-disabling launch', (_label, command, args) => {
+    expect(disables(command, args)).toBe(true)
+  })
+
+  test('rejects a hook-disabling launch behind the shell `command` builtin', () => {
+    expect(disables('/bin/sh', ['-c', 'command /usr/bin/python3 -S'])).toBe(true)
+  })
 
   test('sees through an env(1) prefix but not through its assignments', () => {
     expect(disables('/usr/bin/env', ['python3', '-S'])).toBe(true)
@@ -223,4 +239,28 @@ describe('python ownership-hook detection', () => {
       )
     },
   )
+
+  // buildPtyCommand is a pure function of the platform, so the wrapper shape
+  // the broker actually receives in production can be checked for every flag
+  // without a python on disk — and for the dialect this host does not run.
+  test.each([
+    ['darwin', '-S'],
+    ['darwin', '-E'],
+    ['darwin', '-I'],
+    ['darwin', '-ES'],
+    ['linux', '-S'],
+    ['linux', '-E'],
+    ['linux', '-I'],
+    ['linux', '-ES'],
+  ])('rejects python %s through the %s production PTY wrapper', (platform, pythonFlag) => {
+    const ptyCommand = new NodeProcessGateway(undefined, platform).buildPtyCommand({
+      binaryPath: '/usr/bin/python3',
+      args: [pythonFlag, '-c', 'print("SHOULD_NOT_RUN")'],
+      rows: 24,
+      cols: 80,
+      transcriptPath: '/tmp/taskchute-broker-test.log',
+    })
+
+    expect(disables(...toRequest(ptyCommand))).toBe(true)
+  })
 })

--- a/tests/features/ai-task/brokerTestUtils.ts
+++ b/tests/features/ai-task/brokerTestUtils.ts
@@ -1,0 +1,113 @@
+import { readdirSync } from 'fs'
+import { basename, dirname, join } from 'path'
+
+/**
+ * Helpers the two broker integration suites both need.
+ *
+ * They were duplicated per file, with divergent timeouts (8s in one, 15s in the
+ * other) for the same kind of wait. Every use is either a poll loop or a wait on
+ * a real process, and neither becomes more correct by giving up sooner, so they
+ * share one number here.
+ */
+export const BROKER_TEST_TIMEOUT_MS = 20_000
+
+/** Interval for the poll loops below. */
+const POLL_INTERVAL_MS = 25
+
+export function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs = BROKER_TEST_TIMEOUT_MS,
+  label = 'Broker integration test',
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${String(timeoutMs)}ms`)),
+      timeoutMs,
+    )
+    void promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timer)
+        reject(error instanceof Error ? error : new Error(String(error)))
+      },
+    )
+  })
+}
+
+/**
+ * Poll until `predicate` holds. `describe` is folded into the timeout message,
+ * because "condition timed out" tells whoever reads the CI log nothing about
+ * which condition, and these all fail on a loaded runner eventually.
+ */
+export async function waitUntil(
+  predicate: () => boolean,
+  describeCondition: string,
+  timeoutMs = BROKER_TEST_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await sleep(POLL_INTERVAL_MS)
+  }
+  throw new Error(
+    `Timed out after ${String(timeoutMs)}ms waiting until ${describeCondition}`,
+  )
+}
+
+/** Whether a pid is still signalable by this process. */
+export function isAlive(pid: number | undefined): boolean {
+  if (pid === undefined || !Number.isInteger(pid) || pid < 1) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Poll until every pid is gone, naming the survivors when it times out. */
+export async function waitUntilAllGone(
+  pids: readonly number[],
+  timeoutMs = BROKER_TEST_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let surviving = pids.filter(isAlive)
+  while (Date.now() < deadline && surviving.length > 0) {
+    await sleep(POLL_INTERVAL_MS)
+    surviving = pids.filter(isAlive)
+  }
+  if (surviving.length > 0) {
+    throw new Error(
+      `Timed out after ${String(timeoutMs)}ms; still alive: ${surviving.join(', ')}`,
+    )
+  }
+}
+
+export function ownerPidFiles(descriptorPath: string): string[] {
+  const directory = dirname(descriptorPath)
+  const prefix = `${basename(descriptorPath)}.owner-`
+  return readdirSync(directory)
+    .filter((name) => name.startsWith(prefix) && name.endsWith('.jsonl'))
+    .map((name) => join(directory, name))
+}

--- a/tests/features/ai-task/parse-descendant-snapshot.test.ts
+++ b/tests/features/ai-task/parse-descendant-snapshot.test.ts
@@ -1,0 +1,110 @@
+import { parseDescendantSnapshot } from '../../../src/features/ai-task/services/process/parseDescendantSnapshot'
+
+/**
+ * Until this file existed, the gateway's `ps` parsing was reachable only by
+ * spawning real processes: injecting the `snapshotDescendantPids` seam replaces
+ * the exec and the parse together, so no test ever exercised the regex or the
+ * walk.
+ */
+const LSTART = 'Mon Aug 25 09:14:07 2025'
+
+/** `ps -axo pid=,ppid=,lstart=` right-aligns the numeric columns. */
+const line = (pid: number, ppid: number, lstart = LSTART): string =>
+  `${String(pid).padStart(6)} ${String(ppid).padStart(5)} ${lstart}`
+
+describe('parseDescendantSnapshot', () => {
+  test('follows a chain past the first level', () => {
+    const output = [line(101, 100), line(102, 101), line(103, 102), ''].join('\n')
+
+    expect(parseDescendantSnapshot(output, 100).map((entry) => entry.pid).sort()).toEqual(
+      [101, 102, 103],
+    )
+  })
+
+  test('carries the raw lstart text as the birth token', () => {
+    // The token is compared as an opaque string to reject PID reuse, so it must
+    // arrive intact rather than parsed.
+    expect(parseDescendantSnapshot(`${line(101, 100)}\n`, 100)).toEqual([
+      { pid: 101, birthToken: LSTART },
+    ])
+  })
+
+  test('keeps a single-digit lstart day intact', () => {
+    // `Aug  4` carries two spaces; the command column is `(.+)$`, so the token
+    // must not be split on whitespace.
+    const singleDigitDay = 'Mon Aug  4 09:14:07 2025'
+
+    expect(
+      parseDescendantSnapshot(`${line(101, 100, singleDigitDay)}\n`, 100)[0]?.birthToken,
+    ).toBe(singleDigitDay)
+  })
+
+  test('keeps a locale-rendered lstart rather than dropping the process', () => {
+    // A ps that ran without LC_ALL=C renders the month in the local language.
+    // The pid still matters for reaping; only the token's text differs, and it
+    // is only ever compared against another reading from the same machine.
+    const french = 'lun. aoû  4 09:14:07 2025'
+
+    expect(parseDescendantSnapshot(`${line(101, 100, french)}\n`, 100)).toEqual([
+      { pid: 101, birthToken: french },
+    ])
+  })
+
+  test('excludes the root itself', () => {
+    const output = [line(100, 1), line(101, 100), ''].join('\n')
+
+    expect(parseDescendantSnapshot(output, 100).map((entry) => entry.pid)).toEqual([101])
+  })
+
+  test('returns nothing for a root with no children', () => {
+    expect(parseDescendantSnapshot(`${line(101, 100)}\n`, 999)).toEqual([])
+  })
+
+  test('does not treat pid 0 as the parent of everything', () => {
+    const output = [line(101, 0), line(102, 101), ''].join('\n')
+
+    expect(parseDescendantSnapshot(output, 0).map((entry) => entry.pid).sort()).toEqual([
+      101, 102,
+    ])
+    expect(parseDescendantSnapshot(output, 100)).toEqual([])
+  })
+
+  test('terminates on a ppid cycle', () => {
+    // A self-parenting entry, and a pair that point at each other. A walk
+    // without a seen set never returns here.
+    const output = [line(101, 100), line(102, 102), line(103, 104), line(104, 103), ''].join(
+      '\n',
+    )
+
+    expect(parseDescendantSnapshot(output, 100).map((entry) => entry.pid)).toEqual([101])
+  })
+
+  test('never walks back into the root through a cycle', () => {
+    const output = [line(101, 100), line(100, 101), ''].join('\n')
+
+    expect(parseDescendantSnapshot(output, 100).map((entry) => entry.pid)).toEqual([101])
+  })
+
+  test('skips lines that are not process rows', () => {
+    const output = [
+      '   PID  PPID STARTED',
+      line(101, 100),
+      'ps: some error text',
+      '',
+    ].join('\n')
+
+    expect(parseDescendantSnapshot(output, 100).map((entry) => entry.pid)).toEqual([101])
+  })
+
+  test('survives empty output', () => {
+    expect(parseDescendantSnapshot('', 100)).toEqual([])
+  })
+
+  test('collects siblings as well as depth', () => {
+    const output = [line(101, 100), line(102, 100), line(103, 101), ''].join('\n')
+
+    expect(parseDescendantSnapshot(output, 100).map((entry) => entry.pid).sort()).toEqual([
+      101, 102, 103,
+    ])
+  })
+})

--- a/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
+++ b/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
@@ -2329,48 +2329,11 @@ describePosix('TerminalSessionBroker resilience', () => {
     await secondClient.shutdown()
   })
 
-  test('bounds newline-free stderr while preserving its tail and exit sentinel', async () => {
-    const unique = `stderr-cap-${process.pid}-${Date.now()}-${Math.random()}`
-    const identity = `broker-resilience-${unique}`
-    const sessionId = `session-stderr-cap-${process.pid}-${Date.now()}`
-    const transcriptPath = join(tmpdir(), `taskchute-broker-${unique}.log`)
-    const exited = deferred<void>()
-    let output = ''
-    const client = new TerminalSessionBrokerClient({ identity })
-    try {
-      client.start(
-        sessionId,
-        {
-          command: '/bin/sh',
-          args: [
-            '-c',
-            'dd if=/dev/zero bs=65536 count=4 2>/dev/null | tr "\\000" "e" >&2; printf "TAIL\\n__TASKCHUTE_AI_EXIT__0\\n" >&2',
-          ],
-          env: { ...process.env },
-          stdinMode: 'pipe',
-        },
-        transcriptPath,
-        undefined,
-        {
-          onData: (data) => {
-            output += data
-          },
-          onExit: (outcome) => {
-            if (outcome.status === 'succeeded') exited.resolve()
-            else exited.reject(new Error(`Unexpected exit: ${outcome.status}`))
-          },
-        },
-      )
-      await withTimeout(exited.promise)
-
-      expect(output).toMatch(/^…\[\+\d+ stderr chars truncated\]\n/)
-      expect(output).toContain('TAIL\n')
-      expect(output).not.toContain('__TASKCHUTE_AI_EXIT__')
-      expect(output.length).toBeLessThanOrEqual(64 * 1024 + 128)
-    } finally {
-      await client.shutdown()
-    }
-  })
+  // The stderr cap itself is covered by
+  // tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts.
+  // Driving it through a real pipe made the outcome depend on how much one
+  // read delivered, which is a platform property: macOS passed by luck while
+  // Linux always failed. The pure test pins the read size instead.
 
   test('uses a close-flushed sentinel without a trailing newline for the final outcome', async () => {
     const unique = `sentinel-close-flush-${process.pid}-${Date.now()}-${Math.random()}`

--- a/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
+++ b/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
@@ -445,9 +445,9 @@ describePosix('TerminalSessionBroker resilience', () => {
         outcome: { status: 'stopped' },
       })
       // The source emits the acknowledgement from finish(), which only runs
-      // after the wrapper child close event. PID liveness is checked as an
-      // independent process-level assertion.
-      expect(() => process.kill(childPid, 0)).toThrow()
+      // after the wrapper child close event. PID liveness is a separate
+      // process-level fact that can land just after it.
+      await waitUntilAllGone([childPid])
       control.end()
       control.destroy()
     } finally {
@@ -518,16 +518,7 @@ describePosix('TerminalSessionBroker resilience', () => {
         rendererLeaseGeneration,
       })}\n`)
 
-      const deadline = Date.now() + 5_000
-      while (Date.now() < deadline) {
-        try {
-          process.kill(childPid, 0)
-          await sleep(25)
-        } catch {
-          break
-        }
-      }
-      expect(() => process.kill(childPid, 0)).toThrow()
+      await waitUntilAllGone([childPid])
     } finally {
       await client.shutdown()
     }
@@ -576,25 +567,7 @@ describePosix('TerminalSessionBroker resilience', () => {
       // Do not let this renderer reconnect while the broker's signal handler
       // is completing its process-tree shutdown.
       client.detach()
-      const deadline = Date.now() + 5_000
-      while (Date.now() < deadline) {
-        let childAlive = true
-        let brokerAlive = true
-        try {
-          process.kill(childPid, 0)
-        } catch {
-          childAlive = false
-        }
-        try {
-          process.kill(descriptor.pid, 0)
-        } catch {
-          brokerAlive = false
-        }
-        if (!childAlive && !brokerAlive) break
-        await sleep(25)
-      }
-      expect(() => process.kill(childPid, 0)).toThrow()
-      expect(() => process.kill(descriptor.pid, 0)).toThrow()
+      await waitUntilAllGone([childPid, descriptor.pid])
     } finally {
       await client.shutdown()
     }
@@ -655,25 +628,7 @@ describePosix('TerminalSessionBroker resilience', () => {
       process.kill(descriptor.pid, 'SIGKILL')
       await withTimeout(unavailable.promise, 8_000)
 
-      const deadline = Date.now() + 5_000
-      while (Date.now() < deadline) {
-        let childAlive = true
-        let brokerAlive = true
-        try {
-          process.kill(confirmedChildPid, 0)
-        } catch {
-          childAlive = false
-        }
-        try {
-          process.kill(descriptor.pid, 0)
-        } catch {
-          brokerAlive = false
-        }
-        if (!childAlive && !brokerAlive) break
-        await sleep(25)
-      }
-      expect(() => process.kill(confirmedChildPid, 0)).toThrow()
-      expect(() => process.kill(descriptor.pid, 0)).toThrow()
+      await waitUntilAllGone([confirmedChildPid, descriptor.pid])
     } finally {
       client.detach()
       if (childPid !== undefined) {
@@ -744,18 +699,8 @@ describePosix('TerminalSessionBroker resilience', () => {
       brokerPid = descriptor.pid
 
       client.detach()
-      const deadline = Date.now() + 9_000
-      while (Date.now() < deadline) {
-        let brokerAlive = true
-        let guardAlive = true
-        try { process.kill(descriptor.pid, 0) } catch { brokerAlive = false }
-        try { process.kill(guardPid, 0) } catch { guardAlive = false }
-        if (!brokerAlive && !guardAlive) break
-        await sleep(50)
-      }
+      await waitUntilAllGone([descriptor.pid, guardPid])
 
-      expect(() => process.kill(descriptor.pid, 0)).toThrow()
-      expect(() => process.kill(guardPid ?? -1, 0)).toThrow()
       expect(existsSync(descriptorPath)).toBe(false)
       expect(ownerArtifactPaths(descriptorPath)).toEqual([])
     } finally {
@@ -1097,25 +1042,12 @@ describePosix('TerminalSessionBroker resilience', () => {
       client.detach()
       process.kill(descriptor.pid, 'SIGKILL')
 
-      const processDeadline = Date.now() + 6_000
-      while (Date.now() < processDeadline) {
-        try {
-          process.kill(confirmedDetachedPid, 0)
-          await sleep(25)
-        } catch {
-          break
-        }
-      }
-      expect(() => process.kill(detachedPid ?? -1, 0)).toThrow()
+      await waitUntilAllGone([confirmedDetachedPid])
 
-      const artifactDeadline = Date.now() + 3_000
-      while (
-        Date.now() < artifactDeadline &&
-        ownerArtifactPaths(descriptorPath).length > 0
-      ) {
-        await sleep(25)
-      }
-      expect(ownerArtifactPaths(descriptorPath)).toEqual([])
+      await waitUntil(
+        () => ownerArtifactPaths(descriptorPath).length === 0,
+        'the guard has removed its owner artifacts',
+      )
     } finally {
       client.detach()
       if (detachedPid !== undefined) {
@@ -1235,7 +1167,7 @@ describePosix('TerminalSessionBroker resilience', () => {
       expect(existsSync(markerPath)).toBe(true)
       detachedPid = Number(readFileSync(markerPath, 'utf8'))
       await withTimeout(exited.promise)
-      expect(() => process.kill(detachedPid ?? -1, 0)).toThrow()
+      await waitUntilAllGone([detachedPid])
     } finally {
       await client.shutdown().catch(() => undefined)
       if (detachedPid !== undefined) {
@@ -1257,6 +1189,7 @@ describePosix('TerminalSessionBroker resilience', () => {
     const exited = deferred<void>()
     const client = new TerminalSessionBrokerClient({ identity })
     let childPid: number | undefined
+    let nativeOutput = ''
     try {
       client.start(
         sessionId,
@@ -1270,7 +1203,12 @@ describePosix('TerminalSessionBroker resilience', () => {
         undefined,
         {
           onData: (data) => {
-            const match = /NATIVE_CHILD:(\d+)/u.exec(data)
+            // Accumulated, not matched per chunk: through a PTY the marker can
+            // arrive split across two reads, and where the boundary lands is a
+            // platform property. Matching one chunk passed on macOS and hung
+            // on Linux.
+            nativeOutput += data
+            const match = /NATIVE_CHILD:(\d+)/u.exec(nativeOutput)
             if (match) childReady.resolve(Number(match[1]))
           },
           onExit: () => exited.resolve(),
@@ -1280,7 +1218,9 @@ describePosix('TerminalSessionBroker resilience', () => {
       )
       childPid = await withTimeout(childReady.promise)
       await withTimeout(exited.promise)
-      expect(() => process.kill(childPid ?? -1, 0)).toThrow()
+      // The reaper runs after the guard observes the target's exit, so the
+      // exit frame can reach this client first.
+      await waitUntilAllGone([childPid])
     } finally {
       await client.shutdown().catch(() => undefined)
       if (childPid !== undefined) {

--- a/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
+++ b/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
@@ -25,6 +25,8 @@ import { NodeProcessGateway } from '../../../src/features/ai-task/services/NodeP
 import { TERMINAL_BROKER_SOURCE } from '../../../src/features/ai-task/services/TerminalSessionBrokerSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from '../../../src/features/ai-task/services/TerminalSessionGuardSource'
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
+import { describePosix, testWithBinaries } from '../../support/platform'
+import { waitUntil, waitUntilAllGone } from './brokerTestUtils'
 
 function writeFileSync(
   path: Parameters<typeof fsWriteFileSync>[0],
@@ -240,7 +242,7 @@ async function runMockWindowsGuardIdentityScenario(
 
 const OVERSIZED_FRAME = 'x'.repeat(1024 * 1024 + 64 * 1024)
 
-const describePosix = process.platform === 'win32' ? describe.skip : describe
+const { test: overloadTest, paths: overloadPaths } = testWithBinaries(['yes', 'tail'])
 
 describePosix('TerminalSessionBroker resilience', () => {
   jest.setTimeout(30_000)
@@ -846,41 +848,29 @@ describePosix('TerminalSessionBroker resilience', () => {
         pid: number
       }
       brokerPid = descriptor.pid
+      // The owner hook, python hook dir and per-session jsonl are written
+      // asynchronously; REAL_PTY_READY does not order them. Reading the
+      // directory once right after the marker was a read-after-write race.
+      await waitUntil(
+        () => ownerArtifactPaths(descriptorPath).length >= 3,
+        'the broker has written its owner artifacts',
+      )
       staleArtifacts = ownerArtifactPaths(descriptorPath)
-      expect(staleArtifacts.length).toBeGreaterThanOrEqual(3)
 
       // Simulate the renderer/app disappearing before the broker. Cleanup
       // must be owned by the guard processes, not by an onUnavailable callback.
       first.detach()
       process.kill(descriptor.pid, 'SIGKILL')
-      const deadline = Date.now() + 5_000
-      while (Date.now() < deadline) {
-        let wrapperAlive = true
-        let detachedAlive = true
-        try {
-          process.kill(confirmedWrapperPid, 0)
-        } catch {
-          wrapperAlive = false
-        }
-        try {
-          process.kill(detachedPid ?? -1, 0)
-        } catch {
-          detachedAlive = false
-        }
-        if (!wrapperAlive && !detachedAlive) break
-        await sleep(25)
-      }
-      expect(() => process.kill(confirmedWrapperPid, 0)).toThrow()
-      expect(() => process.kill(detachedPid ?? -1, 0)).toThrow()
+      // The watchdog retries with a backoff capped at 1s, and on Linux each
+      // pass reads a full `ps axeww`. The old 5s budget was a coin flip on a
+      // loaded runner; a generous budget on a poll loop costs nothing when it
+      // passes, and the failure now names which pid survived.
+      await waitUntilAllGone([confirmedWrapperPid, detachedPid ?? -1])
 
-      const artifactDeadline = Date.now() + 3_000
-      while (
-        Date.now() < artifactDeadline &&
-        staleArtifacts.some((path) => existsSync(path))
-      ) {
-        await sleep(25)
-      }
-      expect(staleArtifacts.every((path) => !existsSync(path))).toBe(true)
+      await waitUntil(
+        () => staleArtifacts.every((path) => !existsSync(path)),
+        'the guard has removed the stale owner artifacts',
+      )
 
       const secondReady = deferred<void>()
       const second = new TerminalSessionBrokerClient({
@@ -948,7 +938,11 @@ describePosix('TerminalSessionBroker resilience', () => {
     }
   })
 
-  test('owner sentinel cleanup covers Node child_process options-only overloads', async () => {
+  // yes(1) and tail(1) are only stand-ins for "a child that stays alive", but
+  // hardcoding their absolute paths made the outcome depend on the image. A
+  // missing one now skips visibly instead of timing out on a marker that never
+  // arrives.
+  overloadTest('owner sentinel cleanup covers Node child_process options-only overloads', async () => {
     const unique = `broker-overload-sentinel-${process.pid}-${Date.now()}-${Math.random()}`
     const identity = `broker-resilience-${unique}`
     const descriptorPath = getTerminalBrokerDescriptorPath(identity)
@@ -959,8 +953,8 @@ describePosix('TerminalSessionBroker resilience', () => {
       "const cp=require('child_process');" +
       `const forkModule=${JSON.stringify(forkModulePath)};` +
       "const children=[" +
-        "cp.spawn('/usr/bin/yes',{detached:true,stdio:'ignore'})," +
-        "cp.execFile('/usr/bin/tail',{detached:true},()=>{})," +
+        `cp.spawn(${JSON.stringify(overloadPaths['yes'])},{detached:true,stdio:'ignore'}),` +
+        `cp.execFile(${JSON.stringify(overloadPaths['tail'])},{detached:true},()=>{}),` +
         "cp.fork(forkModule,{detached:true,stdio:'ignore'})," +
         "cp.exec('sleep 30',{detached:true},()=>{})" +
       "];" +
@@ -1004,22 +998,11 @@ describePosix('TerminalSessionBroker resilience', () => {
       client.detach()
       process.kill(descriptor.pid, 'SIGKILL')
 
-      const deadline = Date.now() + 6_000
-      while (Date.now() < deadline) {
-        const alive = childPids.some((pid) => {
-          try {
-            process.kill(pid, 0)
-            return true
-          } catch {
-            return false
-          }
-        })
-        if (!alive) break
-        await sleep(25)
-      }
-      for (const pid of childPids) {
-        expect(() => process.kill(pid, 0)).toThrow()
-      }
+      // Four children, each reached through a different child_process
+      // overload, against a watchdog whose retry backoff caps at 1s. The old
+      // 6s budget could be spent in six retries on a loaded runner, and the
+      // per-pid assertion did not say which of the four had survived.
+      await waitUntilAllGone(childPids)
     } finally {
       client.detach()
       for (const pid of childPids) {

--- a/tests/features/ai-task/terminal-session-broker.integration.test.ts
+++ b/tests/features/ai-task/terminal-session-broker.integration.test.ts
@@ -17,56 +17,15 @@ import {
   type TerminalBrokerSessionCallbacks,
 } from '../../../src/features/ai-task/services/TerminalSessionBroker'
 import { NodeProcessGateway } from '../../../src/features/ai-task/services/NodeProcessGateway'
-import { buildTerminalShellLaunch } from '../../../src/features/ai-task/services/dispatchers/TerminalShellBootstrap'
+import { describePosix, testWithBinaries } from '../../support/platform'
+import {
+  deferred,
+  ownerPidFiles,
+  waitUntil,
+  waitUntilAllGone,
+  withTimeout,
+} from './brokerTestUtils'
 
-function deferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
-}
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs = 8_000): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error('Broker integration test timed out')),
-      timeoutMs,
-    )
-    void promise.then(
-      (value) => {
-        clearTimeout(timer)
-        resolve(value)
-      },
-      (error: unknown) => {
-        clearTimeout(timer)
-        reject(error instanceof Error ? error : new Error(String(error)))
-      },
-    )
-  })
-}
-
-async function waitUntil(
-  predicate: () => boolean,
-  timeoutMs = 5_000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (predicate()) return
-    await new Promise((resolve) => setTimeout(resolve, 25))
-  }
-  throw new Error('Broker integration condition timed out')
-}
-
-function ownerPidFiles(descriptorPath: string): string[] {
-  const directory = dirname(descriptorPath)
-  const prefix = `${basename(descriptorPath)}.owner-`
-  return readdirSync(directory)
-    .filter((name) => name.startsWith(prefix) && name.endsWith('.jsonl'))
-    .map((name) => join(directory, name))
-}
 
 interface RawBrokerDescriptor {
   port: number
@@ -129,7 +88,7 @@ async function sendRawBrokerFrame(
   })
 }
 
-const describePosix = process.platform === 'win32' ? describe.skip : describe
+const { test: pythonTest } = testWithBinaries(['python3'])
 
 describePosix('TerminalSessionBrokerClient integration', () => {
   jest.setTimeout(20_000)
@@ -422,7 +381,7 @@ describePosix('TerminalSessionBrokerClient integration', () => {
       } catch {
         return true
       }
-    })
+    }, 'the stopped session child is gone')
     await client.shutdown()
   })
 
@@ -640,6 +599,7 @@ describePosix('TerminalSessionBrokerClient integration', () => {
         () =>
           existsSync(sttyLogPath) &&
           readFileSync(sttyLogPath, 'utf8').includes('rows 24 cols 99'),
+        'the current-generation resize reaches stty',
       )
       expect(readFileSync(sttyLogPath, 'utf8')).not.toContain(
         'rows 55 cols 177',
@@ -652,7 +612,7 @@ describePosix('TerminalSessionBrokerClient integration', () => {
         } catch {
           return true
         }
-      })
+      }, 'the stopped session child is gone')
       await client.shutdown()
     } finally {
       delete process.env.TASKCHUTE_BROKER_STTY
@@ -810,7 +770,10 @@ describePosix('TerminalSessionBrokerClient integration', () => {
     await client.scheduleShutdownAfterGrace(200)
     client.detach()
 
-    await waitUntil(() => !existsSync(descriptorPath), 5_000)
+    await waitUntil(
+      () => !existsSync(descriptorPath),
+      'the broker descriptor is gone',
+    )
     expect(() => process.kill(childPid ?? -1, 0)).toThrow()
   })
 
@@ -852,7 +815,10 @@ describePosix('TerminalSessionBrokerClient integration', () => {
     // late traffic from that already-authenticated socket is not proof of a
     // canceled quit and must not renew/cancel the deadline.
     client.resize(sessionId, 100, 30)
-    await waitUntil(() => !existsSync(descriptorPath), 5_000)
+    await waitUntil(
+      () => !existsSync(descriptorPath),
+      'the broker descriptor is gone',
+    )
     expect(() => process.kill(childPid ?? -1, 0)).toThrow()
     client.detach()
   })
@@ -1077,6 +1043,10 @@ describePosix('TerminalSessionBrokerClient integration', () => {
     const unique = `natural-exit-detached-${process.pid}-${Date.now()}-${Math.random()}`
     const identity = `broker-integration-${unique}`
     const exited = deferred<void>()
+    // Resolved from the stdout match rather than read after onExit: the child
+    // holds the root's stdout open, so its marker and the exit event race, and
+    // the pid must be captured whichever way that race lands.
+    const detached = deferred<number>()
     let output = ''
     let detachedPid: number | undefined
     const client = new TerminalSessionBrokerClient({
@@ -1093,7 +1063,7 @@ describePosix('TerminalSessionBrokerClient integration', () => {
       client.start(
         `session-${unique}`,
         {
-          command: 'node',
+          command: process.execPath,
           args: ['-e', nodeCode],
           env: { ...process.env },
           stdinMode: 'pipe',
@@ -1104,17 +1074,26 @@ describePosix('TerminalSessionBrokerClient integration', () => {
           onData: (data) => {
             output += data
             const match = /DETACHED_PID:(\d+)/u.exec(output)
-            if (match) detachedPid = Number(match[1])
+            if (match) {
+              detachedPid = Number(match[1])
+              detached.resolve(detachedPid)
+            }
           },
           onExit: () => exited.resolve(),
-          onUnavailable: () =>
-            exited.reject(new Error('Natural-exit session was unavailable')),
+          onUnavailable: () => {
+            const error = new Error('Natural-exit session was unavailable')
+            exited.reject(error)
+            detached.reject(error)
+          },
         },
       )
 
+      const reapedPid = await withTimeout(detached.promise)
       await withTimeout(exited.promise)
-      expect(detachedPid).toEqual(expect.any(Number))
-      expect(() => process.kill(detachedPid ?? -1, 0)).toThrow()
+      // The broker reaps the descendant after it observes the root's exit, so
+      // the exit frame can reach this client first. Polling makes the assertion
+      // about whether the reap happens, not about which of the two won.
+      await waitUntilAllGone([reapedPid])
       await withTimeout(client.shutdown())
     } finally {
       if (detachedPid !== undefined) {
@@ -1187,8 +1166,9 @@ describePosix('TerminalSessionBrokerClient integration', () => {
     }
   })
 
-  test('Python intermediary tracking chains sitecustomize and survives a localized broker environment', async () => {
-    if (!existsSync('/usr/bin/python3')) return
+  pythonTest(
+    'Python intermediary tracking chains sitecustomize and survives a localized broker environment',
+    async () => {
     const unique = `python-detached-${process.pid}-${Date.now()}-${Math.random()}`
     const identity = `broker-integration-${unique}`
     const descriptorPath = getTerminalBrokerDescriptorPath(identity)
@@ -1275,24 +1255,16 @@ describePosix('TerminalSessionBrokerClient integration', () => {
     }
   })
 
-  test.each([
-    ['direct', '/usr/bin/python3 -S'],
-    ['ignore environment', '/usr/bin/python3 -E'],
-    ['isolated mode', '/usr/bin/python3 -I'],
-    ['combined flags', '/usr/bin/python3 -ES'],
-    ['env launcher', '/usr/bin/env python3 -B -S'],
-    ['env clear', '/usr/bin/env -i /usr/bin/python3'],
-    ['env unset Python path', '/usr/bin/env -u PYTHONPATH /usr/bin/python3'],
-    ['env replace Python path', '/usr/bin/env PYTHONPATH= /usr/bin/python3'],
-    ['shell command prefix', 'command /usr/bin/python3 -S'],
-  ])('rejects %s hook-disabling Python flags before they can leak a detached child', async (
-    label,
-    pythonLaunch,
-  ) => {
-    if (!existsSync('/usr/bin/python3')) return
-    const safeLabel = label.replace(/[^A-Za-z0-9_-]/gu, '-')
+  // The full matrix of hook-disabling launch shapes lives in
+  // tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts,
+  // where it needs no interpreter on disk. What only a real spawn can show is
+  // that the rejection happens BEFORE the process starts, so one shape stays
+  // here: nothing runs, and nothing detaches.
+  pythonTest(
+    'rejects a hook-disabling Python launch before it can leak a detached child',
+    async () => {
     const unique =
-      `python-no-site-detached-${safeLabel}-${process.pid}-${Date.now()}-${Math.random()}`
+      `python-no-site-detached-${process.pid}-${Date.now()}-${Math.random()}`
     const identity = `broker-integration-${unique}`
     const failed = deferred<{
       status: string
@@ -1313,7 +1285,7 @@ describePosix('TerminalSessionBrokerClient integration', () => {
           command: '/bin/sh',
           args: [
             '-c',
-            `${pythonLaunch} -c ${JSON.stringify(pythonCode)}; echo READY; while :; do sleep 10; done`,
+            `/usr/bin/python3 -S -c ${JSON.stringify(pythonCode)}; echo READY; while :; do sleep 10; done`,
           ],
           env: { ...process.env },
           stdinMode: 'pipe',
@@ -1342,122 +1314,11 @@ describePosix('TerminalSessionBrokerClient integration', () => {
     }
   })
 
-  test.each(['-S', '-E', '-I', '-ES'])(
-    'rejects Python %s through the production PTY wrapper shape before spawn',
-    async (pythonFlag) => {
-    if (!existsSync('/usr/bin/python3')) return
-    const unique =
-      `python-no-site-production-pty-${process.pid}-${Date.now()}-${Math.random()}`
-    const identity = `broker-integration-${unique}`
-    const failed = deferred<{ status: string; errorMessage?: string }>()
-    const transcriptPath = join(tmpdir(), `taskchute-broker-${unique}.log`)
-    const gateway = new NodeProcessGateway()
-    const ptyCommand = gateway.buildPtyCommand({
-      binaryPath: '/usr/bin/python3',
-      args: [pythonFlag, '-c', 'print("SHOULD_NOT_RUN")'],
-      rows: 24,
-      cols: 80,
-      transcriptPath,
-    })
-    const client = new TerminalSessionBrokerClient({ identity })
-    let output = ''
-    try {
-      client.start(
-        `session-${unique}`,
-        {
-          command: ptyCommand.command,
-          args: ptyCommand.args,
-          env: { ...process.env },
-          stdinMode: 'pipe',
-        },
-        transcriptPath,
-        undefined,
-        {
-          onData: (data) => {
-            output += data
-          },
-          onExit: failed.resolve,
-          onUnavailable: () =>
-            failed.reject(new Error('Production PTY rejection was unavailable')),
-        },
-      )
-
-      const outcome = await withTimeout(failed.promise)
-      expect(outcome.status).toBe('failed')
-      expect(outcome.errorMessage).toContain('Python interpreter flags')
-      expect(output).not.toContain('SHOULD_NOT_RUN')
-    } finally {
-      await client.shutdown().catch(() => undefined)
-      rmSync(transcriptPath, { force: true })
-      rmSync(`${transcriptPath}.tty`, { force: true })
-    }
-    },
-  )
-
-  test('rejects hook-disabling Python hidden inside the AI terminal argv bootstrap', async () => {
-    if (!existsSync('/usr/bin/python3')) return
-    const unique =
-      `python-no-site-terminal-bootstrap-${process.pid}-${Date.now()}-${Math.random()}`
-    const identity = `broker-integration-${unique}`
-    const observed = deferred<
-      | { kind: 'rejected'; errorMessage?: string }
-      | { kind: 'spawned' }
-    >()
-    const transcriptPath = join(tmpdir(), `taskchute-broker-${unique}.log`)
-    const gateway = new NodeProcessGateway()
-    const shellLaunch = buildTerminalShellLaunch(
-      '/bin/sh',
-      '/usr/bin/python3',
-      ['-S'],
-      ['-c', 'print("SHOULD_NOT_RUN", flush=True)'],
-    )
-    const ptyCommand = gateway.buildPtyCommand({
-      binaryPath: shellLaunch.binaryPath,
-      args: shellLaunch.args,
-      rows: 24,
-      cols: 80,
-      transcriptPath,
-    })
-    const client = new TerminalSessionBrokerClient({ identity })
-    try {
-      client.start(
-        `session-${unique}`,
-        {
-          command: ptyCommand.command,
-          args: ptyCommand.args,
-          env: { ...process.env },
-          stdinMode: 'pipe',
-        },
-        transcriptPath,
-        undefined,
-        {
-          onData: (data) => {
-            if (data.includes('SHOULD_NOT_RUN')) {
-              observed.resolve({ kind: 'spawned' })
-            }
-          },
-          onExit: (outcome) =>
-            observed.resolve({
-              kind: 'rejected',
-              errorMessage: outcome.errorMessage,
-            }),
-          onUnavailable: () =>
-            observed.reject(new Error('Bootstrap rejection was unavailable')),
-        },
-      )
-
-      const outcome = await withTimeout(observed.promise)
-      expect(outcome.kind).toBe('rejected')
-      if (outcome.kind === 'rejected') {
-        expect(outcome.errorMessage).toContain('Python interpreter flags')
-      }
-    } finally {
-      client.stop(`session-${unique}`, true)
-      await client.shutdown().catch(() => undefined)
-      rmSync(transcriptPath, { force: true })
-      rmSync(`${transcriptPath}.tty`, { force: true })
-    }
-  })
+  // The argv-bootstrap hiding case moved to
+  // tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts.
+  // buildTerminalShellLaunch and buildPtyCommand are both pure, so the nested
+  // shape is now checked for BOTH wrapper dialects instead of only the one this
+  // host speaks — and without needing an interpreter installed.
 
   test.each([
     ['clear environment', ['-i']],

--- a/tests/support/platform.test.ts
+++ b/tests/support/platform.test.ts
@@ -1,0 +1,54 @@
+import { resolveBinary, testWithBinaries } from './platform'
+
+/**
+ * The gate decides whether a suite runs, so a bug here silently removes
+ * coverage — exactly the failure mode it was written to end.
+ */
+describe('resolveBinary', () => {
+  test('finds a binary every POSIX host has', () => {
+    // /bin/sh is what the broker itself spawns, so if this cannot be resolved
+    // the integration suites could not run either.
+    expect(resolveBinary('sh')).toMatch(/\/sh$/u)
+  })
+
+  test('returns null rather than throwing for something not installed', () => {
+    expect(resolveBinary('taskchute-definitely-not-a-real-binary')).toBeNull()
+  })
+
+  test('accepts an absolute path and checks it is executable', () => {
+    expect(resolveBinary('/bin/sh')).toBe('/bin/sh')
+    expect(resolveBinary('/bin/taskchute-not-real')).toBeNull()
+  })
+})
+
+describe('testWithBinaries', () => {
+  test('hands back a runnable test and the resolved paths', () => {
+    const gate = testWithBinaries(['sh'])
+
+    expect(gate.missing).toEqual([])
+    expect(gate.paths['sh']).toMatch(/\/sh$/u)
+    expect(gate.test).toBe(it)
+  })
+
+  test('downgrades to it.skip and names what is missing', () => {
+    // The name matters: a skip is printed by every reporter, whereas the old
+    // `if (!existsSync(...)) return` reported a pass.
+    const gate = testWithBinaries(['taskchute-definitely-not-a-real-binary'])
+
+    expect(gate.missing).toEqual(['taskchute-definitely-not-a-real-binary'])
+    expect(gate.test).toBe(it.skip)
+  })
+
+  test('fails loudly when CI demands the binaries be present', () => {
+    const previous = process.env['TASKCHUTE_TEST_REQUIRE_BINARIES']
+    process.env['TASKCHUTE_TEST_REQUIRE_BINARIES'] = '1'
+    try {
+      expect(() => testWithBinaries(['taskchute-definitely-not-a-real-binary'])).toThrow(
+        /not installed: taskchute-definitely-not-a-real-binary/u,
+      )
+    } finally {
+      if (previous === undefined) delete process.env['TASKCHUTE_TEST_REQUIRE_BINARIES']
+      else process.env['TASKCHUTE_TEST_REQUIRE_BINARIES'] = previous
+    }
+  })
+})

--- a/tests/support/platform.ts
+++ b/tests/support/platform.ts
@@ -1,0 +1,108 @@
+import { accessSync, constants } from 'fs'
+import { delimiter, join } from 'path'
+
+/**
+ * Platform and binary gates for suites that drive real processes.
+ *
+ * The point of routing every such gate through here is that a suite which
+ * cannot run says so. The previous shape — `if (!existsSync('/usr/bin/python3'))
+ * return` inside the test body — reported a **pass**, so fifteen cases,
+ * including every hook-disabling Python flag rejection, could report green on a
+ * machine that never ran them.
+ */
+
+export const describePosix = process.platform === 'win32' ? describe.skip : describe
+export const describeDarwin = process.platform === 'darwin' ? describe : describe.skip
+export const describeLinux = process.platform === 'linux' ? describe : describe.skip
+
+/**
+ * Set in CI. Turns a missing binary into a failure rather than a skip, so a
+ * runner image change cannot quietly reduce a suite to zero coverage — which
+ * would be the same defect as the silent early return, one step removed.
+ */
+const REQUIRE_BINARIES_ENV = 'TASKCHUTE_TEST_REQUIRE_BINARIES'
+
+// The absolute locations the production code itself hardcodes, tried before
+// PATH so a test resolves the same binary the broker would spawn.
+const WELL_KNOWN_DIRECTORIES = ['/usr/bin', '/bin', '/usr/local/bin', '/opt/homebrew/bin']
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Absolute path to `name`, or null when it is not installed. Never throws. */
+export function resolveBinary(name: string): string | null {
+  if (name.includes('/')) return isExecutable(name) ? name : null
+  for (const directory of WELL_KNOWN_DIRECTORIES) {
+    const candidate = join(directory, name)
+    if (isExecutable(candidate)) return candidate
+  }
+  for (const directory of (process.env['PATH'] ?? '').split(delimiter)) {
+    if (!directory) continue
+    const candidate = join(directory, name)
+    if (isExecutable(candidate)) return candidate
+  }
+  return null
+}
+
+function resolveAll(names: readonly string[]): {
+  paths: Record<string, string>
+  missing: string[]
+} {
+  const paths: Record<string, string> = {}
+  const missing: string[] = []
+  for (const name of names) {
+    const resolved = resolveBinary(name)
+    if (resolved === null) missing.push(name)
+    else paths[name] = resolved
+  }
+  if (missing.length > 0 && process.env[REQUIRE_BINARIES_ENV] === '1') {
+    throw new Error(
+      `${REQUIRE_BINARIES_ENV}=1 but these are not installed: ${missing.join(', ')}`,
+    )
+  }
+  return { paths, missing }
+}
+
+/**
+ * describe() when every binary resolves, describe.skip() otherwise, with the
+ * reason folded into the suite name — reporters always print a skipped suite,
+ * while a console warning would be swallowed by tests/setup/console-silence.ts.
+ *
+ * The body receives the resolved absolute paths; when the suite is skipped they
+ * are empty strings, which is safe because nothing in a skipped body runs.
+ */
+export function describeWithBinaries(
+  names: readonly string[],
+  suiteName: string,
+  body: (paths: Record<string, string>) => void,
+): void {
+  const { paths, missing } = resolveAll(names)
+  if (missing.length > 0) {
+    describe.skip(`${suiteName} [requires ${missing.join(', ')}: not installed]`, () => {
+      body(Object.fromEntries(names.map((name) => [name, ''])))
+    })
+    return
+  }
+  describe(suiteName, () => {
+    body(paths)
+  })
+}
+
+/**
+ * The per-test form, for a suite where only some cases need the binary.
+ * `test` is `it.skip` when anything is missing, and `paths` holds what resolved.
+ */
+export function testWithBinaries(names: readonly string[]): {
+  test: jest.It
+  paths: Record<string, string>
+  missing: string[]
+} {
+  const { paths, missing } = resolveAll(names)
+  return { test: missing.length > 0 ? it.skip : it, paths, missing }
+}


### PR DESCRIPTION
## What

Two Linux-only broker defects, and the testing seams that make both verifiable from a macOS checkout.

## Why

`test.yml` excluded the integration suites because they "currently fail on Linux runners", and the suites themselves hid fifteen cases behind `if (!existsSync('/usr/bin/python3')) return` — which reports a **pass**, not a skip. So the cases most worth running were the ones least likely to have run.

### 1. The stderr cap was measured against the wrong thing

`consumeStderr` trimmed the pending buffer *after* the emit loop, so a single emitted line could reach the 64KB cap plus the length of one pipe read. macOS delivered small chunks and stayed under it by luck; Linux delivered ~24KB and blew past it. `bounds newline-free stderr` failed on every CI run and passed locally.

### 2. The broker program no longer fit in a Linux argv string

The broker ships as the single `-e` argument of a spawned node. Linux rejects an execve whose individual argv string exceeds `MAX_ARG_STRLEN` (32 × PAGE_SIZE = 131,072 bytes) with `E2BIG` — it does not misbehave, it never starts. macOS has no per-argument cap.

`main` stood at **130,251 bytes**: inside the limit, with 821 bytes of headroom. The stderr fix alone was enough to cross it.

Verified in a Linux container:

| broker size | spawn |
|---:|---|
| 131,237 | `E2BIG` — never starts |
| 101,154 (after) | starts, reaches its own env validation |

The guard and watchdog programs the broker hands to its children were ~46KB of that budget as JSON string literals. They now travel gzipped and base64'd (~16KB) inside the same argv — nothing moves into the environment, where Linux `ps axeww` would expose it and every descendant would inherit it, or onto disk. A unit test budgets all three programs so the next person to add a feature finds out while there is still room to fix it.

## Testing seams

The same platform-variable inputs kept deciding test outcomes, so each is now a parameter:

- **Pipe read size** — pinned at 128B / 4KB / 24KB / 64KB instead of whatever the OS delivered.
- **`ps` dialect** — the parsing that existed in triplicate across the broker, guard and watchdog is now one fragment spliced verbatim into all three, taking the platform as an argument. The Linux `axeww` branch had never been executed by any test; none of this parsing had a unit test at all.
- **PTY wrapper dialect** — built from an injected platform, so a macOS checkout covers the Linux shape and the reverse.
- **Installed binaries** — `tests/support/platform.ts` resolves them and folds anything missing into the suite name, so a skip is printed. `TASKCHUTE_TEST_REQUIRE_BINARIES=1` in CI turns a miss into a failure.

Thirteen of the fifteen silently-skipped cases moved to pure tests and now cover both dialects. Composition tests assert each program still embeds each fragment byte for byte, and that none has grown a private copy beside it.

## CI

The integration suites now run on ubuntu in their own job, with a preflight that names any missing binary before the tests start. `release.yml`'s `skip_tests` narrows to the integration suite only — the unit suite always runs.

**Suggest leaving the integration job non-required until its pass rate is known.** See below.

## Verification

| | |
|---|---|
| lint / typecheck | clean (one pre-existing warning) |
| unit | 216 suites / 2,974 cases |
| integration | 76 cases |
| `TASKCHUTE_TEST_REQUIRE_BINARIES=1` | zero skips |
| broker program | 106,344 bytes (budget 120,000, kernel limit 131,072) |

## Deliberately not in this PR

No production behaviour changes beyond the argv transport. Four known issues stay open:

- `beginGracefulStop` does not pass its snapshot to `signalDirectTarget`, so three full `ps` runs happen before SIGTERM — against a 1500ms `stopGraceMs`. **`a non-force stop preserves the target SIGTERM grace period` can still fail on a loaded Linux runner**; this is the main reason to keep the job non-required at first.
- `stopGraceMs` is a grace period for `ps`, not for the app.
- `NodeProcessGateway` omits `LC_ALL=C` on two `ps` call sites that every other call site sets.
- The guard reads the non-environment `ps` form on Linux while the broker and watchdog read `axeww`.

`@jest-environment node` for the integration suites was attempted and reverted: the shared `tests/setup/obsidian-dom-globals.ts` requires a DOM.

---

## Correction (added after merge)

The `continue-on-error` comment this PR added to `test.yml` explained the remaining Linux integration failures as cross-test interference, fixable by isolating the suites. **That was wrong**, and so was the next explanation after it. Both were reached by reading which processes survived instead of what the watchdog decided.

Reproduced since, in a Debian 12 container running the same suites (`docker run --init`, node 20, non-root):

| suite | this commit | with the follow-up |
|---|---:|---:|
| resilience | 5 failed | 1 failed |
| broker | 1 failed | 0 failed |

Three defects, each of which only a Linux kernel can produce:

1. **Linux has no wall-clock process start time.** It derives one, as boot time plus the process' start in jiffies, and both are truncated — so `ps` reports the second *before* the clock reading that bracketed `spawn()`. Measured at HZ=100: 7 spawns in 40, against 40 of 40 exact on macOS. Every ownership check failed for those processes, so nothing signalled them. This 1-in-6 is what made the failing set look random between runs of the same commit, and it is what the "interference" story was actually describing.
2. **`readlink /proc/<pid>/fd/<n>` returns EACCES for a sibling's descriptor**, so the inherited sentinel that authenticates an owned process could not be read at all. All three programs collapsed "could not read it" into the same verdict as "it is not there". macOS answers the same question through `lsof` and never reaches this.
3. The first fix for (2) waited before falling back to weaker evidence. The session guard removes the owner records within ~100ms of the broker's death, so waiting meant losing the only record naming the process — and then exiting to report the session clean.

So this PR's claim to have parameterised the platform-variable inputs was incomplete in exactly the places that mattered: the `ps` dialect became one tested fragment, while the process birth time it parses, and the `/proc` vs `lsof` branch beside it, stayed untested — and both were where the failures were.

Fixed in a follow-up, which splits the sentinel probe into a shared fragment returning evidence rather than a verdict, moves the reap decision into a pure fragment, widens the birth window by the second Linux can lose, and adds a watchdog-only integration suite — the existing ones reach the watchdog through a broker whose session guard reaps the tree first, so the watchdog's own decision was never what they tested. It also adds an opt-in decision trace (`TASKCHUTE_OWNER_WATCH_TRACE`); all three defects were found by reading it, and none was found without it.

Still failing, here and on the follow-up: `target exit captures and reaps an unhooked native background group member`. It times out waiting for the session's exit frame rather than for a reap — `sleep 30 &` holds the PTY open and node-pty reports the exit differently on Linux. Unrelated to ownership, still open, and the reason the integration job stays non-blocking.

One note for anyone reproducing this: use `docker run --init`. Without a real init as PID 1 nothing reaps orphaned zombies, so SIGKILLed processes stay visible to `kill(pid, 0)` indefinitely and every reap assertion fails for a reason that does not exist on a runner.
