### PR TITLE
fix(ai-task): capture a group member Linux reported a second too early

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,17 +55,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     timeout-minutes: 15
-    # Reports without blocking. One case still fails on Linux; the rest were
-    # three defects that only a Linux kernel can produce, now fixed and measured
-    # in a Debian 12 container running the same suites:
+    # Reports without blocking, until a run here is green. Four defects that
+    # only a Linux kernel can produce have been fixed and measured in a Debian
+    # 12 container running the same suites:
     #
-    #   resilience suite   before: 5 failed   after: 1 failed
+    #   resilience suite   before: 5 failed   after: 0 failed
     #   broker suite       before: 1 failed   after: 0 failed
     #
     # An earlier version of this comment blamed cross-test interference. That was
     # wrong, and so was every explanation reached by reading the surviving
-    # processes instead of the watchdog's own decisions. What the three turned
-    # out to be:
+    # processes instead of what the broker and watchdog actually decided. What
+    # the four turned out to be:
     #
     #   1. Linux has no wall-clock process start time. It derives one, as boot
     #      time plus the start in jiffies, both truncated, so `ps` reports the
@@ -82,11 +82,14 @@ jobs:
     #      broker's death, so waiting meant losing the only record naming the
     #      process, and exiting to report the session clean.
     #
-    # Still failing, on this branch and on the commit before it:
-    # `target exit captures and reaps an unhooked native background group
-    # member`. It times out waiting for the session's exit frame, not for a
-    # reap — `sleep 30 &` holds the PTY open and node-pty reports the exit
-    # differently here than on macOS. Unrelated to ownership; not yet fixed.
+    #   4. The same truncation as (1), in a second spelling the shared fix did
+    #      not reach: the guard skipped any process in the target's group whose
+    #      reported start was below `posixBirthFloor(sessionStart)`. A
+    #      background process reported one second early was never captured and
+    #      never signalled, so it held the PTY open and the session's exit was
+    #      never emitted — the run looked hung rather than finished. Both
+    #      comparisons now go through the shared helpers, and a composition test
+    #      rejects a third spelling.
     #
     # Reproducing this locally needs `docker run --init`. Without a real init as
     # PID 1, nothing reaps orphaned zombies, so SIGKILLed processes stay visible
@@ -95,8 +98,8 @@ jobs:
     #
     # If something fails here again: TASKCHUTE_OWNER_WATCH_TRACE=<path> makes the
     # watchdog write one line per round naming each pid, the verdict, the
-    # evidence behind it, and what it signalled. Every one of the three above was
-    # found by reading that file and none was found without it.
+    # evidence behind it, and what it signalled. Every one of the four above was
+    # found by tracing a decision; none was found by reading survivors.
     #
     # Flip this to a blocking check once a run is green.
     continue-on-error: true

