### PR TITLE
chore(ci): gate the release on the Obsidian plugin review

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,29 @@ jobs:
           TASKCHUTE_TEST_REQUIRE_BINARIES: "1"
         run: npm run test:integration
 
+      # The Obsidian plugin review gate. Obsidian auto-reviews every published
+      # version and blocks the ones that fail, so run the part of that review we
+      # can run ourselves (eslint-plugin-obsidianmd, which Obsidian publishes for
+      # exactly this) before anything irreversible happens. Everything below this
+      # point pushes a bump commit and a tag to the default branch; a failure
+      # here leaves the branch untouched.
+      #
+      # Errors fail the release, warnings are reported only -- that is how
+      # Obsidian itself judges a submission. The dashboard additionally runs
+      # malware and dependency scans that have no public API, so a pass here is
+      # not a guarantee that publication is allowed; a failure is a guarantee
+      # that it is not.
+      - name: Obsidian plugin review
+        run: npm run review:obsidian
+
+      - name: Upload plugin review report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: obsidian-review-${{ github.run_id }}
+          path: obsidian-review.json
+          if-no-files-found: warn
+
       - name: Configure git user
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ memory:
 
 .codex
 .agents/
+# Report written by npm run review:obsidian
+/obsidian-review.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,11 @@ memory/
   - Optional: `author`, `authorUrl`, `fundingUrl` (string or map)
 - Never change `id` after release. Treat it as stable API.
 - Keep `minAppVersion` accurate when using newer APIs.
-- Canonical requirements are coded here: https://github.com/obsidianmd/obsidian-releases/blob/master/.github/workflows/validate-plugin-entry.yml
+- Canonical requirements: https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines
+  （`obsidian-releases` の `validate-plugin-entry.yml` は既に存在しない。エントリ検証は
+  開発者ダッシュボード側の自動レビューへ移管済み）
+- 自動レビューのうち手元で再現できる範囲は `npm run review:obsidian` で確認できる。
+  `manifest.json` の検証もここで初めて実際に動く
 
 
 ## Coding conventions
@@ -189,3 +193,10 @@ npm test       # Jest (ts-jest, jsdom)
 - `esbuild.config.mjs` handles bundling; uses `esbuild --bundle --format=cjs`
 - `tsconfig.json` for main build, `tsconfig.test.json` extends for tests
 - `eslint.config.mjs` で `eslint-plugin-obsidianmd` と `typescript-eslint` を共有設定化し、`npm run lint` で実行
+- `eslint.review.config.mjs` は別物で、Obsidian の自動レビュー基準そのもの。
+  `eslint-plugin-obsidianmd` の `configs.recommended` を **手写しせずに spread** し、
+  `manifest.json` / `LICENSE` / `package.json` も対象に含める。`npm run review:obsidian`
+  で実行し、リリースワークフローが version bump より前に同じものを走らせる。
+  error があるとリリースは失敗し、warning は報告のみ（Obsidian 自身の判定と同じ）。
+  ダッシュボード側のマルウェア/依存脆弱性スキャンは公開 API がなく再現できないので、
+  通っても公開許可の保証にはならない（落ちれば確実に指摘される、の側だけが成り立つ）

