### PR TITLE
fix(ai-task): reap owned processes on Linux, and test the three places it could not

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,15 +55,48 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     timeout-minutes: 15
-    # Reports without blocking, because these suites are not green on Linux yet
-    # and never have been — this job is the first time they have run there.
+    # Reports without blocking. One case still fails on Linux; the rest were
+    # three defects that only a Linux kernel can produce, now fixed and measured
+    # in a Debian 12 container running the same suites:
     #
-    # The remaining failures are cross-test interference, not a Linux defect in
-    # the broker: the failing set changes between runs of the same commit on the
-    # same machine (observed 1, 3 and 5 failures), and every one of them passes
-    # when run alone. A test that fails to reap its detached children leaves them
-    # behind for whatever runs next. Fixing that means giving each case its own
-    # isolation, which is a change to the suites, not to the broker.
+    #   resilience suite   before: 5 failed   after: 1 failed
+    #   broker suite       before: 1 failed   after: 0 failed
+    #
+    # An earlier version of this comment blamed cross-test interference. That was
+    # wrong, and so was every explanation reached by reading the surviving
+    # processes instead of the watchdog's own decisions. What the three turned
+    # out to be:
+    #
+    #   1. Linux has no wall-clock process start time. It derives one, as boot
+    #      time plus the start in jiffies, both truncated, so `ps` reports the
+    #      second BEFORE the clock reading that bracketed spawn() — 7 times in 40
+    #      at HZ=100, against 40 of 40 exact on macOS. Every ownership check
+    #      failed for those, so nothing was ever signalled. This is the 1-in-6
+    #      that made the failing set look random.
+    #   2. `readlink /proc/<pid>/fd/<n>` returns EACCES for a sibling's
+    #      descriptor, so the sentinel that authenticates an owned process could
+    #      not be read at all. macOS answers the same question through lsof and
+    #      never hit it.
+    #   3. The first fix for (2) waited before falling back to weaker evidence.
+    #      The session guard removes the owner records within ~100ms of the
+    #      broker's death, so waiting meant losing the only record naming the
+    #      process, and exiting to report the session clean.
+    #
+    # Still failing, on this branch and on the commit before it:
+    # `target exit captures and reaps an unhooked native background group
+    # member`. It times out waiting for the session's exit frame, not for a
+    # reap — `sleep 30 &` holds the PTY open and node-pty reports the exit
+    # differently here than on macOS. Unrelated to ownership; not yet fixed.
+    #
+    # Reproducing this locally needs `docker run --init`. Without a real init as
+    # PID 1, nothing reaps orphaned zombies, so SIGKILLed processes stay visible
+    # to kill(pid, 0) forever and every reap assertion fails for a reason that
+    # does not exist on a runner. That artifact cost more time than the bugs did.
+    #
+    # If something fails here again: TASKCHUTE_OWNER_WATCH_TRACE=<path> makes the
+    # watchdog write one line per round naming each pid, the verdict, the
+    # evidence behind it, and what it signalled. Every one of the three above was
+    # found by reading that file and none was found without it.
     #
     # Flip this to a blocking check once a run is green.
     continue-on-error: true

--- a/src/features/ai-task/services/TerminalSessionBrokerSource.ts
+++ b/src/features/ai-task/services/TerminalSessionBrokerSource.ts
@@ -1,6 +1,7 @@
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from './TerminalSessionOwnerWatchdogSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from './TerminalSessionGuardSource'
 import { TERMINAL_BROKER_PURE_SOURCE } from './broker-source/TerminalBrokerPureSource'
+import { OWNER_SENTINEL_PROBE_SOURCE } from './broker-source/OwnerSentinelProbeSource'
 import { POSIX_PROCESS_SNAPSHOT_SOURCE } from './broker-source/PosixProcessSnapshotSource'
 import {
   gzipBase64,
@@ -615,54 +616,7 @@ function readPosixProcessSnapshotAsync(callback) {
     });
   } catch (_) { callback(null); }
 }