--- a/src/features/ai-task/services/TerminalSessionGuardSource.ts
+++ b/src/features/ai-task/services/TerminalSessionGuardSource.ts
@@ -251,8 +251,7 @@ function captureOriginalGroupMembers(snapshot) {
     if (
       pid === target.pid ||
       entry.pgid !== target.pid ||
-      !Number.isFinite(entry.startedAt) ||
-      entry.startedAt < posixBirthFloor(targetStartedAtLower)
+      !posixBirthAtOrAfter(entry.startedAt, targetStartedAtLower)
     ) continue;
     found += 1;
     const existing = captured.get(pid);

--- a/src/features/ai-task/services/broker-source/PosixProcessSnapshotSource.ts
+++ b/src/features/ai-task/services/broker-source/PosixProcessSnapshotSource.ts
@@ -100,10 +100,21 @@ function posixBirthFloor(ms) {
 function posixBirthSlackMs() {
   return 1000;
 }
+// The one-sided form, for a caller that has a lower bound and no upper one.
+// Kept here so that comparison cannot be open-coded against posixBirthFloor
+// again: that spelling skips the slack, and a process the kernel reported one
+// second early then falls outside a window it belongs to. It is how an unhooked
+// background process survived its own session.
+function posixBirthAtOrAfter(actualStart, lower) {
+  return (
+    Number.isFinite(actualStart) &&
+    actualStart >= posixBirthFloor(lower) - posixBirthSlackMs()
+  );
+}
 // The owner record stores the interval surrounding spawn(), so both ends are
 // floored: a paused or slow syscall stays a match without widening the
-// PID-reuse window to several seconds. The slack below makes that window ~2s on
-// a host that reports an early start; a PID reused inside it is still caught by
+// PID-reuse window to several seconds. The slack makes that window ~2s on a
+// host that reports an early start; a PID reused inside it is still caught by
 // the identity checks the callers layer on top (the inherited sentinel
 // descriptor, the guard token, the command hint).
 function posixBirthWindowMatches(actualStart, lower, upper) {

--- a/tests/features/ai-task/broker-source/posix-process-snapshot-source.test.ts
+++ b/tests/features/ai-task/broker-source/posix-process-snapshot-source.test.ts
@@ -44,6 +44,7 @@ runInContext(POSIX_PROCESS_SNAPSHOT_SOURCE, context)
 const posix = context as unknown as {
   parsePosixProcessSnapshot: (output: string) => Map<number, SnapshotEntry>
   posixBirthFloor: (ms: number) => number
+  posixBirthAtOrAfter: (actualStart: number, lower: number) => boolean
   posixBirthSlackMs: () => number
   posixBirthWindowMatches: (
     actualStart: number,
@@ -112,6 +113,11 @@ describe('posix snapshot fragment composition', () => {
     expect(
       outsideFragment.match(/Math\.floor\([^)]*\/\s*1000\)\s*\*\s*1000/gu) ?? [],
     ).toEqual([])
+    // posixBirthFloor on its own is not enough: compared directly it drops the
+    // slack the floor exists to be paired with. Every comparison goes through
+    // posixBirthWindowMatches or posixBirthAtOrAfter.
+    expect(outsideFragment).not.toMatch(/[<>]=?\s*posixBirthFloor\(/u)
+    expect(outsideFragment).not.toMatch(/posixBirthFloor\([^)]*\)\s*[<>]/u)
   })
 })
 
@@ -296,6 +302,31 @@ describe('birth windows', () => {
 
   test('spends exactly the one second the truncation can lose', () => {
     expect(posix.posixBirthSlackMs()).toBe(1_000)
+  })
+
+  /**
+   * The same rule for a caller that has only a lower bound — the session
+   * guard, deciding whether a process in the target's group is young enough to
+   * belong to this session. It was open-coded as `startedAt <
+   * posixBirthFloor(lower)`, which skips the slack, so a background process the
+   * kernel reported one second early was never captured and never signalled:
+   * the session then waited for a PTY that process was holding open. Same
+   * defect as above, a second spelling of it.
+   */
+  test('accepts a member the kernel reported a second before its session', () => {
+    expect(posix.posixBirthAtOrAfter(second - 1000, second)).toBe(true)
+  })
+
+  test('accepts a member started later than its session', () => {
+    expect(posix.posixBirthAtOrAfter(second + 5_000, second)).toBe(true)
+  })
+
+  test('rejects a member older than truncation can explain', () => {
+    expect(posix.posixBirthAtOrAfter(second - 2000, second)).toBe(false)
+  })
+
+  test('rejects an unusable birth time instead of accepting everything', () => {
+    expect(posix.posixBirthAtOrAfter(Number.NaN, second)).toBe(false)
   })
 
   test('accepts a zero-width window', () => {


### PR DESCRIPTION
## What

The last Linux integration failure, and it is the same defect as #134's first one wearing a different spelling.

| suite (Debian 12 container, `docker run --init`) | before | after |
|---|---:|---:|
| `terminal-session-broker-resilience` (46) | 1 failed | **0 failed** |
| `terminal-session-broker` (30) | 0 failed | 0 failed |
| `owner-watchdog` (6) | 0 failed | 0 failed |
| the failing case, run alone | ~1 in 3 fails | **8 of 8 pass** |
| macOS, whole suite | 3151 passed | 3151 passed |

## Why

When the target exits, the session guard captures every process left in the target's **process group**. That is how a background job started with `&` gets reaped: no language hook can see it, so the group is the only thing tying it to the session. The eligibility test was open-coded:

```js
entry.startedAt < posixBirthFloor(targetStartedAtLower)   // skip: older than this session
```

Linux derives a process' start time as boot time plus its start in jiffies, both truncated, so `ps` can report the second *before* the clock reading that bracketed the spawn — 7 times in 40 at HZ=100 (#134). A background process reported early therefore looks **older than the session that started it**, is skipped as someone else's, and is never signalled.

#134 spent that second inside `posixBirthWindowMatches`. This comparison has a lower bound and no upper one, so it never went through it.

### What it looks like from outside

This is not a leaked process — it is a session that never reports finishing:

```
client-start        +0ms
guard-target-exit   +85ms      ← the guard sees the exit immediately and captures
client-marker       +85ms
  ... nothing ...
finish              +15,121ms  ← only because the test gave up and killed the process itself
client-onExit       +15,246ms
```

The guard did everything right at 85ms. The exit frame never came because the stream it drains was still held open by the one process nobody had captured. **For a user on Linux, an AI run that leaves a background process behind looks like it is still running long after it finished.**

## The fix

- `posixBirthAtOrAfter(actualStart, lower)` joins `posixBirthWindowMatches` in the shared fragment, spending the same second.
- The guard uses it.
- The composition test now rejects `posixBirthFloor` in a bare comparison, in any of the three programs, so a third spelling cannot appear. That check is the actual point of this PR — the arithmetic was right in one place and wrong in another for as long as both existed.

## How it was found

`/loop`-free, but not guess-free: the first three explanations I reached were wrong (cross-test interference, then node-pty's exit reporting, then a failed capture). Each was discarded by a timestamped trace of what the broker and guard actually decided, rather than by reading which processes survived. The timeline above is that trace.

## Verification

| | |
|---|---|
| lint / typecheck | clean (one pre-existing warning) |
| macOS, whole suite | 221 suites / 3151 cases |
| Linux container | all three integration suites green, resilience run twice |
| failing case, alone | 8 of 8 |

The integration job stays `continue-on-error` in this PR. If its run here is green, flipping it to a blocking check is a one-line follow-up — worth doing while the suite is actually green.