--- a/eslint.review.config.mjs
+++ b/eslint.review.config.mjs
@@ -1,0 +1,96 @@
+// The Obsidian plugin review gate.
+//
+// Obsidian auto-reviews every published version of a community plugin. The
+// part of that review we can run ourselves is eslint-plugin-obsidianmd, which
+// Obsidian publishes as the local equivalent of its guidelines. This config
+// exists to run that plugin's recommended config *verbatim* — the day it is
+// hand-copied here, it stops being a review and starts being a second opinion.
+// eslint.config.mjs is the day-to-day lint; this one is the release gate.
+import obsidianmd from "eslint-plugin-obsidianmd";
+import tseslint from "typescript-eslint";
+import { PlainTextParser } from "eslint-plugin-obsidianmd/dist/lib/plainTextParser.js";
+
+export default [
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "build/**",
+      "coverage/**",
+      "main.js",
+      ".obsidian/**",
+      "tests/**",
+      "tmp/**",
+      ".husky/**",
+    ],
+  },
+
+  // The review criteria themselves. Never inline these rules.
+  ...obsidianmd.configs.recommended,
+
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.mjs", "eslint.review.config.mjs"],
+        },
+      },
+    },
+  },
+
+  // The recommended config reports Node builtins through
+  // obsidianmd/no-nodejs-modules, while src/ suppresses them through
+  // import/no-nodejs-modules (what eslint.config.mjs enables). Leaving that
+  // rule off here would make every existing directive unused, and the
+  // recommended config sets reportUnusedDisableDirectives to "error".
+  // Do not re-declare the `import` plugin: recommended already registers it.
+  {
+    files: ["src/**/*.ts"],
+    rules: {
+      "import/no-nodejs-modules": "error",
+    },
+  },
+
+  // validate-manifest only runs when manifest.json itself is linted, so the
+  // recommended config's TS/JS blocks can never reach it. Type-aware parsing
+  // has to be off or the project service rejects the .json extension.
+  {
+    files: ["manifest.json"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { project: false, projectService: false, program: null },
+    },
+    rules: {
+      ...tseslint.configs.disableTypeChecked.rules,
+      "obsidianmd/validate-manifest": "error",
+    },
+  },
+
+  // Same story for validate-license, via the line-oriented parser the plugin
+  // ships for exactly this purpose.
+  {
+    files: ["LICENSE"],
+    languageOptions: { parser: PlainTextParser },
+    rules: {
+      "obsidianmd/validate-license": "error",
+    },
+  },
+
+  // depend/ban-dependencies does not distinguish dev from prod. Neither of
+  // these reaches the published plugin: moment is a type-only dependency the
+  // obsidian typings require (esbuild marks obsidian external), and
+  // lint-staged only runs in the pre-commit hook. Anything added here needs
+  // the same kind of reason written next to it.
+  {
+    files: ["package.json"],
+    rules: {
+      "depend/ban-dependencies": [
+        "error",
+        {
+          presets: ["native", "microutilities", "preferred"],
+          allowed: ["moment", "lint-staged"],
+        },
+      ],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "prepare": "husky",
-    "lint": "eslint --config eslint.config.mjs \"src/**/*.{ts,tsx,js}\" \"tests/**/*.{ts,tsx,js}\""
+    "lint": "eslint --config eslint.config.mjs \"src/**/*.{ts,tsx,js}\" \"tests/**/*.{ts,tsx,js}\"",
+    "review:obsidian": "node scripts/obsidian-review.mjs"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx,js}": "eslint --config eslint.config.mjs --no-warn-ignored",

--- a/scripts/obsidian-review.mjs
+++ b/scripts/obsidian-review.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// Runs the Obsidian plugin review gate (eslint.review.config.mjs) and reports
+// it three ways: stylish text on stdout, GitHub annotations, and a job summary.
+// Errors fail the run; warnings are reported and tolerated, which is how
+// Obsidian's own review treats them.
+import fs from "node:fs";
+import path from "node:path";
+import { ESLint } from "eslint";
+
+const REVIEW_CONFIG = "eslint.review.config.mjs";
+const REVIEW_TARGETS = ["src", "manifest.json", "LICENSE", "package.json"];
+const REPORT_PATH = "obsidian-review.json";
+const GUIDELINES_URL =
+  "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines";
+
+const repoRoot = process.cwd();
+
+function relative(filePath) {
+  return path.relative(repoRoot, filePath) || filePath;
+}
+
+// GitHub workflow commands are line-oriented; the payload has to be escaped or
+// a message containing a newline silently truncates the annotation.
+function escapeAnnotationData(value) {
+  return String(value)
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+}
+
+function escapeAnnotationProperty(value) {
+  return escapeAnnotationData(value).replace(/:/g, "%3A").replace(/,/g, "%2C");
+}
+
+function annotate(kind, file, message) {
+  const properties = [
+    `file=${escapeAnnotationProperty(relative(file.filePath))}`,
+    `line=${message.line ?? 1}`,
+    `col=${message.column ?? 1}`,
+    `title=${escapeAnnotationProperty(message.ruleId ?? "obsidian-review")}`,
+  ].join(",");
+  process.stdout.write(
+    `::${kind} ${properties}::${escapeAnnotationData(message.message)}\n`,
+  );
+}
+
+function escapeCell(value) {
+  return String(value).replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function table(rows) {
+  const lines = [
+    "| Rule | File | Line | Message |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const { file, message } of rows) {
+    lines.push(
+      `| \`${escapeCell(message.ruleId ?? "(parse)")}\` | ${escapeCell(
+        relative(file.filePath),
+      )} | ${message.line ?? "-"} | ${escapeCell(message.message)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function writeSummary(errors, warnings) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const parts = [
+    "## Obsidian plugin review",
+    "",
+    `**${errors.length} error(s), ${warnings.length} warning(s)** — `
+      + `[plugin guidelines](${GUIDELINES_URL})`,
+    "",
+    errors.length === 0
+      ? "No blocking findings. Obsidian's review blocks on errors only, so this release may proceed."
+      : "Errors block publication. This release was stopped.",
+    "",
+  ];
+
+  if (errors.length > 0) {
+    parts.push("### Errors", "", table(errors), "");
+  }
+  if (warnings.length > 0) {
+    parts.push(
+      "<details><summary>" + `${warnings.length} warning(s)` + "</summary>",
+      "",
+      table(warnings),
+      "",
+      "</details>",
+      "",
+    );
+  }
+  parts.push(
+    "> This gate runs `eslint-plugin-obsidianmd`, the checks Obsidian publishes"
+      + " for local use. The dashboard also runs malware and dependency scans"
+      + " that cannot be reproduced here, so a pass is not a guarantee of"
+      + " publication.",
+    "",
+  );
+
+  fs.appendFileSync(summaryPath, parts.join("\n"), "utf8");
+}
+
+const eslint = new ESLint({ overrideConfigFile: REVIEW_CONFIG });
+const results = await eslint.lintFiles(REVIEW_TARGETS);
+
+const stylish = await eslint.loadFormatter("stylish");
+const rendered = await stylish.format(results);
+if (rendered.trim().length > 0) {
+  process.stdout.write(rendered.endsWith("\n") ? rendered : `${rendered}\n`);
+}
+
+const jsonFormatter = await eslint.loadFormatter("json");
+fs.writeFileSync(REPORT_PATH, await jsonFormatter.format(results), "utf8");
+
+const errors = [];
+const warnings = [];
+for (const file of results) {
+  for (const message of file.messages) {
+    (message.severity === 2 ? errors : warnings).push({ file, message });
+  }
+}
+
+if (process.env.GITHUB_ACTIONS === "true") {
+  for (const { file, message } of errors) annotate("error", file, message);
+  for (const { file, message } of warnings) annotate("warning", file, message);
+}
+
+writeSummary(errors, warnings);
+
+process.stdout.write(
+  `Obsidian plugin review: ${errors.length} error(s), ${warnings.length} warning(s); report written to ${REPORT_PATH}\n`,
+);
+
+if (errors.length > 0) {
+  process.stdout.write(
+    `Obsidian would not allow this version to be published. See ${GUIDELINES_URL}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/tests/guardrails/obsidian-review-config.test.ts
+++ b/tests/guardrails/obsidian-review-config.test.ts
@@ -1,0 +1,122 @@
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+const ROOT = path.resolve(__dirname, '../..')
+const REVIEW_CONFIG = 'eslint.review.config.mjs'
+
+// depend/ban-dependencies は dev と prod を区別しないので、配布物に入らない
+// dev 専用パッケージだけをここで許している。増やすときは必ずこのテストと
+// eslint.review.config.mjs のコメントの両方を通すこと。
+const ALLOWED_BANNED_DEPENDENCIES = ['moment', 'lint-staged']
+
+type RuleEntry = unknown
+type RuleMap = Record<string, RuleEntry>
+
+interface Probe {
+  official: RuleMap
+  resolved: Record<string, RuleMap>
+}
+
+// eslint-plugin-obsidianmd は ESM 専用で、jest は CJS で走っている。
+// 子プロセスに追い出せば Node のバージョンに関係なく読める。
+const PROBE_SOURCE = `
+import { ESLint } from "eslint";
+import obsidianmd from "eslint-plugin-obsidianmd";
+const eslint = new ESLint({ overrideConfigFile: ${JSON.stringify(REVIEW_CONFIG)} });
+const official = {};
+for (const block of obsidianmd.configs.recommended) {
+  if (!block || typeof block !== "object" || !block.rules) continue;
+  for (const [name, value] of Object.entries(block.rules)) official[name] = value;
+}
+const resolved = {};
+for (const file of ["src/main.ts", "manifest.json", "LICENSE", "package.json"]) {
+  resolved[file] = (await eslint.calculateConfigForFile(file)).rules ?? {};
+}
+console.log(JSON.stringify({ official, resolved }));
+`
+
+function severityOf(entry: RuleEntry): number {
+  const raw = Array.isArray(entry) ? entry[0] : entry
+  if (raw === 'error' || raw === 2) return 2
+  if (raw === 'warn' || raw === 1) return 1
+  return 0
+}
+
+describe('Obsidian review gate configuration', () => {
+  let probe: Probe
+
+  beforeAll(() => {
+    const stdout = execFileSync(process.execPath, ['--input-type=module', '-e', PROBE_SOURCE], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    })
+    probe = JSON.parse(stdout) as Probe
+  }, 180_000)
+
+  // validate-manifest は「lint 対象のファイル名が manifest.json のときだけ」動く。
+  // eslint.config.mjs は src/**/*.ts のブロックに書いていたので一度も発火して
+  // いなかった。同じ取りこぼしを二度とやらないための番人。
+  test('manifest.json is actually linted by validate-manifest', () => {
+    expect(severityOf(probe.resolved['manifest.json']['obsidianmd/validate-manifest'])).toBe(2)
+  })
+
+  // validate-license も同じで、LICENSE そのものを lint したときだけ動く。
+  test('LICENSE is actually linted by validate-license', () => {
+    expect(severityOf(probe.resolved['LICENSE']['obsidianmd/validate-license'])).toBe(2)
+  })
+
+  // レビュー基準を手写しした瞬間にズレが始まる（#123 / #130 がその後始末だった）。
+  // 公式 recommended が有効にしているルールは、必ずどこかの対象ファイルで
+  // 公式以上の強さで効いていること。
+  test('every rule the official recommended config enables stays enabled', () => {
+    const drift: string[] = []
+    for (const [name, entry] of Object.entries(probe.official)) {
+      const required = severityOf(entry)
+      if (required === 0) continue
+      const strongest = Math.max(
+        ...Object.values(probe.resolved).map((rules) =>
+          name in rules ? severityOf(rules[name]) : 0,
+        ),
+      )
+      if (strongest < required) {
+        drift.push(`${name} (official ${required}, ours ${strongest})`)
+      }
+    }
+    expect(drift).toEqual([])
+    // 空の recommended を読んでしまったのに通った、を防ぐ
+    expect(Object.keys(probe.official).length).toBeGreaterThan(100)
+  })
+
+  test('the banned-dependency exemptions stay exactly the documented ones', () => {
+    const entry = probe.resolved['package.json']['depend/ban-dependencies']
+    expect(severityOf(entry)).toBe(2)
+    const options = Array.isArray(entry) ? (entry[1] as { allowed?: string[] }) : undefined
+    expect(options?.allowed).toEqual(ALLOWED_BANNED_DEPENDENCIES)
+  })
+
+  // 手写しに戻っていないこと。公式 config を spread しているのが唯一の正解。
+  test('the review config derives from the official recommended config', () => {
+    const source = fs.readFileSync(path.join(ROOT, REVIEW_CONFIG), 'utf8')
+    expect(source).toContain('...obsidianmd.configs.recommended')
+  })
+
+  test('the release workflow runs the review before it touches the branch', () => {
+    const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/release.yml'), 'utf8')
+
+    const reviewAt = workflow.indexOf('npm run review:obsidian')
+    const gitUserAt = workflow.indexOf('Configure git user')
+
+    expect(reviewAt).toBeGreaterThan(-1)
+    expect(gitUserAt).toBeGreaterThan(-1)
+    // bump コミットとタグの push より後ろに置くと、落ちたときに main だけ
+    // 進んだ状態が残る
+    expect(reviewAt).toBeLessThan(gitUserAt)
+
+    const scripts = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>
+    }
+    expect(scripts.scripts['review:obsidian']).toBe('node scripts/obsidian-review.mjs')
+  })
+})


### PR DESCRIPTION
## Why

Obsidian auto-reviews **every** published version of a community plugin, not just the first submission, and a version that fails is blocked from the directory. Today the first signal we get is a plugin that has already shipped — #123 and #130 were both cleanups after that signal arrived.

This runs the part of that review we can run ourselves, before the release does anything irreversible.

## What the automated review actually is

Three layers; only the middle one can run in CI.

| Layer | What it does | Reproducible in CI |
| --- | --- | --- |
| Developer dashboard scan | Malware, known vulnerabilities, code quality. Runs per version; a failure pulls the plugin from search within 24h | **No** — server side, no public API; preview scans are dashboard-only |
| `eslint-plugin-obsidianmd` | The checks Obsidian publishes for authors to run locally against the official guidelines | **Yes** — this is what the gate runs |
| `obsidian-releases` entry bot | `validate-plugin-entry.yml` **no longer exists** in that repo (only `mirror-community-json.yml` and `plugin-stat.yml` remain); entry validation moved to the dashboard | Its checks are already covered by guards in `release.yml` |

## Two gaps this also closes

`eslint-plugin-obsidianmd` was already a devDependency, but `eslint.config.mjs` hand-copies its recommended config ("manually extracted to avoid 'extends' compatibility issue"):

1. **Over ten rules were missing** — `no-nodejs-modules`, `no-unsupported-api`, `editor-drop-paste`, `prefer-get-language`, `rule-custom-message`, three `settings-tab/*` rules, `depend/ban-dependencies`, and more.
2. **Two rules could never fire.** `validate-manifest` and `validate-license` are configured in the `src/**/*.ts` block, but both bail unless the linted file is named `manifest.json` / `LICENSE`. They have never run.

## Changes

- **`eslint.review.config.mjs`** — spreads `obsidianmd.configs.recommended` *verbatim* rather than copying it, so a plugin upgrade picks up new rules automatically. Adds `manifest.json` (type-checking off, TS parser), `LICENSE` (the plugin's own line-oriented parser) and `package.json` as targets. `depend/ban-dependencies` exempts `moment` and `lint-staged` with the reason inline — neither reaches the published plugin.
- **`scripts/obsidian-review.mjs`** — one ESLint pass, reported four ways: stylish on stdout, `::error` / `::warning` annotations, a job summary table, and `obsidian-review.json` uploaded as an artifact. Exits 1 on errors only.
- **`release.yml`** — new step at position 9, **before the version bump and tag push**, so a failure leaves the default branch untouched. Errors fail the release, warnings are reported only — how Obsidian itself judges a submission.
- **`tests/guardrails/obsidian-review-config.test.ts`** — drift detection against all 210 official rules, proof that `manifest.json` and `LICENSE` are genuinely linted, the exemption list pinned, and the step-order invariant.
- **`AGENTS.md`** — replaces the now-dead `validate-plugin-entry.yml` link and documents the split between the two configs.

`eslint.config.mjs` is untouched; day-to-day lint behaviour is unchanged.

## Verification

- `npm run review:obsidian` → **0 errors, 14 warnings** (13 × `no-nodejs-modules` on the AI-terminal Node imports, 1 × `settings-tab/prefer-setting-definitions`). Releases pass as-is today.
- Failure path exercised by temporarily breaking `manifest.json`: exit 1, three `::error` annotations, summary reading "Errors block publication. This release was stopped." File restored, no diff.
- `npm run lint`, `npm run typecheck`, `npm run test:unit` (3075 passed), new guardrail suite (6 passed, 1.8s).

## Known limit

This reproduces the published eslint rules and nothing more. The dashboard's malware and dependency scans have no public API, so **passing is not proof that publication is allowed; failing is proof that it is not.** That caveat is written into the workflow comment and `AGENTS.md`.