-function canonicalSentinelPath(value) {
-  const clean = String(value || '').replace(/ \(deleted\)$/, '');
-  try { return fs.realpathSync(clean); } catch (_) { return clean; }
-}
-function sentinelState(pid, identity) {
-  if (
-    !identity ||
-    !Number.isInteger(identity.sentinelFd) ||
-    !identity.sentinelPath
-  ) return 'unknown';
-  try {
-    let actualPath;
-    if (process.platform === 'linux') {
-      actualPath = fs.readlinkSync(
-        '/proc/' + String(pid) + '/fd/' + String(identity.sentinelFd),
-      );
-    } else if (process.platform === 'darwin') {
-      const output = cp.execFileSync(
-        '/usr/sbin/lsof',
-        [
-          '-a',
-          '-p',
-          String(pid),
-          '-d',
-          String(identity.sentinelFd),
-          '-Fn',
-        ],
-        { encoding: 'utf8', maxBuffer: 16 * 1024, windowsHide: true },
-      );
-      const nameLine = String(output).split('\n')
-        .find(line => line.startsWith('n'));
-      if (!nameLine) return 'mismatch';
-      actualPath = nameLine.slice(1);
-    } else {
-      return 'unknown';
-    }
-    return canonicalSentinelPath(actualPath) ===
-      canonicalSentinelPath(identity.sentinelPath)
-      ? 'match'
-      : 'mismatch';
-  } catch (error) {
-    if (
-      error &&
-      (error.code === 'ENOENT' || error.status === 1)
-    ) return 'mismatch';
-    return 'unknown';
-  }
-}
+${OWNER_SENTINEL_PROBE_SOURCE}
 function pidOwnershipState(pid, identity, snapshot) {
   const liveness = pidLivenessState(pid);
   if (liveness === 'dead') return 'dead';
@@ -729,9 +683,17 @@ function pidOwnershipState(pid, identity, snapshot) {
     ) {
       // The inherited sentinel FD remains stable across reparenting and exec,
       // unlike ppid/argv, and uniquely identifies this session even when a
-      // numeric PID/PGID is reused within the same lstart second.
-      const sentinel = sentinelState(pid, identity);
-      if (sentinel !== 'match') return sentinel;
+      // numeric PID/PGID is reused within the same lstart second. When it
+      // cannot be read at all, ownership falls back to the evidence that is
+      // available rather than staying unproven forever — an unproven owner is
+      // never signalled and never written off, which is how a detached child
+      // outlived the session that started it.
+      const sentinel = probeSentinelState(pid, identity);
+      if (sentinel === 'unreadable' || sentinel === 'unknown') {
+        if (resolveUnprovenSentinel(identity, entry) !== 'match') {
+          return 'mismatch';
+        }
+      } else if (sentinel !== 'match') return sentinel;
     }
     if (
       process.platform !== 'win32' &&

--- a/src/features/ai-task/services/TerminalSessionGuardSource.ts
+++ b/src/features/ai-task/services/TerminalSessionGuardSource.ts
@@ -1,3 +1,4 @@
+import { OWNER_SENTINEL_PROBE_SOURCE } from './broker-source/OwnerSentinelProbeSource'
 import { POSIX_PROCESS_SNAPSHOT_SOURCE } from './broker-source/PosixProcessSnapshotSource'
 
 /**
@@ -317,55 +318,7 @@ function windowsStartedAt(pid) {
   }
 }
 
-function canonicalSentinelPath(value) {
-  const clean = String(value || '').replace(/ \(deleted\)$/, '');
-  try { return fs.realpathSync(clean); } catch (_) { return clean; }
-}
-
-function sentinelState(pid, identity) {
-  if (
-    !identity ||
-    !Number.isInteger(identity.sentinelFd) ||
-    !identity.sentinelPath
-  ) return 'unknown';
-  try {
-    let actualPath;
-    if (process.platform === 'linux') {
-      actualPath = fs.readlinkSync(
-        '/proc/' + String(pid) + '/fd/' + String(identity.sentinelFd),
-      );
-    } else if (process.platform === 'darwin') {
-      const output = cp.execFileSync(
-        '/usr/sbin/lsof',
-        [
-          '-a',
-          '-p',
-          String(pid),
-          '-d',
-          String(identity.sentinelFd),
-          '-Fn',
-        ],
-        { encoding: 'utf8', maxBuffer: 16 * 1024, windowsHide: true },
-      );
-      const nameLine = String(output).split('\n')
-        .find(line => line.startsWith('n'));
-      if (!nameLine) return 'mismatch';
-      actualPath = nameLine.slice(1);
-    } else {
-      return 'unknown';
-    }
-    return canonicalSentinelPath(actualPath) ===
-      canonicalSentinelPath(identity.sentinelPath)
-      ? 'match'
-      : 'mismatch';
-  } catch (error) {
-    if (
-      error &&
-      (error.code === 'ENOENT' || error.status === 1)
-    ) return 'mismatch';
-    return 'unknown';
-  }
-}
+${OWNER_SENTINEL_PROBE_SOURCE}
 
 function ownershipState(pid, identity, snapshot) {
   try { process.kill(pid, 0); }
@@ -398,8 +351,15 @@ function ownershipState(pid, identity, snapshot) {
     posixBirthWindowMatches(actualStart, identity.lower, identity.upper);
   if (!birthMatches) return 'mismatch';
   if (identity.kind === 'process') {
-    const sentinel = sentinelState(pid, identity);
-    if (sentinel !== 'match') return sentinel;
+    // An unreadable descriptor is not a closed one: fall back to the available
+    // evidence instead of leaving the process forever unproven, and therefore
+    // forever neither signalled nor written off.
+    const sentinel = probeSentinelState(pid, identity);
+    if (sentinel === 'unreadable' || sentinel === 'unknown') {
+      if (resolveUnprovenSentinel(identity, posixEntry) !== 'match') {
+        return 'mismatch';
+      }
+    } else if (sentinel !== 'match') return sentinel;
   }
   if (identity.kind === 'snapshot') {
     if (

--- a/src/features/ai-task/services/TerminalSessionOwnerWatchdogSource.ts
+++ b/src/features/ai-task/services/TerminalSessionOwnerWatchdogSource.ts
@@ -1,3 +1,5 @@
+import { OWNER_REAP_PLAN_SOURCE } from './broker-source/OwnerReapPlanSource'
+import { OWNER_SENTINEL_PROBE_SOURCE } from './broker-source/OwnerSentinelProbeSource'
 import { POSIX_PROCESS_SNAPSHOT_SOURCE } from './broker-source/PosixProcessSnapshotSource'
 
 /**
@@ -8,6 +10,12 @@ import { POSIX_PROCESS_SNAPSHOT_SOURCE } from './broker-source/PosixProcessSnaps
  * that pipe in the kernel, so the watchdog can reap detached descendants from
  * the per-session owner records even when both the broker control socket and
  * renderer are unavailable.
+ *
+ * What is left in this file is the I/O: it gathers evidence (owner records, a
+ * ps snapshot, kill(0) liveness, sentinel descriptors), hands it to the pure
+ * planner in OwnerReapPlanSource, and applies the plan it gets back. The
+ * reasoning about ownership lives there, where it can be tested without
+ * crashing a broker on a real OS.
  */
 export const TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE = String.raw`
 'use strict';
@@ -15,16 +23,18 @@ const fs = require('fs');
 const cp = require('child_process');
 const path = require('path');
 ${POSIX_PROCESS_SNAPSHOT_SOURCE}
+${OWNER_SENTINEL_PROBE_SOURCE}
+${OWNER_REAP_PLAN_SOURCE}
 const ownerPrefix = process.env.TASKCHUTE_OWNER_WATCH_PREFIX || '';
 const descriptorPath = process.env.TASKCHUTE_OWNER_WATCH_DESCRIPTOR || '';
 const descriptorToken = process.env.TASKCHUTE_OWNER_WATCH_TOKEN || '';
 const brokerPid = Number(process.env.TASKCHUTE_OWNER_WATCH_BROKER_PID);
 const hookPath = process.env.TASKCHUTE_OWNER_WATCH_HOOK || '';
 const pythonHookDir = process.env.TASKCHUTE_OWNER_WATCH_PYTHON || '';
+const tracePath = process.env.TASKCHUTE_OWNER_WATCH_TRACE || '';
 const forcePsFailure =
   process.env.TASKCHUTE_OWNER_WATCH_TEST_PS_FAILURE === '1';
 const ownerReadLimit = 16 * 1024 * 1024;
-const ownerRecordLimit = 2048;
 let input = '';
 let disarmed = false;
 let finished = false;
@@ -68,94 +78,6 @@ function ownerPaths() {
   };
 }
 
-function applyRecord(active, record, ownerFile) {
-  if (
-    !record ||
-    !Number.isInteger(record.pid) ||
-    record.pid < 1 ||
-    !Number.isFinite(record.startedAt)
-  ) return false;
-  const identity = {
-    lower: Number.isFinite(record.startedAtLower)
-      ? record.startedAtLower
-      : record.startedAt,
-    upper: record.startedAt,
-    kind: record.kind === 'guard'
-      ? (
-        typeof record.guardToken === 'string' &&
-        /^[a-f0-9]{48}$/.test(record.guardToken)
-          ? 'guard'
-          : 'unknown'
-      )
-      : (record.kind === 'unknown' ? 'unknown' : 'process'),
-    guardToken:
-      typeof record.guardToken === 'string' &&
-      /^[a-f0-9]{48}$/.test(record.guardToken)
-        ? record.guardToken
-        : null,
-    parentPid:
-      Number.isInteger(record.parentPid) && record.parentPid > 0
-        ? record.parentPid
-        : null,
-    processGroup:
-      Number.isInteger(record.processGroup) && record.processGroup > 0
-        ? record.processGroup
-        : null,
-    commandHint:
-      typeof record.commandHint === 'string' &&
-      record.commandHint.length > 0 &&
-      record.commandHint.length <= 256
-        ? record.commandHint
-        : null,
-    sentinelFd:
-      Number.isInteger(record.sentinelFd) &&
-      record.sentinelFd >= 3 &&
-      record.sentinelFd <= 4096
-        ? record.sentinelFd
-        : null,
-    sentinelPath:
-      typeof record.sentinelPath === 'string' &&
-      record.sentinelPath === ownerFile
-        ? record.sentinelPath
-        : null,
-  };
-  if (record.active === false) {
-    const current = active.get(record.pid);
-    if (
-      current &&
-      current.lower === identity.lower &&
-      current.upper === identity.upper
-    ) active.delete(record.pid);
-  } else {
-    active.set(record.pid, identity);
-  }
-  return true;
-}
-
-function applyPartialRecord(active, text, ownerFile) {
-  const match = String(text).match(
-    /^\s*\{\s*"pid"\s*:\s*(\d+)\s*,\s*"startedAt"\s*:\s*(\d+)(?:\s*,\s*"startedAtLower"\s*:\s*(\d+))?/,
-  );
-  if (!match) return false;
-  const startedAt = Number(match[2]);
-  // A torn record cannot authenticate its complete process identity.
-  const kind = 'unknown';
-  const applied = applyRecord(active, {
-    pid: Number(match[1]),
-    startedAt,
-    startedAtLower: match[3] === undefined
-      ? startedAt
-      : Number(match[3]),
-    active: !/"active"\s*:\s*false/.test(text),
-    kind,
-    guardToken: (
-      String(text).match(/"guardToken"\s*:\s*"([a-f0-9]{48})"/) ||
-      []
-    )[1],
-  }, ownerFile);
-  return applied && kind !== 'unknown';
-}
-
 function readOwnerFile(target, active) {
   const before = trustedStats(target, 'file');
   if (!before || before.size > ownerReadLimit) return false;
@@ -188,26 +110,11 @@ function readOwnerFile(target, active) {
       after.size !== opened.size ||
       offset !== opened.size
     ) return false;
-    const text = buffer.toString('utf8', 0, offset);
-    const lines = text.split('\n');
-    const tail = lines.pop() || '';
-    let valid = true;
-    for (const line of lines) {
-      if (!line) continue;
-      if (line.length > ownerRecordLimit) {
-        valid = applyPartialRecord(active, line, target) && valid;
-        continue;
-      }
-      try {
-        valid = applyRecord(active, JSON.parse(line), target) && valid;
-      } catch (_) {
-        valid = applyPartialRecord(active, line, target) && valid;
-      }
-    }
-    if (tail) {
-      valid = applyPartialRecord(active, tail, target) && valid;
-    }
-    return valid;
+    return applyOwnerFileText(
+      active,
+      buffer.toString('utf8', 0, offset),
+      target,
+    );
   } catch (_) {
     return false;
   } finally {
@@ -266,119 +173,77 @@ function windowsStartedAt(pid) {
   }
 }
 
-function canonicalSentinelPath(value) {
-  const clean = String(value || '').replace(/ \(deleted\)$/, '');
-  try { return fs.realpathSync(clean); } catch (_) { return clean; }
-}
-
-function sentinelState(pid, identity) {
-  if (
-    !identity ||
-    !Number.isInteger(identity.sentinelFd) ||
-    !identity.sentinelPath
-  ) return 'unknown';
+// One line per reap round, off unless a path is given. A watchdog that will
+// not finish is otherwise silent by construction — it holds no socket and no
+// terminal — and the only evidence left is which processes survived, which is
+// what made the CI failures unattributable.
+function trace(round) {
+  if (!tracePath) return;
   try {
-    let actualPath;
-    if (process.platform === 'linux') {
-      actualPath = fs.readlinkSync(
-        '/proc/' + String(pid) + '/fd/' + String(identity.sentinelFd),
-      );
-    } else if (process.platform === 'darwin') {
-      const output = cp.execFileSync(
-        '/usr/sbin/lsof',
-        [
-          '-a',
-          '-p',
-          String(pid),
-          '-d',
-          String(identity.sentinelFd),
-          '-Fn',
-        ],
-        { encoding: 'utf8', maxBuffer: 16 * 1024, windowsHide: true },
-      );
-      const nameLine = String(output).split('\n')
-        .find(line => line.startsWith('n'));
-      if (!nameLine) return 'mismatch';
-      actualPath = nameLine.slice(1);
-    } else {
-      return 'unknown';
-    }
-    return canonicalSentinelPath(actualPath) ===
-      canonicalSentinelPath(identity.sentinelPath)
-      ? 'match'
-      : 'mismatch';
+    fs.appendFileSync(tracePath, JSON.stringify(round) + '\n');
+  } catch (_) {}
+}
+
+function tracedStates(states, owned) {
+  const rendered = [];
+  for (const [pid, verdict] of states.entries()) {
+    const identity = owned.get(pid);
+    rendered.push({
+      pid,
+      state: verdict.state,
+      reason: verdict.reason,
+      kind: identity ? identity.kind : null,
+      hint: identity ? identity.commandHint : null,
+      fd: identity ? identity.sentinelFd : null,
+    });
+  }
+  return rendered;
+}
+
+function pidLiveness(pid) {
+  try {
+    process.kill(pid, 0);
+    return 'alive';
   } catch (error) {
-    if (
-      error &&
-      (error.code === 'ENOENT' || error.status === 1)
-    ) return 'mismatch';
-    return 'unknown';
+    return error && error.code === 'ESRCH' ? 'dead' : 'unknown';
   }
 }
 
-function ownershipState(pid, identity, snapshot) {
-  let alive = true;
-  try { process.kill(pid, 0); }
-  catch (error) {
-    if (error && error.code === 'ESRCH') alive = false;
-    else return 'unknown';
+// Gathers the evidence the planner asks for, in the two passes it asks for:
+// sentinel descriptors are probed only for the PIDs whose ownership still turns
+// on one.
+function classifyOwned(owned, snapshot) {
+  const entries = Array.from(owned.entries());
+  const liveness = new Map();
+  const windowsBirths = new Map();
+  for (const [pid] of entries) {
+    liveness.set(pid, pidLiveness(pid));
+    if (process.platform === 'win32') {
+      windowsBirths.set(pid, windowsStartedAt(pid));
+    }
   }
-  if (!alive) return 'dead';
-  let actualStart = null;
-  let posixEntry = null;
-  if (process.platform === 'win32') {
-    actualStart = windowsStartedAt(pid);
-  } else {
-    if (!snapshot) return 'unknown';
-    posixEntry = snapshot && snapshot.get(pid);
-    if (!posixEntry) return 'unknown';
-    actualStart = posixEntry.startedAt;
-    if (
-      identity &&
-      identity.kind === 'guard' &&
-      identity.guardToken &&
-      (
-        typeof posixEntry.command !== 'string' ||
-        !posixEntry.command.includes(identity.guardToken)
-      )
-    ) return 'mismatch';
+  const evidence = {
+    platform: process.platform,
+    entries,
+    snapshot,
+    liveness,
+    windowsStartedAt: windowsBirths,
+    sentinel: new Map(),
+  };
+  let planned = classifyOwnedPids(evidence);
+  if (planned.needSentinel.length === 0) return planned.states;
+  for (const pid of planned.needSentinel) {
+    evidence.sentinel.set(pid, probeSentinelState(pid, owned.get(pid)));
   }
-  if (
-    !identity ||
-    !Number.isFinite(identity.lower) ||
-    !Number.isFinite(identity.upper) ||
-    !Number.isFinite(actualStart)
-  ) return 'unknown';
-  if (process.platform === 'win32') {
-    return windowsBirthWindowMatches(actualStart, identity.lower, identity.upper)
-      ? 'match'
-      : 'mismatch';
-  }
-  const birthMatches =
-    posixBirthWindowMatches(actualStart, identity.lower, identity.upper);
-  if (!birthMatches) return 'mismatch';
-  if (identity.kind === 'process') {
-    const sentinel = sentinelState(pid, identity);
-    if (sentinel !== 'match') return sentinel;
-  }
-  if (identity.kind === 'snapshot') {
-    if (
-      !Number.isInteger(identity.processGroup) ||
-      !identity.commandHint ||
-      posixEntry.pgid !== identity.processGroup ||
-      typeof posixEntry.command !== 'string' ||
-      !posixEntry.command.startsWith(identity.commandHint)
-    ) return 'mismatch';
-  }
-  return 'match';
+  return classifyOwnedPids(evidence).states;
 }
 
-function expandOwned(active, snapshot) {
-  const expanded = new Map(active);
+function expandOwned(roots, snapshot) {
+  const expanded = new Map(roots);
   if (!snapshot) return expanded;
   const descendants = posixSnapshotDescendantPids(
     snapshot,
-    Array.from(active.keys()),
+    Array.from(roots.keys()),
   );
   for (const pid of descendants) {
     if (expanded.has(pid)) continue;
@@ -387,8 +252,7 @@ function expandOwned(active, snapshot) {
   return expanded;
 }
 
-function signalOwned(pid, snapshot) {
-  if (pid === process.pid || pid === brokerPid) return;
+function signalOwned(pid, target) {
   if (process.platform === 'win32') {
     try {
       const root = process.env.SystemRoot || process.env.SYSTEMROOT || 'C:\\Windows';
@@ -402,8 +266,7 @@ function signalOwned(pid, snapshot) {
     } catch (_) {}
     return;
   }
-  const entry = snapshot && snapshot.get(pid);
-  if (entry && entry.pgid === pid) {
+  if (target === 'group') {
     try { process.kill(-pid, 'SIGKILL'); return; } catch (_) {}
   }
   try { process.kill(pid, 'SIGKILL'); } catch (_) {}
@@ -441,70 +304,56 @@ function cleanupArtifacts(files) {
   } catch (_) {}
 }
 
-function reapUntilGone(deadline) {
+function reapUntilGone(startedAt) {
+  const elapsed = Math.max(0, Date.now() - startedAt);
   const records = readOwnedRecords();
   const snapshot = readPosixSnapshot();
-  const matchingRoots = new Map();
-  let unknown = false;
-  let sessionGuardAlive = false;
-  for (const [pid, identity] of records.active.entries()) {
-    const state = ownershipState(pid, identity, snapshot);
-    if (
-      identity &&
-      identity.kind === 'unknown' &&
-      state !== 'dead' &&
-      state !== 'mismatch'
-    ) {
-      unknown = true;
-      continue;
-    }
-    if (state === 'match') {
-      if (identity && identity.kind === 'guard') {
-        // The guard owns the only race-free raw ChildProcess reference. Never
-        // kill it from a reusable PID record; broker-pipe EOF tells it to
-        // finish cleanup and exit on its own.
-        sessionGuardAlive = true;
-      } else {
-        matchingRoots.set(pid, identity);
-      }
-    } else if (state === 'unknown') {
-      unknown = true;
-    }
-  }
-  // Never derive ownership from a stale/reused root PID. Only a root whose
-  // own birth identity matches may confer ownership on its current children.
-  const expanded = expandOwned(matchingRoots, snapshot);
+  const rootStates = classifyOwned(records.active, snapshot);
+  const rootPlan = planReapRoots(rootStates, records.active);
+  const expanded = expandOwned(rootPlan.roots, snapshot);
+  // Revalidate against a snapshot taken immediately before signalling.
   const signalSnapshot = readPosixSnapshot();
-  let matching = 0;
-  for (const [pid, identity] of expanded.entries()) {
-    // Revalidate immediately before signalling. This closes the gap between
-    // the initial root classification and process-tree expansion.
-    const state = ownershipState(pid, identity, signalSnapshot);
-    if (state === 'match') {
-      matching += 1;
-      signalOwned(pid, signalSnapshot);
-    } else if (state === 'unknown') {
-      unknown = true;
-    }
+  const signalStates = classifyOwned(expanded, signalSnapshot);
+  const signalPlan = planReapSignals(
+    signalStates,
+    expanded,
+    {
+      snapshot: signalSnapshot,
+      selfPid: process.pid,
+      brokerPid,
+    },
+  );
+  for (const target of signalPlan.kill) {
+    signalOwned(target.pid, target.target);
   }
-  if (
-    matching === 0 &&
-    !unknown &&
-    !sessionGuardAlive &&
-    records.trustworthy
-  ) {
+  const outcome = planReapOutcome({
+    matching: signalPlan.kill.length,
+    unknown: rootPlan.unknown || signalPlan.unknown,
+    sessionGuardAlive: rootPlan.sessionGuardAlive,
+    trustworthy: records.trustworthy,
+  });
+  trace({
+    elapsed,
+    platform: process.platform,
+    snapshot: Boolean(snapshot),
+    trustworthy: records.trustworthy,
+    guard: rootPlan.sessionGuardAlive,
+    roots: tracedStates(rootStates, records.active),
+    signals: tracedStates(signalStates, expanded),
+    kill: signalPlan.kill,
+    outcome,
+  });
+  if (outcome === 'cleanup') {
     cleanupArtifacts(records.files);
     process.exit(0);
     return;
   }
-  // This retry is the watchdog's final live handle after the broker pipe
-  // closes. Keep it referenced until every birth-validated owner is gone.
-  // Transient ps/readdir failures must never turn into "clean" or abandon
-  // the only recovery actor. Permanent corruption intentionally preserves
-  // both this small guard and the owner evidence for manual diagnosis.
-  const elapsed = Math.max(0, Date.now() - deadline);
-  const retryMs = Math.min(1000, 50 + Math.floor(elapsed / 20));
-  global.setTimeout(() => reapUntilGone(deadline), retryMs);
+  // Keep this retry referenced until every birth-validated owner is gone: it is
+  // the last live handle on the session after the broker pipe closes.
+  global.setTimeout(
+    () => reapUntilGone(startedAt),
+    reapRetryDelayMs(elapsed),
+  );
 }
 
 function finishAfterPipeClose() {

--- a/src/features/ai-task/services/broker-source/OwnerReapPlanSource.ts
+++ b/src/features/ai-task/services/broker-source/OwnerReapPlanSource.ts
@@ -1,0 +1,338 @@
+/**
+ * The decision half of the owner watchdog: which recorded PIDs the watchdog
+ * still owns, which of them it must signal, and whether it may stop.
+ *
+ * The watchdog is the last actor alive after a broker crash. It reads the
+ * per-session owner records, proves that each recorded PID is still the process
+ * that was recorded (and not a reused PID), expands the proven roots across the
+ * process tree, and SIGKILLs what it owns. Every one of those steps used to sit
+ * inside one function interleaved with the syscalls that fed it — readdir, ps,
+ * kill(0), readlink, unlink — so the only way to reach any of the reasoning was
+ * to crash a real broker on a real OS and watch what survived. That is why four
+ * integration tests that spawn processes and wait on SIGKILL were the entire
+ * coverage of this logic, and why they failed only on Linux and only in CI.
+ *
+ * Nothing here touches fs, child_process or process. The host program gathers
+ * evidence and applies the plan; this fragment turns one into the other, and a
+ * test can hand it any evidence either platform could produce.
+ *
+ * The shape is deliberately two-phase. `classifyOwnedPids` reports which PIDs
+ * it needs a sentinel reading for instead of reading one, so the caller probes
+ * exactly those and calls again with the answers. That keeps the one
+ * OS-specific syscall out of the reasoning without hiding the dependency.
+ *
+ * The policy the two-phase shape exists to make testable: an owner whose
+ * sentinel cannot be read is resolved from the evidence that is available
+ * rather than left unproven. It is resolved IMMEDIATELY, on the first round.
+ * A grace period was tried and measured to be actively harmful: the session
+ * guard removes the owner records within ~100ms of the broker's death, so a
+ * watchdog that waits loses the only evidence naming the process it has to
+ * reap, and then exits reporting the session clean. Liveness already separates
+ * "on its way out" from "still here" without waiting. The resolution itself
+ * lives with the probe it interprets, in OwnerSentinelProbeSource, because the
+ * broker and the guard reach the same conclusion the same way.
+ *
+ * Comments inside the template below ship inside the program's single argv
+ * string, which Linux caps at 128KB. Rationale belongs up here.
+ *
+ * Spliced into the watchdog only; a composition test asserts it is embedded
+ * verbatim. Every declaration is a `function` for the reason
+ * PosixProcessSnapshotSource gives: these names are spliced beside a program
+ * that declares its own, and a duplicated top-level `const` is a SyntaxError
+ * that kills the program before it can report anything.
+ *
+ * Keep this plain ES2018 — nothing transpiles the contents of this template.
+ */
+export const OWNER_REAP_PLAN_SOURCE =
+  String.raw`function ownerRecordLimitBytes() {
+  return 2048;
+}
+function ownerRecordIdentity(record, ownerFile) {
+  const guardToken =
+    typeof record.guardToken === 'string' &&
+    /^[a-f0-9]{48}$/.test(record.guardToken)
+      ? record.guardToken
+      : null;
+  return {
+    lower: Number.isFinite(record.startedAtLower)
+      ? record.startedAtLower
+      : record.startedAt,
+    upper: record.startedAt,
+    kind: record.kind === 'guard'
+      ? (guardToken ? 'guard' : 'unknown')
+      : (record.kind === 'unknown' ? 'unknown' : 'process'),
+    guardToken: guardToken,
+    parentPid:
+      Number.isInteger(record.parentPid) && record.parentPid > 0
+        ? record.parentPid
+        : null,
+    processGroup:
+      Number.isInteger(record.processGroup) && record.processGroup > 0
+        ? record.processGroup
+        : null,
+    commandHint:
+      typeof record.commandHint === 'string' &&
+      record.commandHint.length > 0 &&
+      record.commandHint.length <= 256
+        ? record.commandHint
+        : null,
+    sentinelFd:
+      Number.isInteger(record.sentinelFd) &&
+      record.sentinelFd >= 3 &&
+      record.sentinelFd <= 4096
+        ? record.sentinelFd
+        : null,
+    sentinelPath:
+      typeof record.sentinelPath === 'string' &&
+      record.sentinelPath === ownerFile
+        ? record.sentinelPath
+        : null,
+  };
+}
+function applyOwnerRecord(active, record, ownerFile) {
+  if (
+    !record ||
+    !Number.isInteger(record.pid) ||
+    record.pid < 1 ||
+    !Number.isFinite(record.startedAt)
+  ) return false;
+  const identity = ownerRecordIdentity(record, ownerFile);
+  if (record.active === false) {
+    const current = active.get(record.pid);
+    if (
+      current &&
+      current.lower === identity.lower &&
+      current.upper === identity.upper
+    ) active.delete(record.pid);
+  } else {
+    active.set(record.pid, identity);
+  }
+  return true;
+}
+function applyPartialOwnerRecord(active, text, ownerFile) {
+  const match = String(text).match(
+    /^\s*\{\s*"pid"\s*:\s*(\d+)\s*,\s*"startedAt"\s*:\s*(\d+)(?:\s*,\s*"startedAtLower"\s*:\s*(\d+))?/,
+  );
+  if (!match) return false;
+  const startedAt = Number(match[2]);
+  // A torn record cannot authenticate its complete process identity.
+  const kind = 'unknown';
+  const applied = applyOwnerRecord(active, {
+    pid: Number(match[1]),
+    startedAt: startedAt,
+    startedAtLower: match[3] === undefined
+      ? startedAt
+      : Number(match[3]),
+    active: !/"active"\s*:\s*false/.test(text),
+    kind: kind,
+    guardToken: (
+      String(text).match(/"guardToken"\s*:\s*"([a-f0-9]{48})"/) ||
+      []
+    )[1],
+  }, ownerFile);
+  return applied && kind !== 'unknown';
+}
+// False when any line failed to authenticate: the session is then not
+// accounted for, because the evidence could not be read.
+function applyOwnerFileText(active, text, ownerFile) {
+  const lines = String(text).split('\n');
+  const tail = lines.pop() || '';
+  let valid = true;
+  for (const line of lines) {
+    if (!line) continue;
+    if (line.length > ownerRecordLimitBytes()) {
+      valid = applyPartialOwnerRecord(active, line, ownerFile) && valid;
+      continue;
+    }
+    let record = null;
+    try {
+      record = JSON.parse(line);
+    } catch (_) {
+      valid = applyPartialOwnerRecord(active, line, ownerFile) && valid;
+      continue;
+    }
+    valid = applyOwnerRecord(active, record, ownerFile) && valid;
+  }
+  if (tail) {
+    valid = applyPartialOwnerRecord(active, tail, ownerFile) && valid;
+  }
+  return valid;
+}
+// 'dead' | 'match' | 'mismatch' | 'unknown' | 'needs-sentinel', with the reason
+// alongside, so a stalled watchdog can name the evidence it is missing.
+function classifyOwnedPid(input) {
+  const identity = input && input.identity;
+  const liveness = input && input.liveness;
+  if (liveness === 'unknown') return { state: 'unknown', reason: 'liveness' };
+  if (liveness !== 'alive') return { state: 'dead', reason: 'exited' };
+  let actualStart = null;
+  let entry = null;
+  if (input.platform === 'win32') {
+    actualStart = input.windowsStartedAt;
+  } else {
+    if (!input.snapshotAvailable) {
+      return { state: 'unknown', reason: 'no-snapshot' };
+    }
+    entry = input.entry || null;
+    // kill(0) already proved the numeric PID exists, so a ps omission is a
+    // gap in the snapshot, never proof of exit.
+    if (!entry) return { state: 'unknown', reason: 'not-in-snapshot' };
+    actualStart = entry.startedAt;
+    if (
+      identity &&
+      identity.kind === 'guard' &&
+      identity.guardToken &&
+      (
+        typeof entry.command !== 'string' ||
+        !entry.command.includes(identity.guardToken)
+      )
+    ) return { state: 'mismatch', reason: 'guard-token' };
+  }
+  if (
+    !identity ||
+    !Number.isFinite(identity.lower) ||
+    !Number.isFinite(identity.upper) ||
+    !Number.isFinite(actualStart)
+  ) return { state: 'unknown', reason: 'no-birth' };
+  if (input.platform === 'win32') {
+    return windowsBirthWindowMatches(actualStart, identity.lower, identity.upper)
+      ? { state: 'match', reason: 'birth' }
+      : { state: 'mismatch', reason: 'birth' };
+  }
+  if (!posixBirthWindowMatches(actualStart, identity.lower, identity.upper)) {
+    return { state: 'mismatch', reason: 'birth' };
+  }
+  if (identity.kind === 'process') {
+    const sentinel = input.sentinel;
+    if (sentinel === undefined) {
+      return { state: 'needs-sentinel', reason: 'sentinel' };
+    }
+    if (sentinel === 'mismatch') {
+      return { state: 'mismatch', reason: 'sentinel' };
+    }
+    if (sentinel !== 'match') {
+      // Resolved on this round: waiting cannot make an unreadable descriptor
+      // readable, and the records this decision is made from do not survive
+      // the wait. An unresolvable record stays unknown, which leaves both the
+      // process and the evidence untouched.
+      const resolved = resolveUnprovenSentinel(identity, entry);
+      return {
+        state: resolved,
+        reason: (sentinel === 'unreadable' ? 'sentinel-unreadable' : 'sentinel-unavailable') +
+          (resolved === 'unknown' ? '' : '-resolved'),
+      };
+    }
+  }
+  if (identity.kind === 'snapshot') {
+    if (
+      !Number.isInteger(identity.processGroup) ||
+      !identity.commandHint ||
+      !entry ||
+      entry.pgid !== identity.processGroup ||
+      typeof entry.command !== 'string' ||
+      !entry.command.startsWith(identity.commandHint)
+    ) return { state: 'mismatch', reason: 'snapshot-identity' };
+  }
+  return { state: 'match', reason: 'verified' };
+}
+// entries: [[pid, identity], ...]. Idempotent: call it, probe what it puts in
+// needSentinel, call it again with those readings in input.sentinel.
+function classifyOwnedPids(input) {
+  const states = new Map();
+  const needSentinel = [];
+  for (const pair of input.entries) {
+    const pid = pair[0];
+    const identity = pair[1];
+    const verdict = classifyOwnedPid({
+      platform: input.platform,
+      identity: identity,
+      liveness: input.liveness.get(pid) || 'unknown',
+      entry: input.snapshot ? input.snapshot.get(pid) : null,
+      snapshotAvailable: Boolean(input.snapshot),
+      windowsStartedAt: input.windowsStartedAt
+        ? input.windowsStartedAt.get(pid)
+        : null,
+      sentinel: input.sentinel ? input.sentinel.get(pid) : undefined,
+    });
+    if (verdict.state === 'needs-sentinel') needSentinel.push(pid);
+    states.set(pid, verdict);
+  }
+  return { states: states, needSentinel: needSentinel };
+}
+// Only a root whose own birth identity matches may confer ownership on its
+// current children, so ownership is never derived from a stale or reused PID.
+function planReapRoots(states, active) {
+  const roots = new Map();
+  let unknown = false;
+  let sessionGuardAlive = false;
+  for (const pair of active.entries()) {
+    const pid = pair[0];
+    const identity = pair[1];
+    const verdict = states.get(pid) || { state: 'unknown', reason: 'unclassified' };
+    if (
+      identity &&
+      identity.kind === 'unknown' &&
+      verdict.state !== 'dead' &&
+      verdict.state !== 'mismatch'
+    ) {
+      unknown = true;
+      continue;
+    }
+    if (verdict.state === 'match') {
+      if (identity && identity.kind === 'guard') {
+        // The guard owns the only race-free raw ChildProcess reference. Never
+        // kill it from a reusable PID record; broker-pipe EOF tells it to
+        // finish cleanup and exit on its own.
+        sessionGuardAlive = true;
+      } else {
+        roots.set(pid, identity);
+      }
+    } else if (verdict.state === 'unknown') {
+      unknown = true;
+    }
+  }
+  return { roots: roots, unknown: unknown, sessionGuardAlive: sessionGuardAlive };
+}
+// Signalling the group reaps a detached child's own descendants, and is only
+// correct for a group leader. Self and the broker are never targets.
+function signalTargetFor(pid, entry, selfPid, brokerPid) {
+  if (pid === selfPid || pid === brokerPid) return 'skip';
+  if (entry && entry.pgid === pid) return 'group';
+  return 'process';
+}
+// states must come from a snapshot taken immediately before signalling: it
+// closes the gap between root classification and the expansion below it.
+function planReapSignals(states, expanded, context) {
+  const kill = [];
+  let unknown = false;
+  for (const pid of expanded.keys()) {
+    const verdict = states.get(pid) || { state: 'unknown', reason: 'unclassified' };
+    if (verdict.state === 'match') {
+      const target = signalTargetFor(
+        pid,
+        context.snapshot ? context.snapshot.get(pid) : null,
+        context.selfPid,
+        context.brokerPid,
+      );
+      if (target !== 'skip') kill.push({ pid: pid, target: target });
+    } else if (verdict.state === 'unknown') {
+      unknown = true;
+    }
+  }
+  return { kill: kill, unknown: unknown };
+}
+// Anything short of proven-and-gone retries: a transient ps/readdir failure
+// must never read as "clean" or abandon the last recovery actor. Permanent
+// corruption preserves this guard and the owner evidence for diagnosis.
+function planReapOutcome(summary) {
+  return (
+    summary.matching === 0 &&
+    !summary.unknown &&
+    !summary.sessionGuardAlive &&
+    summary.trustworthy
+  ) ? 'cleanup' : 'retry';
+}
+function reapRetryDelayMs(elapsedMs) {
+  const elapsed = Math.max(0, Number.isFinite(elapsedMs) ? elapsedMs : 0);
+  return Math.min(1000, 50 + Math.floor(elapsed / 20));
+}`

--- a/src/features/ai-task/services/broker-source/OwnerSentinelProbeSource.ts
+++ b/src/features/ai-task/services/broker-source/OwnerSentinelProbeSource.ts
@@ -1,0 +1,132 @@
+/**
+ * The inherited-sentinel half of the broker, guard and watchdog programs.
+ *
+ * An owned process is recorded together with a file descriptor it inherited at
+ * spawn — a read handle on the session's own owner record. That descriptor
+ * survives reparenting and exec, unlike ppid or argv, so it is what separates
+ * "PID 4242, born in this second, is still our session" from "PID 4242 was
+ * reused within the same lstart second by something unrelated".
+ *
+ * Reading it is the ONLY place where the three programs branch on the host OS:
+ * Linux answers from `/proc/<pid>/fd/<n>`, macOS only through `lsof`. That made
+ * it the one code path a macOS checkout could never execute, and it is where
+ * the CI-only reap failures were traced to. The branch is now a single
+ * function, `readSentinelFdPath`, that returns data instead of a verdict, so
+ * the verdict itself (`sentinelStateFrom`) is reachable from either host and
+ * the OS-specific half is small enough to be checked against the live kernel in
+ * one assertion.
+ *
+ * The distinction that function preserves is the whole point:
+ *
+ * - `missing` — the kernel answered, and the descriptor is not there. Proof
+ *   that this PID is not ours.
+ * - `unreadable` — the probe itself failed (EACCES under a hardened /proc, no
+ *   lsof in the image, an exec failure). Proof of nothing at all.
+ *
+ * Collapsing those two into one "unknown", which is what every copy of this
+ * code did before, is what let a live descendant sit unowned forever: an owner
+ * that cannot be proven is neither signalled nor written off, so the broker
+ * never confirmed its tree was gone and the watchdog retried until the machine
+ * went down, while the process they exist to reap stayed alive.
+ *
+ * `resolveUnprovenSentinel` is where that stops. Waiting cannot improve the
+ * evidence — a /proc that refuses the readlink now will refuse it for the life
+ * of the process — so the corroboration that IS available decides, and it
+ * decides definitively or the retry loops never end. The birth window already
+ * bounds PID reuse to the recorded spawn second; the command hint rules out the
+ * one case the descriptor was there to catch, a same-second reuse of the number
+ * by an unrelated program.
+ *
+ * Comments inside the template below are shipped inside each program's single
+ * argv string, which is capped at 128KB on Linux. Rationale belongs up here.
+ *
+ * Spliced into all three programs verbatim; a composition test asserts they
+ * still contain it byte for byte and have not regrown a private copy. Unlike
+ * PosixProcessSnapshotSource this fragment does touch `fs`, `cp` and
+ * `process` — it is the I/O boundary, not the pure one — so each host program
+ * must have those three names in scope.
+ *
+ * Keep this plain ES2018 — nothing transpiles the contents of this template.
+ */
+export const OWNER_SENTINEL_PROBE_SOURCE =
+  String.raw`function canonicalSentinelPath(value) {
+  const clean = String(value || '').replace(/ \(deleted\)$/, '');
+  try { return fs.realpathSync(clean); } catch (_) { return clean; }
+}
+// Evidence, never a verdict: { path } | 'missing' | 'unsupported' |
+// 'unreadable'. 'missing' is the kernel answering; 'unreadable' is the probe
+// failing, and the two must never collapse into one.
+function readSentinelFdPath(pid, fd) {
+  // A kernel that will not name another process' descriptor cannot be produced
+  // on demand, so the end-to-end reap is testable only by simulating one.
+  if (process.env.TASKCHUTE_OWNER_SENTINEL_TEST_UNREADABLE === '1') {
+    return 'unreadable';
+  }
+  if (process.platform === 'linux') {
+    try {
+      return {
+        path: fs.readlinkSync('/proc/' + String(pid) + '/fd/' + String(fd)),
+      };
+    } catch (error) {
+      // ENOENT: the descriptor (or the process) is gone. EACCES under a
+      // hardened /proc, and anything else, is the probe being unavailable.
+      return error && error.code === 'ENOENT' ? 'missing' : 'unreadable';
+    }
+  }
+  if (process.platform === 'darwin') {
+    try {
+      const output = cp.execFileSync(
+        '/usr/sbin/lsof',
+        ['-a', '-p', String(pid), '-d', String(fd), '-Fn'],
+        { encoding: 'utf8', maxBuffer: 16 * 1024, windowsHide: true },
+      );
+      const nameLine = String(output).split('\n')
+        .find(line => line.startsWith('n'));
+      return nameLine ? { path: nameLine.slice(1) } : 'missing';
+    } catch (error) {
+      // lsof exits 1 when nothing matched. A missing or unrunnable lsof throws
+      // the same shape of error and means the opposite.
+      return error && error.status === 1 ? 'missing' : 'unreadable';
+    }
+  }
+  return 'unsupported';
+}
+function sentinelStateFrom(identity, reading) {
+  if (
+    !identity ||
+    !Number.isInteger(identity.sentinelFd) ||
+    !identity.sentinelPath
+  ) return 'unknown';
+  if (reading === 'missing') return 'mismatch';
+  if (reading === 'unreadable') return 'unreadable';
+  if (!reading || typeof reading.path !== 'string') return 'unknown';
+  return canonicalSentinelPath(reading.path) ===
+    canonicalSentinelPath(identity.sentinelPath)
+    ? 'match'
+    : 'mismatch';
+}
+function probeSentinelState(pid, identity) {
+  if (
+    !identity ||
+    !Number.isInteger(identity.sentinelFd) ||
+    !identity.sentinelPath
+  ) return 'unknown';
+  return sentinelStateFrom(
+    identity,
+    readSentinelFdPath(pid, identity.sentinelFd),
+  );
+}
+// Ownership of a process whose birth window matched but whose sentinel could
+// not be READ — an unavailable probe, or a record that never carried a
+// descriptor. Absence of the probe is not evidence of non-ownership. See the
+// module comment.
+//
+// 'unknown' is a real answer here and must stay one: a record carrying nothing
+// but a PID and a birth second — the ambiguous legacy shape — authorizes
+// neither killing the process nor discarding the record. Corroboration is what
+// upgrades it, and when there is none the evidence is left in place.
+function resolveUnprovenSentinel(identity, entry) {
+  if (!identity || !identity.commandHint) return 'unknown';
+  if (!entry || typeof entry.command !== 'string') return 'unknown';
+  return entry.command.includes(identity.commandHint) ? 'match' : 'mismatch';
+}`

--- a/src/features/ai-task/services/broker-source/PosixProcessSnapshotSource.ts
+++ b/src/features/ai-task/services/broker-source/PosixProcessSnapshotSource.ts
@@ -87,12 +87,28 @@ function posixSnapshotIdentity(entry) {
 function posixBirthFloor(ms) {
   return Math.floor(ms / 1000) * 1000;
 }
+// Linux does not store a process' start time as a wall clock: it derives one,
+// as boot time plus the process' start in jiffies, and BOTH of those are
+// truncated. The second it reports can therefore be the second BEFORE the one
+// the clock showed when spawn() returned. Measured at HZ=100: 7 of 40 spawns
+// came back one second early. macOS keeps a real timeval and was 40 of 40 exact,
+// which is why nothing here ever failed on a developer machine while CI lost
+// roughly one process in six.
+//
+// The error only ever runs backwards — truncation cannot invent time — so only
+// the lower bound is widened.
+function posixBirthSlackMs() {
+  return 1000;
+}
 // The owner record stores the interval surrounding spawn(), so both ends are
 // floored: a paused or slow syscall stays a match without widening the
-// PID-reuse window to several seconds.
+// PID-reuse window to several seconds. The slack below makes that window ~2s on
+// a host that reports an early start; a PID reused inside it is still caught by
+// the identity checks the callers layer on top (the inherited sentinel
+// descriptor, the guard token, the command hint).
 function posixBirthWindowMatches(actualStart, lower, upper) {
   return (
-    actualStart >= posixBirthFloor(lower) &&
+    actualStart >= posixBirthFloor(lower) - posixBirthSlackMs() &&
     actualStart <= posixBirthFloor(upper)
   );
 }

--- a/tests/features/ai-task/broker-source/broker-source-budget.test.ts
+++ b/tests/features/ai-task/broker-source/broker-source-budget.test.ts
@@ -1,3 +1,4 @@
+import { Script } from 'vm'
 import { gunzipSync } from 'zlib'
 
 import {
@@ -26,10 +27,15 @@ const MAX_ARG_STRLEN = 32 * 4096
  * hundred bytes is already broken for the next person who adds a feature, so
  * the budget has to fail while there is still room to land a fix.
  *
- * ~11KB of cushion. Because the guard and watchdog reach the broker compressed,
- * roughly 3KB of growth in either of them costs the broker 1KB, so this covers
- * a substantial feature in any of the three before anyone has to think about
- * the transport again.
+ * Because the guard and watchdog reach the broker compressed, roughly 3KB of
+ * growth in either of them costs the broker 1KB.
+ *
+ * The broker sits ~7KB under this budget and ~18KB under the kernel limit. It
+ * had ~13KB of cushion before the owner-reap logic was split into testable
+ * fragments, which cost ~6KB across the three programs — the shared code is
+ * spliced into each of them, so deduplicating it saves less than it reads like.
+ * Anything approaching this budget again should move text out of the templates
+ * rather than raise it: comments inside them ship inside argv.
  */
 const PROGRAM_BUDGET = 120_000
 
@@ -81,5 +87,19 @@ describe('compressed program transport', () => {
     expect(TERMINAL_BROKER_SOURCE.indexOf(INFLATE_PROGRAM_SOURCE)).toBeLessThan(
       TERMINAL_BROKER_SOURCE.indexOf('inflateProgram('.concat('"')),
     )
+  })
+})
+
+describe('program syntax', () => {
+  test.each([
+    ['broker', TERMINAL_BROKER_SOURCE],
+    ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
+    ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
+  ])('the composed %s program parses', (_name, source) => {
+    // These programs are assembled from spliced fragments, so a name declared
+    // twice or a fragment landing inside a template literal is a SyntaxError
+    // that node reports only at spawn time — with the terminal simply never
+    // appearing and nothing written to any log.
+    expect(() => new Script(source)).not.toThrow()
   })
 })

--- a/tests/features/ai-task/broker-source/owner-reap-plan-source.test.ts
+++ b/tests/features/ai-task/broker-source/owner-reap-plan-source.test.ts
@@ -1,0 +1,549 @@
+import { createContext, runInContext } from 'vm'
+
+import { OWNER_REAP_PLAN_SOURCE } from '../../../../src/features/ai-task/services/broker-source/OwnerReapPlanSource'
+import { OWNER_SENTINEL_PROBE_SOURCE } from '../../../../src/features/ai-task/services/broker-source/OwnerSentinelProbeSource'
+import { POSIX_PROCESS_SNAPSHOT_SOURCE } from '../../../../src/features/ai-task/services/broker-source/PosixProcessSnapshotSource'
+import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
+import { LSTART, LSTART_EPOCH_MS } from './psSnapshots'
+
+/**
+ * The watchdog's reap reasoning, exercised as the pure function it now is.
+ *
+ * Until this existed the only way to reach any of it was to start a broker,
+ * SIGKILL it, and inspect what the OS had left behind twenty seconds later —
+ * four integration tests that spawned real processes, could only run one
+ * platform's branch per checkout, and reported "something survived" without
+ * saying which piece of evidence the watchdog had been unable to obtain.
+ *
+ * Here the evidence is the input.
+ */
+type Identity = {
+  lower: number
+  upper: number
+  kind: string
+  guardToken?: string | null
+  processGroup?: number | null
+  commandHint?: string | null
+  sentinelFd?: number | null
+  sentinelPath?: string | null
+}
+
+type Entry = {
+  ppid: number
+  pgid: number
+  startedAt: number | null
+  command: string
+}
+
+type Verdict = { state: string; reason: string }
+
+const context = createContext({
+  JSON,
+  Map,
+  Set,
+  Date,
+  Math,
+  Number,
+  String,
+  // The fallback the planner reaches for lives with the probe it interprets,
+  // because the broker and the guard need it too. It is spliced beside this
+  // fragment in the shipped program, so it is spliced beside it here.
+  process: { platform: 'linux' },
+  fs: { realpathSync: (value: string) => value },
+  cp: {},
+})
+runInContext(POSIX_PROCESS_SNAPSHOT_SOURCE, context)
+runInContext(OWNER_SENTINEL_PROBE_SOURCE, context)
+runInContext(OWNER_REAP_PLAN_SOURCE, context)
+
+const plan = context as unknown as {
+  applyOwnerFileText: (
+    active: Map<number, Identity>,
+    text: string,
+    ownerFile: string,
+  ) => boolean
+  classifyOwnedPid: (input: Record<string, unknown>) => Verdict
+  classifyOwnedPids: (input: Record<string, unknown>) => {
+    states: Map<number, Verdict>
+    needSentinel: number[]
+  }
+  planReapRoots: (
+    states: Map<number, Verdict>,
+    active: Map<number, Identity>,
+  ) => { roots: Map<number, Identity>; unknown: boolean; sessionGuardAlive: boolean }
+  planReapSignals: (
+    states: Map<number, Verdict>,
+    expanded: Map<number, Identity | null>,
+    context: {
+      snapshot: Map<number, Entry> | null
+      selfPid: number
+      brokerPid: number
+    },
+  ) => { kill: { pid: number; target: string }[]; unknown: boolean }
+  planReapOutcome: (summary: {
+    matching: number
+    unknown: boolean
+    sessionGuardAlive: boolean
+    trustworthy: boolean
+  }) => string
+  reapRetryDelayMs: (elapsedMs: number) => number
+  resolveUnprovenSentinel: (
+    identity: Identity | null,
+    entry: Entry | null,
+  ) => string
+  signalTargetFor: (
+    pid: number,
+    entry: Entry | null,
+    selfPid: number,
+    brokerPid: number,
+  ) => string
+}
+
+const OWNER_FILE = '/tmp/taskchute/owner-session-abc.jsonl'
+const GUARD_TOKEN = 'a'.repeat(48)
+
+const entryOf = (overrides: Partial<Entry> = {}): Entry => ({
+  ppid: 1,
+  pgid: 4242,
+  startedAt: LSTART_EPOCH_MS,
+  command: '/usr/bin/yes',
+  ...overrides,
+})
+
+const identityOf = (overrides: Partial<Identity> = {}): Identity => ({
+  lower: LSTART_EPOCH_MS,
+  upper: LSTART_EPOCH_MS + 40,
+  kind: 'process',
+  guardToken: null,
+  processGroup: 4242,
+  commandHint: 'yes',
+  sentinelFd: 9,
+  sentinelPath: OWNER_FILE,
+  ...overrides,
+})
+
+const classify = (overrides: Record<string, unknown> = {}): Verdict =>
+  plan.classifyOwnedPid({
+    platform: 'linux',
+    identity: identityOf(),
+    liveness: 'alive',
+    entry: entryOf(),
+    snapshotAvailable: true,
+    windowsStartedAt: null,
+    sentinel: 'match',
+    ...overrides,
+  })
+
+describe('reap plan fragment composition', () => {
+  test('the shipped watchdog program embeds the fragment verbatim', () => {
+    expect(TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE).toContain(
+      OWNER_REAP_PLAN_SOURCE,
+    )
+  })
+
+  test('the fragment reaches no host facility, so it can be reasoned about alone', () => {
+    // Comments stripped first: they discuss processes, ps and /proc in prose,
+    // and the claim being made here is about the code.
+    const code = OWNER_REAP_PLAN_SOURCE.replace(/^\s*\/\/.*$/gmu, '')
+
+    expect(code).not.toMatch(/\b(?:require|__dirname|globalThis)\b/u)
+    expect(code).not.toMatch(/\b(?:process|cp|fs|net)\s*\./u)
+  })
+
+  // `toContain` alone would still pass if the watchdog grew a second, private
+  // copy beside the shared one, which is how the ownership checks drifted into
+  // three subtly different versions before.
+  test('the watchdog keeps no private copy of the reasoning', () => {
+    const outsideFragment = TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE.replace(
+      OWNER_REAP_PLAN_SOURCE,
+      '',
+    )
+
+    expect(outsideFragment).not.toMatch(
+      /function\s+(?:ownershipState|applyRecord|applyPartialRecord)\b/u,
+    )
+  })
+})
+
+describe('applyOwnerFileText', () => {
+  test('keeps the last state of every recorded pid', () => {
+    const active = new Map<number, Identity>()
+
+    const valid = plan.applyOwnerFileText(
+      active,
+      [
+        JSON.stringify({ pid: 11, startedAt: 1000, kind: 'process' }),
+        JSON.stringify({ pid: 12, startedAt: 2000, kind: 'process' }),
+        JSON.stringify({ pid: 11, startedAt: 1000, active: false }),
+        '',
+      ].join('\n'),
+      OWNER_FILE,
+    )
+
+    expect(valid).toBe(true)
+    expect(Array.from(active.keys())).toEqual([12])
+  })
+
+  test('a close record for a different birth never retires the live pid', () => {
+    // PID reuse: the same number, recorded again after the first exited.
+    const active = new Map<number, Identity>()
+
+    plan.applyOwnerFileText(
+      active,
+      [
+        JSON.stringify({ pid: 11, startedAt: 2000, kind: 'process' }),
+        JSON.stringify({ pid: 11, startedAt: 1000, active: false }),
+        '',
+      ].join('\n'),
+      OWNER_FILE,
+    )
+
+    expect(active.get(11)?.upper).toBe(2000)
+  })
+
+  test('a torn trailing record is honoured but never trusted', () => {
+    const active = new Map<number, Identity>()
+
+    // An append cut mid-line by the crash the watchdog is reacting to.
+    const valid = plan.applyOwnerFileText(
+      active,
+      '{"pid":13,"startedAt":1000,"startedAtLower":9',
+      OWNER_FILE,
+    )
+
+    expect(valid).toBe(false)
+    expect(active.get(13)?.kind).toBe('unknown')
+  })
+
+  test('a sentinel path naming another session is dropped', () => {
+    const active = new Map<number, Identity>()
+
+    plan.applyOwnerFileText(
+      active,
+      `${JSON.stringify({
+        pid: 14,
+        startedAt: 1000,
+        kind: 'process',
+        sentinelFd: 9,
+        sentinelPath: '/tmp/taskchute/owner-session-other.jsonl',
+      })}\n`,
+      OWNER_FILE,
+    )
+
+    expect(active.get(14)?.sentinelPath).toBeNull()
+  })
+
+  test('a guard record without a well-formed token cannot claim to be a guard', () => {
+    const active = new Map<number, Identity>()
+
+    plan.applyOwnerFileText(
+      active,
+      `${JSON.stringify({ pid: 15, startedAt: 1000, kind: 'guard' })}\n`,
+      OWNER_FILE,
+    )
+
+    expect(active.get(15)?.kind).toBe('unknown')
+  })
+})
+
+describe('classifyOwnedPid', () => {
+  test('an exited pid is dead', () => {
+    expect(classify({ liveness: 'dead' }).state).toBe('dead')
+  })
+
+  test('a kill(0) that failed for any other reason proves nothing', () => {
+    expect(classify({ liveness: 'unknown' })).toEqual({
+      state: 'unknown',
+      reason: 'liveness',
+    })
+  })
+
+  test.each([
+    ['the ps snapshot could not be taken', { snapshotAvailable: false, entry: null }, 'no-snapshot'],
+    ['the pid is missing from an otherwise good snapshot', { entry: null }, 'not-in-snapshot'],
+  ])('%s is unknown, never proof of exit', (_name, overrides, reason) => {
+    expect(classify(overrides)).toEqual({ state: 'unknown', reason })
+  })
+
+  test('a pid born outside the recorded window is someone else', () => {
+    expect(
+      classify({ entry: entryOf({ startedAt: LSTART_EPOCH_MS + 60_000 }) }),
+    ).toEqual({ state: 'mismatch', reason: 'birth' })
+  })
+
+  test('a matching pid whose sentinel confirms it is owned', () => {
+    expect(classify()).toEqual({ state: 'match', reason: 'verified' })
+  })
+
+  test('a sentinel the kernel says is absent disowns the pid', () => {
+    expect(classify({ sentinel: 'mismatch' })).toEqual({
+      state: 'mismatch',
+      reason: 'sentinel',
+    })
+  })
+
+  test('the sentinel is requested rather than assumed', () => {
+    expect(classify({ sentinel: undefined }).state).toBe('needs-sentinel')
+  })
+
+  test('a guard whose command no longer carries its token is a reused pid', () => {
+    expect(
+      classify({
+        identity: identityOf({ kind: 'guard', guardToken: GUARD_TOKEN }),
+      }),
+    ).toEqual({ state: 'mismatch', reason: 'guard-token' })
+  })
+
+  test('a guard is verified without a sentinel of its own', () => {
+    expect(
+      classify({
+        identity: identityOf({ kind: 'guard', guardToken: GUARD_TOKEN }),
+        entry: entryOf({ command: `node -e x ${GUARD_TOKEN}` }),
+        sentinel: undefined,
+      }),
+    ).toEqual({ state: 'match', reason: 'verified' })
+  })
+
+  test.each([
+    ['a foreign process group', { processGroup: 99 }],
+    ['a command that does not start with the hint', { commandHint: 'sleep' }],
+  ])('a tree-snapshot entry with %s is not owned', (_name, overrides) => {
+    expect(
+      classify({
+        identity: identityOf({ kind: 'snapshot', ...overrides }),
+        entry: entryOf({ command: 'yes' }),
+        sentinel: undefined,
+      }),
+    ).toEqual({ state: 'mismatch', reason: 'snapshot-identity' })
+  })
+
+  test('windows decides on its birth time alone', () => {
+    expect(
+      classify({
+        platform: 'win32',
+        entry: null,
+        snapshotAvailable: false,
+        windowsStartedAt: LSTART_EPOCH_MS + 10,
+        sentinel: undefined,
+      }),
+    ).toEqual({ state: 'match', reason: 'birth' })
+  })
+})
+
+/**
+ * The regression these tests exist for, and the reason there is no grace period.
+ *
+ * On Linux the watchdog cannot read a sibling's descriptor at all: measured in a
+ * container, `readlink /proc/<pid>/fd/<n>` returns EACCES. Every such owner used
+ * to classify as unproven, and an unproven owner is neither signalled nor
+ * written off — so the process stayed alive and the session was never declared
+ * clean. A grace period was then tried, and made it worse: the session guard
+ * removes the owner records within ~100ms of the broker's death, so by the time
+ * the grace expired the watchdog no longer had a record naming the process, and
+ * it exited reporting success. The decision has to be made on the first round.
+ */
+describe('an unprovable sentinel', () => {
+  const unreadable = (overrides: Record<string, unknown> = {}): Verdict =>
+    classify({ sentinel: 'unreadable', ...overrides })
+
+  test('is resolved on the first round, not waited out', () => {
+    expect(unreadable()).toEqual({
+      state: 'match',
+      reason: 'sentinel-unreadable-resolved',
+    })
+  })
+
+  test('names which of the two ways the descriptor was unavailable', () => {
+    expect(unreadable({ sentinel: 'unknown' }).reason).toBe(
+      'sentinel-unavailable-resolved',
+    )
+  })
+
+  test('is disowned when the command contradicts the record', () => {
+    // Same PID, born inside the same lstart second, running something else:
+    // the only case the descriptor was there to catch.
+    expect(
+      unreadable({ entry: entryOf({ command: '/usr/bin/tail -f /dev/null' }) }),
+    ).toEqual({ state: 'mismatch', reason: 'sentinel-unreadable-resolved' })
+  })
+
+  test('stays unknown when the record carries nothing to corroborate', () => {
+    // Neither killed nor written off: an owner record that is only a PID and a
+    // birth second is what a reused PID matches too, so both the process and
+    // the evidence are left alone.
+    expect(
+      classify({
+        sentinel: 'unreadable',
+        identity: identityOf({ commandHint: null }),
+      }),
+    ).toEqual({ state: 'unknown', reason: 'sentinel-unreadable' })
+  })
+})
+
+describe('classifyOwnedPids', () => {
+  test('asks for a sentinel reading only where ownership still turns on one', () => {
+    const first = plan.classifyOwnedPids({
+      platform: 'linux',
+      entries: [
+        [10, identityOf()],
+        [11, identityOf({ kind: 'guard', guardToken: GUARD_TOKEN })],
+        [12, identityOf()],
+      ],
+      snapshot: new Map<number, Entry>([
+        [10, entryOf()],
+        [11, entryOf({ command: `node ${GUARD_TOKEN}` })],
+      ]),
+      liveness: new Map([[10, 'alive'], [11, 'alive'], [12, 'dead']]),
+      windowsStartedAt: new Map(),
+      sentinel: new Map(),
+      elapsedMs: 0,
+    })
+
+    expect(first.needSentinel).toEqual([10])
+
+    const second = plan.classifyOwnedPids({
+      platform: 'linux',
+      entries: [[10, identityOf()]],
+      snapshot: new Map<number, Entry>([[10, entryOf()]]),
+      liveness: new Map([[10, 'alive']]),
+      windowsStartedAt: new Map(),
+      sentinel: new Map([[10, 'match']]),
+      elapsedMs: 0,
+    })
+
+    expect(second.needSentinel).toEqual([])
+    expect(second.states.get(10)?.state).toBe('match')
+  })
+})
+
+describe('planReapRoots', () => {
+  const verdict = (state: string): Verdict => ({ state, reason: 'test' })
+
+  test('only a verified root confers ownership on its children', () => {
+    const active = new Map<number, Identity>([
+      [10, identityOf()],
+      [11, identityOf()],
+    ])
+    const states = new Map([[10, verdict('match')], [11, verdict('mismatch')]])
+
+    expect(Array.from(plan.planReapRoots(states, active).roots.keys())).toEqual([
+      10,
+    ])
+  })
+
+  test('the session guard is never signalled from a reusable pid record', () => {
+    const active = new Map<number, Identity>([
+      [10, identityOf({ kind: 'guard', guardToken: GUARD_TOKEN })],
+    ])
+    const result = plan.planReapRoots(new Map([[10, verdict('match')]]), active)
+
+    expect(result.roots.size).toBe(0)
+    expect(result.sessionGuardAlive).toBe(true)
+  })
+
+  test('a live record that could not be authenticated blocks the clean exit', () => {
+    const active = new Map<number, Identity>([[10, identityOf()]])
+
+    expect(
+      plan.planReapRoots(new Map([[10, verdict('unknown')]]), active).unknown,
+    ).toBe(true)
+  })
+
+  test('a torn record is neither killed nor forgotten while it may be alive', () => {
+    const active = new Map<number, Identity>([
+      [10, identityOf({ kind: 'unknown' })],
+    ])
+    const result = plan.planReapRoots(new Map([[10, verdict('match')]]), active)
+
+    expect(result.roots.size).toBe(0)
+    expect(result.unknown).toBe(true)
+  })
+
+  test('a torn record whose pid is gone stops blocking', () => {
+    const active = new Map<number, Identity>([
+      [10, identityOf({ kind: 'unknown' })],
+    ])
+
+    expect(
+      plan.planReapRoots(new Map([[10, verdict('dead')]]), active).unknown,
+    ).toBe(false)
+  })
+})
+
+describe('planReapSignals', () => {
+  const snapshot = new Map<number, Entry>([
+    [10, entryOf({ pgid: 10 })],
+    [11, entryOf({ pgid: 10 })],
+  ])
+
+  test('signals a group leader by group and a follower by pid', () => {
+    const states = new Map([
+      [10, { state: 'match', reason: 'test' }],
+      [11, { state: 'match', reason: 'test' }],
+    ])
+    const expanded = new Map<number, Identity | null>([[10, null], [11, null]])
+
+    expect(
+      plan.planReapSignals(states, expanded, {
+        snapshot,
+        selfPid: 900,
+        brokerPid: 901,
+      }).kill,
+    ).toEqual([
+      { pid: 10, target: 'group' },
+      { pid: 11, target: 'process' },
+    ])
+  })
+
+  test.each([
+    ['itself', 900],
+    ['the broker it reports for', 901],
+  ])('never signals %s', (_name, pid) => {
+    expect(plan.signalTargetFor(pid, entryOf({ pgid: pid }), 900, 901)).toBe(
+      'skip',
+    )
+  })
+})
+
+describe('planReapOutcome', () => {
+  const summary = (overrides = {}) => ({
+    matching: 0,
+    unknown: false,
+    sessionGuardAlive: false,
+    trustworthy: true,
+    ...overrides,
+  })
+
+  test('cleans up only once nothing owned is left and every record was read', () => {
+    expect(plan.planReapOutcome(summary())).toBe('cleanup')
+  })
+
+  test.each([
+    ['something was just signalled', { matching: 1 }],
+    ['an owner could not be authenticated', { unknown: true }],
+    ['the guard is still finishing its own cleanup', { sessionGuardAlive: true }],
+    ['a record could not be read', { trustworthy: false }],
+  ])('retries while %s', (_name, overrides) => {
+    expect(plan.planReapOutcome(summary(overrides))).toBe('retry')
+  })
+})
+
+describe('reapRetryDelayMs', () => {
+  test('polls quickly at first and backs off to a second', () => {
+    expect([0, 1_000, 600_000].map(plan.reapRetryDelayMs)).toEqual([
+      50, 100, 1_000,
+    ])
+  })
+
+  test('tolerates a clock that ran backwards', () => {
+    expect(plan.reapRetryDelayMs(-5_000)).toBe(50)
+  })
+})
+
+describe('lstart fixture agreement', () => {
+  test('the birth window is compared against the seconds ps reports', () => {
+    // Guards the fixture itself: LSTART must parse, or every table above would
+    // be comparing NaN and passing for the wrong reason.
+    expect(Number.isFinite(Date.parse(LSTART))).toBe(true)
+  })
+})

--- a/tests/features/ai-task/broker-source/owner-sentinel-probe-source.test.ts
+++ b/tests/features/ai-task/broker-source/owner-sentinel-probe-source.test.ts
@@ -1,0 +1,395 @@
+import { execFileSync } from 'child_process'
+import { closeSync, mkdtempSync, openSync, realpathSync, symlinkSync, writeFileSync } from 'fs'
+import * as fs from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createContext, runInContext } from 'vm'
+
+import { OWNER_SENTINEL_PROBE_SOURCE } from '../../../../src/features/ai-task/services/broker-source/OwnerSentinelProbeSource'
+import { TERMINAL_BROKER_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { TERMINAL_SESSION_GUARD_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionGuardSource'
+import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
+
+/**
+ * The one place the three programs branch on the host OS.
+ *
+ * Two kinds of test live here, and the split is the point:
+ *
+ * - Branch tests run against a fabricated `process`, `fs` and `cp`, so the
+ *   Linux `/proc` branch is exercised from a macOS checkout and the macOS
+ *   `lsof` branch from a Linux runner. Neither was reachable before.
+ * - One conformance test per platform runs the real branch against the live
+ *   kernel, using this very test process as the subject. It is the only OS-level
+ *   claim being made — "a descriptor this process holds can be named" — and it
+ *   needs no spawn, no signal and no waiting.
+ */
+type Reading = { path: string } | string
+
+type Identity = {
+  sentinelFd: number | null
+  sentinelPath: string | null
+}
+
+type Probe = {
+  canonicalSentinelPath: (value: string) => string
+  probeSentinelState: (pid: number, identity: Identity | null) => string
+  readSentinelFdPath: (pid: number, fd: number) => Reading
+  resolveUnprovenSentinel: (
+    identity: (Identity & { commandHint?: string | null }) | null,
+    entry: { command?: unknown } | null,
+  ) => string
+  sentinelStateFrom: (identity: Identity | null, reading: Reading) => string
+}
+
+const errorWith = (fields: Record<string, unknown>): Error =>
+  Object.assign(new Error('probe failed'), fields)
+
+const probeFor = (
+  platform: string,
+  overrides: { fs?: Record<string, unknown>; cp?: Record<string, unknown> } = {},
+): Probe => {
+  const context = createContext({
+    Number,
+    String,
+    process: { platform, env: {} },
+    fs: { realpathSync: (value: string) => value, ...overrides.fs },
+    cp: { ...overrides.cp },
+  })
+  runInContext(OWNER_SENTINEL_PROBE_SOURCE, context)
+  return context as unknown as Probe
+}
+
+const hostProbe = (): Probe => {
+  const context = createContext({ Number, String, process, fs, cp: { execFileSync } })
+  runInContext(OWNER_SENTINEL_PROBE_SOURCE, context)
+  return context as unknown as Probe
+}
+
+const identityOf = (path: string): Identity => ({
+  sentinelFd: 9,
+  sentinelPath: path,
+})
+
+const PROGRAMS = [
+  ['broker', TERMINAL_BROKER_SOURCE],
+  ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
+  ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
+] as const
+
+describe('sentinel probe fragment composition', () => {
+  test.each(PROGRAMS)(
+    'the shipped %s program embeds the fragment verbatim',
+    (_name, source) => {
+      expect(source).toContain(OWNER_SENTINEL_PROBE_SOURCE)
+    },
+  )
+
+  test.each(PROGRAMS)('%s keeps no private copy of the probe', (_name, source) => {
+    const outsideFragment = source.replace(OWNER_SENTINEL_PROBE_SOURCE, '')
+
+    expect(outsideFragment).not.toMatch(
+      /function\s+(?:canonicalSentinelPath|sentinelState)\b/u,
+    )
+    // The /proc path and the lsof argv are the branch itself. A second one
+    // anywhere is a copy that will not be fixed when this one is.
+    expect(outsideFragment).not.toContain("'/proc/'")
+    expect(outsideFragment).not.toContain('/usr/sbin/lsof')
+  })
+
+  // Every program that authenticates a process by its descriptor has to have
+  // somewhere to go when the descriptor cannot be read. A program that splices
+  // the probe but never reaches the fallback is the bug this fragment exists to
+  // remove, and it is invisible from the fragment's own tests.
+  test.each(PROGRAMS)('%s resolves an unreadable descriptor', (_name, source) => {
+    const outsideFragment = source.replace(OWNER_SENTINEL_PROBE_SOURCE, '')
+
+    expect(outsideFragment).toContain('resolveUnprovenSentinel(')
+    expect(outsideFragment).toContain('probeSentinelState(')
+  })
+})
+
+describe('readSentinelFdPath on linux', () => {
+  test('names the descriptor from /proc', () => {
+    const readlinkSync = jest.fn().mockReturnValue('/tmp/owner.jsonl')
+
+    expect(probeFor('linux', { fs: { readlinkSync } }).readSentinelFdPath(42, 9)).toEqual(
+      { path: '/tmp/owner.jsonl' },
+    )
+    expect(readlinkSync).toHaveBeenCalledWith('/proc/42/fd/9')
+  })
+
+  test('reads ENOENT as the kernel answering that the descriptor is gone', () => {
+    const readlinkSync = () => {
+      throw errorWith({ code: 'ENOENT' })
+    }
+
+    expect(probeFor('linux', { fs: { readlinkSync } }).readSentinelFdPath(42, 9)).toBe(
+      'missing',
+    )
+  })
+
+  // The failure this whole refactor was chasing: a /proc that will not answer
+  // is not a descriptor that is gone.
+  test.each([['EACCES'], ['EPERM'], [undefined]])(
+    'reads %s as the probe being unavailable',
+    (code) => {
+      const readlinkSync = () => {
+        throw errorWith({ code })
+      }
+
+      expect(
+        probeFor('linux', { fs: { readlinkSync } }).readSentinelFdPath(42, 9),
+      ).toBe('unreadable')
+    },
+  )
+})
+
+describe('readSentinelFdPath on darwin', () => {
+  const lsofReturning = (output: string): jest.Mock => jest.fn().mockReturnValue(output)
+
+  test('names the descriptor from the lsof name field', () => {
+    const execFile = lsofReturning('p4242\nf9\nn/tmp/owner.jsonl\n')
+
+    expect(
+      probeFor('darwin', { cp: { execFileSync: execFile } }).readSentinelFdPath(42, 9),
+    ).toEqual({ path: '/tmp/owner.jsonl' })
+    expect(execFile).toHaveBeenCalledWith(
+      '/usr/sbin/lsof',
+      ['-a', '-p', '42', '-d', '9', '-Fn'],
+      expect.objectContaining({ encoding: 'utf8' }),
+    )
+  })
+
+  test('reads output without a name field as no such descriptor', () => {
+    expect(
+      probeFor('darwin', {
+        cp: { execFileSync: lsofReturning('p4242\nf9\n') },
+      }).readSentinelFdPath(42, 9),
+    ).toBe('missing')
+  })
+
+  test('reads exit status 1 as lsof answering that nothing matched', () => {
+    const execFileSync = () => {
+      throw errorWith({ status: 1 })
+    }
+
+    expect(
+      probeFor('darwin', { cp: { execFileSync } }).readSentinelFdPath(42, 9),
+    ).toBe('missing')
+  })
+
+  test('reads a missing lsof as the probe being unavailable, not as an answer', () => {
+    const execFileSync = () => {
+      throw errorWith({ code: 'ENOENT' })
+    }
+
+    expect(
+      probeFor('darwin', { cp: { execFileSync } }).readSentinelFdPath(42, 9),
+    ).toBe('unreadable')
+  })
+})
+
+describe('readSentinelFdPath under the test override', () => {
+  test('reports the probe unavailable on any platform', () => {
+    const context = createContext({
+      Number,
+      String,
+      process: {
+        platform: 'linux',
+        env: { TASKCHUTE_OWNER_SENTINEL_TEST_UNREADABLE: '1' },
+      },
+      fs: { readlinkSync: () => '/tmp/owner.jsonl' },
+      cp: {},
+    })
+    runInContext(OWNER_SENTINEL_PROBE_SOURCE, context)
+
+    expect((context as unknown as Probe).readSentinelFdPath(42, 9)).toBe(
+      'unreadable',
+    )
+  })
+})
+
+describe('readSentinelFdPath elsewhere', () => {
+  test.each([['win32'], ['freebsd']])('has no probe on %s', (platform) => {
+    expect(probeFor(platform).readSentinelFdPath(42, 9)).toBe('unsupported')
+  })
+})
+
+describe('sentinelStateFrom', () => {
+  const probe = probeFor('linux')
+
+  test.each([
+    ['the same path', { path: '/tmp/owner.jsonl' }, 'match'],
+    ['another session\'s path', { path: '/tmp/other.jsonl' }, 'mismatch'],
+    ['no such descriptor', 'missing', 'mismatch'],
+    ['an unavailable probe', 'unreadable', 'unreadable'],
+    ['a platform without a probe', 'unsupported', 'unknown'],
+  ])('reads %s as %s', (_name, reading, expected) => {
+    expect(
+      probe.sentinelStateFrom(identityOf('/tmp/owner.jsonl'), reading as Reading),
+    ).toBe(expected)
+  })
+
+  test('a deleted descriptor still names the file it was opened on', () => {
+    // Linux appends " (deleted)" once the path is unlinked, which happens as
+    // soon as another actor cleans the session up underneath the watchdog.
+    expect(
+      probe.sentinelStateFrom(identityOf('/tmp/owner.jsonl'), {
+        path: '/tmp/owner.jsonl (deleted)',
+      }),
+    ).toBe('match')
+  })
+
+  test.each([
+    ['no descriptor was recorded', { sentinelFd: null, sentinelPath: '/tmp/owner.jsonl' }],
+    ['no path was recorded', { sentinelFd: 9, sentinelPath: null }],
+    ['there is no identity at all', null],
+  ])('cannot judge when %s', (_name, identity) => {
+    expect(
+      probe.sentinelStateFrom(identity as Identity | null, { path: '/tmp/owner.jsonl' }),
+    ).toBe('unknown')
+  })
+
+  test('resolves both sides before comparing them', () => {
+    // /tmp is a symlink to /private/tmp on macOS: the recorded path and the
+    // one the kernel reports are then the same file under two names.
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), 'sentinel-')))
+    const linked = join(directory, 'link')
+    const file = join(directory, 'owner.jsonl')
+    writeFileSync(file, '')
+    symlinkSync(directory, linked)
+    const real = hostProbe()
+
+    expect(
+      real.sentinelStateFrom(identityOf(file), { path: join(linked, 'owner.jsonl') }),
+    ).toBe('match')
+  })
+})
+
+describe('probeSentinelState', () => {
+  const unreadableProbe = probeFor('linux', {
+    fs: {
+      readlinkSync: () => {
+        throw errorWith({ code: 'EACCES' })
+      },
+    },
+  })
+
+  test('reports an unavailable probe as such, rather than as an absent descriptor', () => {
+    expect(
+      unreadableProbe.probeSentinelState(42, identityOf('/tmp/owner.jsonl')),
+    ).toBe('unreadable')
+  })
+
+  test('never probes a record that carries no descriptor', () => {
+    const readlinkSync = jest.fn()
+
+    expect(
+      probeFor('linux', { fs: { readlinkSync } }).probeSentinelState(42, {
+        sentinelFd: null,
+        sentinelPath: null,
+      }),
+    ).toBe('unknown')
+    expect(readlinkSync).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * What all three programs do when the descriptor cannot be read.
+ *
+ * Every one of them used to answer "unproven", which meant the process was
+ * neither signalled nor written off: the broker never confirmed its tree was
+ * gone, and the watchdog retried forever, while the detached child they exist
+ * to reap stayed alive. On Linux that is the normal case, not an exotic one —
+ * `readlink /proc/<pid>/fd/<n>` returns EACCES for a sibling's descriptor.
+ *
+ * Absence of the probe is not evidence of non-ownership. What replaces it is
+ * the corroboration the record already carries — and where it carries none,
+ * "unknown" stays the answer, because guessing in that direction is what would
+ * kill an unrelated process.
+ */
+describe('resolveUnprovenSentinel', () => {
+  const probe = probeFor('linux')
+  const withHint = { sentinelFd: 9, sentinelPath: '/tmp/owner.jsonl', commandHint: 'yes' }
+
+  test('keeps a process whose command still matches the record', () => {
+    expect(probe.resolveUnprovenSentinel(withHint, { command: '/usr/bin/yes' })).toBe(
+      'match',
+    )
+  })
+
+  test('disowns a pid now running something else', () => {
+    // The same number, reused inside the recorded lstart second: the one case
+    // the descriptor was there to catch.
+    expect(probe.resolveUnprovenSentinel(withHint, { command: '/usr/bin/tail' })).toBe(
+      'mismatch',
+    )
+  })
+
+  /**
+   * The invariant a fallback must not break. A record carrying nothing but a
+   * PID and a birth second — the ambiguous legacy shape — authorizes neither
+   * killing the process nor discarding the record: that pair is exactly what a
+   * reused PID also matches. Corroboration is what upgrades it, and where there
+   * is none, "unknown" is the answer, and the evidence is left in place for
+   * whoever looks next.
+   */
+  test.each([
+    ['no command hint was recorded', { sentinelFd: 9, sentinelPath: '/x' }, { command: 'yes' }],
+    ['the process is absent from the snapshot', withHint, null],
+    ['ps rendered no command for it', withHint, { command: undefined }],
+    ['there is no identity at all', null, { command: 'yes' }],
+  ])('refuses to decide when %s', (_name, identity, entry) => {
+    expect(
+      probe.resolveUnprovenSentinel(
+        identity as Identity & { commandHint?: string | null },
+        entry as { command?: unknown } | null,
+      ),
+    ).toBe('unknown')
+  })
+})
+
+/**
+ * The live-kernel half. Everything above proves the branch does what the OS is
+ * documented to do; this proves the OS still does it.
+ */
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe
+
+describeOnPosix('conformance with the running kernel', () => {
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), 'sentinel-host-')))
+  const file = join(directory, 'owner-session-host.jsonl')
+  let fd = -1
+
+  beforeAll(() => {
+    writeFileSync(file, '')
+    fd = openSync(file, 'r')
+  })
+
+  afterAll(() => {
+    if (fd >= 0) closeSync(fd)
+  })
+
+  test('a descriptor this process holds is named back', () => {
+    const reading = hostProbe().readSentinelFdPath(process.pid, fd)
+
+    expect(typeof reading === 'object' ? reading.path : reading).toBe(file)
+  })
+
+  test('the descriptor is recognised as this session, from the record alone', () => {
+    expect(
+      hostProbe().probeSentinelState(process.pid, {
+        sentinelFd: fd,
+        sentinelPath: file,
+      }),
+    ).toBe('match')
+  })
+
+  test('a descriptor this process does not hold is reported absent', () => {
+    // Well above anything Jest opens, and closed by definition.
+    expect(hostProbe().readSentinelFdPath(process.pid, 4000)).toBe('missing')
+  })
+
+  test('a pid that does not exist is reported absent', () => {
+    expect(hostProbe().readSentinelFdPath(0x7ffffffe, fd)).toBe('missing')
+  })
+})

--- a/tests/features/ai-task/broker-source/posix-process-snapshot-source.test.ts
+++ b/tests/features/ai-task/broker-source/posix-process-snapshot-source.test.ts
@@ -44,6 +44,7 @@ runInContext(POSIX_PROCESS_SNAPSHOT_SOURCE, context)
 const posix = context as unknown as {
   parsePosixProcessSnapshot: (output: string) => Map<number, SnapshotEntry>
   posixBirthFloor: (ms: number) => number
+  posixBirthSlackMs: () => number
   posixBirthWindowMatches: (
     actualStart: number,
     lower: number,
@@ -268,9 +269,33 @@ describe('birth windows', () => {
     expect(posix.posixBirthWindowMatches(second, second + 120, second + 880)).toBe(true)
   })
 
-  test('rejects the neighbouring seconds', () => {
-    expect(posix.posixBirthWindowMatches(second - 1000, second, second + 500)).toBe(false)
+  /**
+   * The failure that took four integration tests down on Linux and nowhere
+   * else, and that no amount of test isolation would have touched.
+   *
+   * Linux has no wall-clock start time to report: it derives one, as boot time
+   * plus the process' start in jiffies, and both are truncated. The second it
+   * reports is therefore sometimes the second BEFORE the clock reading that
+   * bracketed spawn(). Measured in a container at HZ=100, 7 of 40 spawns came
+   * back one second early — while macOS, which keeps a real timeval, was exact
+   * 40 times out of 40. A process reported early failed every ownership check,
+   * so it was never signalled, which is what left orphans behind on CI runs
+   * that passed locally.
+   */
+  test('accepts the second below, which Linux reports for a process born in this one', () => {
+    expect(posix.posixBirthWindowMatches(second - 1000, second, second + 500)).toBe(true)
+  })
+
+  test('rejects the second above, which truncation cannot produce', () => {
     expect(posix.posixBirthWindowMatches(second + 1000, second, second + 500)).toBe(false)
+  })
+
+  test('rejects a birth further below than truncation can explain', () => {
+    expect(posix.posixBirthWindowMatches(second - 2000, second, second + 500)).toBe(false)
+  })
+
+  test('spends exactly the one second the truncation can lose', () => {
+    expect(posix.posixBirthSlackMs()).toBe(1_000)
   })
 
   test('accepts a zero-width window', () => {

--- a/tests/features/ai-task/owner-watchdog.integration.test.ts
+++ b/tests/features/ai-task/owner-watchdog.integration.test.ts
@@ -1,0 +1,297 @@
+import { execFileSync, spawn } from 'child_process'
+import type { ChildProcess } from 'child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
+import {
+  BROKER_TEST_TIMEOUT_MS,
+  isAlive,
+  waitUntil,
+  waitUntilAllGone,
+} from './brokerTestUtils'
+
+/**
+ * The owner watchdog on its own, with no broker and no session guard.
+ *
+ * Every existing test of this program reaches it through a broker that is then
+ * SIGKILLed, which means the guard is alive and racing it: on a healthy host the
+ * guard reaps the tree first and the watchdog's own decision is never the thing
+ * under test. That is why a watchdog that had stopped reaping entirely still
+ * showed up as four intermittent, platform-specific timeouts somewhere else.
+ *
+ * Here the watchdog is the only actor. It gets a hand-written owner record, a
+ * real detached child holding a real sentinel descriptor, and an EOF on stdin —
+ * which is exactly what a broker crash looks like from inside it.
+ */
+jest.setTimeout(BROKER_TEST_TIMEOUT_MS * 2)
+
+type Session = {
+  childPid: number
+  descriptorPath: string
+  directory: string
+  ownerFile: string
+  prefix: string
+}
+
+const BROKER_PID_STANDIN = 999_999_999
+
+const started: ChildProcess[] = []
+
+const spawnDetached = (script: string): ChildProcess => {
+  const child = spawn('/bin/sh', ['-c', script], {
+    detached: true,
+    stdio: 'ignore',
+  })
+  child.unref()
+  started.push(child)
+  return child
+}
+
+/**
+ * A child that holds the owner record open on fd 9 — the same descriptor the
+ * broker's spawn hook installs, and the thing the watchdog authenticates it by.
+ */
+const startSession = (name: string): Session => {
+  const directory = mkdtempSync(join(tmpdir(), `owner-watchdog-${name}-`))
+  const prefix = join(directory, 'owner-session')
+  const ownerFile = `${prefix}-${name}.jsonl`
+  const descriptorPath = join(directory, 'descriptor.json')
+  writeFileSync(ownerFile, '', { mode: 0o600 })
+  writeFileSync(
+    descriptorPath,
+    JSON.stringify({ pid: BROKER_PID_STANDIN, token: 'watchdog-test-token' }),
+    { mode: 0o600 },
+  )
+  const startedAtLower = Date.now()
+  const child = spawnDetached(
+    `exec 9<${JSON.stringify(ownerFile)}; while :; do sleep 10; done`,
+  )
+  const startedAt = Date.now()
+  if (child.pid === undefined) throw new Error('Detached child was not started')
+  writeFileSync(
+    ownerFile,
+    `${JSON.stringify({
+      pid: child.pid,
+      startedAt,
+      startedAtLower,
+      active: true,
+      kind: 'process',
+      parentPid: process.pid,
+      processGroup: child.pid,
+      commandHint: 'sh',
+      sentinelFd: 9,
+      sentinelPath: ownerFile,
+    })}\n`,
+    { mode: 0o600 },
+  )
+  return { childPid: child.pid, descriptorPath, directory, ownerFile, prefix }
+}
+
+/** The pids `ps` reports in `pgid`'s process group. */
+const groupMembers = (pgid: number): number[] =>
+  execFileSync('/bin/ps', ['-axo', 'pid=,pgid='], { encoding: 'utf8' })
+    .split('\n')
+    .map((line) => /^\s*(\d+)\s+(\d+)\s*$/u.exec(line))
+    .filter((match): match is RegExpExecArray => match !== null)
+    .filter((match) => Number(match[2]) === pgid)
+    .map((match) => Number(match[1]))
+
+/** Starts the watchdog and closes its stdin, which is what a crash looks like. */
+const crashInto = (
+  session: Session,
+  env: NodeJS.ProcessEnv = {},
+): ChildProcess => {
+  const watchdog = spawn(
+    process.execPath,
+    ['-e', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
+    {
+      detached: true,
+      stdio: ['pipe', 'pipe', 'inherit'],
+      env: {
+        ...process.env,
+        TASKCHUTE_OWNER_WATCH_PREFIX: session.prefix,
+        TASKCHUTE_OWNER_WATCH_DESCRIPTOR: session.descriptorPath,
+        TASKCHUTE_OWNER_WATCH_TOKEN: 'watchdog-test-token',
+        TASKCHUTE_OWNER_WATCH_BROKER_PID: String(BROKER_PID_STANDIN),
+        ...env,
+      },
+    },
+  )
+  started.push(watchdog)
+  watchdog.stdin?.end()
+  return watchdog
+}
+
+const exitOf = (watchdog: ChildProcess): Promise<number | null> =>
+  new Promise((resolve) => watchdog.once('exit', (code) => resolve(code)))
+
+afterEach(() => {
+  for (const child of started) {
+    if (child.pid === undefined) continue
+    try {
+      process.kill(-child.pid, 'SIGKILL')
+    } catch {
+      try {
+        process.kill(child.pid, 'SIGKILL')
+      } catch {
+        // Already reaped, which is what most of these tests assert.
+      }
+    }
+  }
+  started.length = 0
+})
+
+describe('the owner watchdog after a broker crash', () => {
+  test('reaps the recorded child and clears the session artifacts', async () => {
+    const session = startSession('plain')
+    const watchdog = crashInto(session)
+
+    await waitUntilAllGone([session.childPid])
+    expect(await exitOf(watchdog)).toBe(0)
+    expect(existsSync(session.ownerFile)).toBe(false)
+    expect(existsSync(session.descriptorPath)).toBe(false)
+    rmSync(session.directory, { recursive: true, force: true })
+  })
+
+  /**
+   * The CI-only failure the reap path was rebuilt for.
+   *
+   * Where the sentinel descriptor cannot be read — a /proc that refuses the
+   * readlink, an image without lsof — the watchdog used to classify this child
+   * as unproven forever: it signalled nothing and declared nothing clean, so it
+   * retried until the machine went down while the child stayed alive and its
+   * owner record stayed on disk. Both halves of that are asserted here, and the
+   * override makes the probe answer the way that host does, so this now runs on
+   * any platform rather than being discovered by a runner.
+   */
+  test('reaps it even where the sentinel descriptor cannot be read', async () => {
+    const session = startSession('blind')
+    const watchdog = crashInto(session, {
+      TASKCHUTE_OWNER_SENTINEL_TEST_UNREADABLE: '1',
+    })
+
+    await waitUntilAllGone([session.childPid])
+    expect(await exitOf(watchdog)).toBe(0)
+    expect(existsSync(session.ownerFile)).toBe(false)
+    rmSync(session.directory, { recursive: true, force: true })
+  })
+
+  test('reaps the recorded child together with its descendants', async () => {
+    const session = startSession('tree')
+    // The record names one pid. Everything below it in the same process group
+    // has to go with it, which is what the group signal is for. The assertion
+    // is on the group rather than on pids captured beforehand: the child spawns
+    // a fresh `sleep` every few seconds, and in a container PID numbers are
+    // recycled fast enough that a captured one can come back as something else.
+    await waitUntil(
+      () => groupMembers(session.childPid).length > 1,
+      'the recorded child has a descendant in its group',
+    )
+
+    const watchdog = crashInto(session)
+
+    await waitUntilAllGone([session.childPid])
+    expect(await exitOf(watchdog)).toBe(0)
+    expect(groupMembers(session.childPid)).toEqual([])
+    rmSync(session.directory, { recursive: true, force: true })
+  })
+
+  test('leaves a pid whose birth time contradicts the record alone', async () => {
+    const session = startSession('reused')
+    // The same PID number, recorded as having been born a day ago: what a
+    // watchdog reading a stale record sees after the number is reused.
+    const record = JSON.parse(
+      readFileSync(session.ownerFile, 'utf8').trim(),
+    ) as Record<string, unknown>
+    writeFileSync(
+      session.ownerFile,
+      `${JSON.stringify({
+        ...record,
+        startedAt: Date.now() - 86_400_000,
+        startedAtLower: Date.now() - 86_400_000 - 100,
+      })}\n`,
+      { mode: 0o600 },
+    )
+    const watchdog = crashInto(session)
+
+    expect(await exitOf(watchdog)).toBe(0)
+    expect(isAlive(session.childPid)).toBe(true)
+    rmSync(session.directory, { recursive: true, force: true })
+  })
+
+  test('a disarmed watchdog reaps nothing', async () => {
+    const session = startSession('disarm')
+    const watchdog = spawn(
+      process.execPath,
+      ['-e', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
+      {
+        detached: true,
+        stdio: ['pipe', 'pipe', 'inherit'],
+        env: {
+          ...process.env,
+          TASKCHUTE_OWNER_WATCH_PREFIX: session.prefix,
+          TASKCHUTE_OWNER_WATCH_DESCRIPTOR: session.descriptorPath,
+          TASKCHUTE_OWNER_WATCH_TOKEN: 'watchdog-test-token',
+          TASKCHUTE_OWNER_WATCH_BROKER_PID: String(BROKER_PID_STANDIN),
+        },
+      },
+    )
+    started.push(watchdog)
+    watchdog.stdin?.write('DISARM\n')
+    watchdog.stdin?.end()
+
+    expect(await exitOf(watchdog)).toBe(0)
+    expect(isAlive(session.childPid)).toBe(true)
+    expect(existsSync(session.ownerFile)).toBe(true)
+    rmSync(session.directory, { recursive: true, force: true })
+  })
+
+  test('writes the evidence behind each round when a trace is asked for', async () => {
+    const session = startSession('trace')
+    const tracePath = join(session.directory, 'trace.jsonl')
+    const watchdog = crashInto(session, {
+      TASKCHUTE_OWNER_WATCH_TRACE: tracePath,
+    })
+
+    await waitUntilAllGone([session.childPid])
+    await exitOf(watchdog)
+    await waitUntil(() => existsSync(tracePath), 'the trace was written')
+    const rounds = readFileSync(tracePath, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as {
+        kill: { pid: number; target: string }[]
+        outcome: string
+        roots: {
+          hint: string | null
+          kind: string | null
+          pid: number
+          reason: string
+          state: string
+        }[]
+      })
+
+    // The question a stalled watchdog has to be able to answer: which pid, in
+    // what state, on what evidence.
+    expect(rounds[0]?.roots).toContainEqual(
+      expect.objectContaining({
+        pid: session.childPid,
+        state: 'match',
+        reason: 'verified',
+        // The identity the verdict was reached from, not just the verdict: a
+        // record that cannot be corroborated is the difference between a reap
+        // and a stall, and it is invisible from the surviving processes.
+        kind: 'process',
+        hint: 'sh',
+      }),
+    )
+    expect(rounds[0]?.kill).toContainEqual({
+      pid: session.childPid,
+      target: 'group',
+    })
+    expect(rounds[rounds.length - 1]?.outcome).toBe('cleanup')
+    rmSync(session.directory, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## What

Three Linux-only defects in the terminal broker's process ownership, and the testing seams that make each of them reachable from a macOS checkout.

Reproduced and measured in a Debian 12 container running the same suites (`docker run --init`, node 20, non-root):

| suite | before | after |
|---|---:|---:|
| `terminal-session-broker-resilience` (46) | 5 failed | **1 failed** |
| `terminal-session-broker` (30) | 1 failed | **0 failed** |
| `owner-watchdog` (6, new) | — | **6 passed** |
| macOS, whole suite | 3147 passed | 3147 passed |

Three consecutive Linux runs of the resilience suite produced the same single failure each time. The intermittency is gone.

## Why

### 1. Linux has no wall-clock process start time

It derives one, as boot time plus the process' start in jiffies, and both are truncated — so the second `ps` reports can be the second *before* the clock reading that bracketed `spawn()`. Measured at HZ=100: **7 spawns in 40** came back one second early, against **40 of 40 exact on macOS**.

The owner record brackets `spawn()` in milliseconds and the comparison floors both ends, so a process reported early fell outside its own birth window, failed every ownership check, and was never signalled — while its record was never retired either. Roughly one process in six. This is what made the failing set change between runs of the same commit, and what no developer machine could reproduce.

The lower bound now allows the one second truncation can lose. The upper bound is unchanged: truncation cannot invent time.

### 2. `readlink /proc/<pid>/fd/<n>` returns EACCES for a sibling's descriptor

The inherited sentinel FD is what authenticates an owned process — it survives reparenting and exec, unlike ppid or argv. On Linux the watchdog cannot read one it did not open itself. All three programs collapsed "the probe failed" into the same verdict as "the kernel says there is no such descriptor", and an owner that cannot be proven is neither signalled nor written off. macOS answers the same question through `lsof` and never reaches this.

The probe now returns evidence rather than a verdict, and `missing` (the kernel answering) stays distinct from `unreadable` (the probe being unavailable). Where the descriptor cannot be read, the fallback uses the corroboration the record already carries. Where it carries none — a record that is only a PID and a birth second, which is what a reused PID matches too — the answer stays `unknown` and both the process and the evidence are left alone.

### 3. A grace period before that fallback made it worse

Tried first, and measured: the session guard removes the owner records within ~100ms of the broker's death, so waiting lost the only record naming the process, and the watchdog then exited reporting the session clean. The fallback is applied on the first round.

## Testing seams

- **The sentinel probe** — the one place the three programs branch on the host OS — is one fragment now, taking its evidence back as data. Branch tests run against a fabricated `process`/`fs`/`cp`, so the Linux `/proc` branch runs from a macOS checkout and the macOS `lsof` branch from a Linux runner. One conformance test per platform checks the real branch against the live kernel, using the test process itself as the subject: no spawn, no signal, no waiting.
- **The watchdog's reap decision** — record parsing, classification, tree expansion, signal target, retry-or-stop — moves into a pure fragment that touches no `fs`, no `child_process` and no `process`. It asks for sentinel readings instead of taking them, so the one OS-specific syscall stays out of the reasoning without being hidden.
- **A watchdog-only integration suite.** Every existing test reaches the watchdog through a broker that is then SIGKILLed, which leaves the session guard alive and racing — on a healthy host the guard reaps the tree first, so the watchdog's own decision was never what they tested. This one gives it a hand-written record, a real detached child, and an EOF on stdin. Six cases in ~7s; 4 of them failed on Linux before this branch.
- **A decision trace.** `TASKCHUTE_OWNER_WATCH_TRACE=<path>` makes the watchdog write one line per round naming each pid, its verdict, the evidence behind it, and what it signalled. A watchdog that will not finish is otherwise silent by construction — it holds no socket and no terminal. All three defects were found by reading that file; none was found without it.
- Composition tests assert both new fragments are spliced byte for byte into every program that uses them, that none has regrown a private copy, and that each one actually reaches the fallback rather than splicing the probe and ignoring it.

## Still failing

`target exit captures and reaps an unhooked native background group member`, on this branch and on `main`. It times out waiting for the session's exit frame, **not** for a reap: `sleep 30 &` holds the PTY open and node-pty reports the exit differently here than on macOS. Unrelated to ownership, not addressed here, and the reason the integration job stays non-blocking.

`a non-force stop preserves the target SIGTERM grace period` also failed on `main` in the container and passes on this branch, but it is timing-dependent and was already listed as a known issue in #133 — treat that one as unproven either way.

## Corrections to #133

That PR's `test.yml` comment explained these failures as cross-test interference, fixable by isolating the suites. That was wrong, and its body has been amended. Its claim to have parameterised the platform-variable inputs was also incomplete in the two places that mattered: the `ps` dialect became one tested fragment, while the birth time that parser produces, and the `/proc` vs `lsof` branch beside it, stayed untested — and both were where the failures were.

## Reproducing

Use `docker run --init`. Without a real init as PID 1 nothing reaps orphaned zombies, so SIGKILLed processes stay visible to `kill(pid, 0)` indefinitely and every reap assertion fails for a reason that does not exist on a runner. That artifact cost more time than the defects did, and the earlier measurements taken without it were false.

## Verification

| | |
|---|---|
| lint / typecheck | clean (one pre-existing warning) |
| macOS, whole suite | 221 suites / 3147 cases |
| Linux container, resilience | 45/46, three runs, same case each time |
| Linux container, broker suite | 30/30 |
| broker program | 112,835 bytes (budget 120,000, kernel limit 131,072) |
