### PR TITLE
fix(ai-task): gate every Node builtin behind Platform.isDesktop

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -421,7 +421,12 @@ const TFolder = jest.fn().mockImplementation(() => ({
   name: "test-folder",
 }))
 
+// Suites that need a non-desktop runtime mock 'obsidian' locally; the shared
+// mock stands in for the ordinary case, an Obsidian desktop app.
+const Platform = { isDesktop: true, isMobile: false }
+
 module.exports = {
+  Platform,
   Plugin,
   ItemView,
   WorkspaceLeaf,

--- a/src/features/ai-task/services/NodeProcessGateway.ts
+++ b/src/features/ai-task/services/NodeProcessGateway.ts
@@ -18,12 +18,17 @@ import {
   WorkspaceEntry,
   WorkspaceFileGateway,
 } from './WorkspaceFileService'
+import { Platform } from 'obsidian'
+
 import { stableTimeoutSource } from '../../../utils/stableTimer'
 import { parseDescendantSnapshot } from './process/parseDescendantSnapshot'
 
 // Ambient declarations for the Electron renderer runtime (no @types/node in
 // the src build). These shadow nothing at runtime; they only inform tsc.
 declare function require(moduleId: string): unknown
+
+/** Every Node builtin below is reachable only from the desktop runtime. */
+const DESKTOP_ONLY_GATEWAY = 'The AI task gateway is desktop only.'
 
 declare const process: {
   env: Record<string, string | undefined>
@@ -270,30 +275,45 @@ interface TextCodecModuleLike {
 }
 
 function loadChildProcessModule(): ChildProcessModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only gateway; the CLI runs as a spawned child process
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_GATEWAY)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; the CLI runs as a spawned child process
   return require('child_process') as ChildProcessModuleLike
 }
 
 function loadOsModule(): OsModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only gateway; the working directory falls back to the OS home dir
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_GATEWAY)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; the working directory falls back to the OS home dir
   return require('os') as OsModuleLike
 }
 
 function loadFsModule(): FsModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only gateway; the gateway reads and writes real files
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_GATEWAY)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; the gateway reads and writes real files
   return require('fs') as FsModuleLike
 }
 
 function loadPathModule(): PathModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only gateway; vault-relative paths are joined with Node path
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_GATEWAY)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; vault-relative paths are joined with Node path
   return require('path') as PathModuleLike
 }
 
 function loadTextCodecModule(): TextCodecModuleLike {
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_GATEWAY)
+  }
   // Jest's jsdom runtime lacks the browser globals. Electron supplies them,
   // while Node's equivalent strict codecs keep the gateway deterministic in
   // tests and any older renderer runtime.
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only gateway; Node's strict text codecs decode PTY chunks (see above)
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; Node's strict text codecs decode PTY chunks (see above)
   return require('util') as TextCodecModuleLike
 }
 

--- a/src/features/ai-task/services/TerminalSessionBroker.ts
+++ b/src/features/ai-task/services/TerminalSessionBroker.ts
@@ -13,17 +13,22 @@
 import type {
   AiRunExitOutcome,
 } from './dispatchers/Dispatcher'
+import { Platform } from 'obsidian'
+
 import type { SpawnProcessRequest } from './NodeProcessGateway'
-import { TERMINAL_BROKER_SOURCE } from './TerminalSessionBrokerSource'
+import { buildTerminalBrokerSource } from './TerminalSessionBrokerSource'
 import {
   sleepWithStableTimer,
   stableTimeoutSource,
   type StableTimeoutId,
 } from '../../../utils/stableTimer'
 
-export { TERMINAL_BROKER_SOURCE } from './TerminalSessionBrokerSource'
+export { buildTerminalBrokerSource } from './TerminalSessionBrokerSource'
 
 declare function require(moduleId: string): unknown
+
+/** Every Node builtin below is reachable only from the desktop runtime. */
+const DESKTOP_ONLY_BROKER = 'The AI terminal broker is desktop only.'
 declare const process: {
   env: Record<string, string | undefined>
   platform?: string
@@ -261,32 +266,50 @@ function isValidBrokerSessionId(sessionId: string): boolean {
 }
 
 function loadNet(): NodeNetModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only broker; the session socket is a Node net server
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_BROKER)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; the session socket is a Node net server
   return require('net') as NodeNetModuleLike
 }
 
 function loadFs(): NodeFsModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only broker; socket paths and lock files live on disk
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_BROKER)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; socket paths and lock files live on disk
   return require('fs') as NodeFsModuleLike
 }
 
 function loadOs(): NodeOsModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only broker; the socket directory is derived from the OS temp dir
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_BROKER)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; the socket directory is derived from the OS temp dir
   return require('os') as NodeOsModuleLike
 }
 
 function loadPath(): NodePathModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only broker; socket and lock paths are joined with Node path
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_BROKER)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; socket and lock paths are joined with Node path
   return require('path') as NodePathModuleLike
 }
 
 function loadCrypto(): NodeCryptoModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only broker; session ids and owner tokens need Node crypto
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_BROKER)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; session ids and owner tokens need Node crypto
   return require('crypto') as NodeCryptoModuleLike
 }
 
 function loadChildProcess(): NodeChildProcessModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only broker; the PTY host is spawned as a child process
+  if (!Platform.isDesktop) {
+    throw new Error(DESKTOP_ONLY_BROKER)
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; the PTY host is spawned as a child process
   return require('child_process') as NodeChildProcessModuleLike
 }
 
@@ -1168,7 +1191,7 @@ export class TerminalSessionBrokerClient {
     const env = this.options.getEnv?.() ?? { ...process.env }
     const child = loadChildProcess().spawn(
       'node',
-      ['-e', TERMINAL_BROKER_SOURCE],
+      ['-e', buildTerminalBrokerSource()],
       {
         detached: true,
         windowsHide: true,

--- a/src/features/ai-task/services/TerminalSessionBrokerSource.ts
+++ b/src/features/ai-task/services/TerminalSessionBrokerSource.ts
@@ -13,8 +13,23 @@ import {
  *
  * Kept plain ES2018 so Electron's `ELECTRON_RUN_AS_NODE` mode can execute it
  * unchanged. The source has no secrets; token/path/TTL arrive through env.
+ *
+ * Built on demand rather than at module init. Composing it gzips the two
+ * carried programs, and zlib does not exist on mobile — where this module is
+ * still imported, because main.js pulls in the whole feature graph on every
+ * platform and only decides against running it afterwards. As a module-scope
+ * constant this threw "Cannot find module 'zlib'" during plugin load and took
+ * the entire plugin down on phones. See
+ * tests/guardrails/mobile-plugin-load.test.ts.
+ *
+ * The result is memoised, so the ~1 ms of compression is paid once per session
+ * by the desktop runtime that actually spawns a broker.
  */
-export const TERMINAL_BROKER_SOURCE = String.raw`
+let cachedBrokerSource: string | undefined
+
+export function buildTerminalBrokerSource(): string {
+  if (cachedBrokerSource !== undefined) return cachedBrokerSource
+  cachedBrokerSource = String.raw`
 'use strict';
 const net = require('net');
 const fs = require('fs');
@@ -1904,3 +1919,5 @@ server.on('error', () => shutdown(false));
 process.on('SIGTERM', () => shutdown(false));
 process.on('SIGINT', () => shutdown(false));
 `
+  return cachedBrokerSource
+}

--- a/src/features/ai-task/services/broker-source/EmbeddedProgramSource.ts
+++ b/src/features/ai-task/services/broker-source/EmbeddedProgramSource.ts
@@ -1,20 +1,24 @@
 /**
  * Transport for the sibling programs the broker carries.
  *
- * The broker starts as `spawn(node, ['-e', TERMINAL_BROKER_SOURCE])`, and Linux
- * caps a single argv string at MAX_ARG_STRLEN = 32 * PAGE_SIZE = 131_072 bytes.
+ * The broker starts as `spawn(node, ['-e', buildTerminalBrokerSource()])`, and
+ * Linux caps a single argv string at MAX_ARG_STRLEN = 32 * PAGE_SIZE = 131_072 bytes.
  * Exceeding it fails the execve with E2BIG, so the broker never starts at all —
  * on Linux only, which is why macOS never noticed. The guard and watchdog
  * programs the broker has to hand to its own children accounted for ~46 KB of
  * that budget when embedded as JSON string literals; gzipped and base64'd they
  * cost ~16 KB.
  *
- * Compression happens at module init on the user's machine and costs ~1 ms; the
- * broker inflates in ~0.1 ms. The encoded text still travels inside argv, so
- * this buys the headroom without moving anything into the environment (where
- * Linux `ps axeww` would expose it and every descendant would inherit it) or
- * onto disk.
+ * Compression happens the first time the broker source is built and costs
+ * ~1 ms; the broker inflates in ~0.1 ms. The encoded text still travels inside
+ * argv, so this buys the headroom without moving anything into the environment
+ * (where Linux `ps axeww` would expose it and every descendant would inherit
+ * it) or onto disk.
+ *
+ * It must not happen at module init: main.js loads on mobile too, and zlib is
+ * not there. See tests/guardrails/mobile-plugin-load.test.ts.
  */
+import { Platform } from 'obsidian'
 
 // Matches the lazy-require boundary used by the other Node-touching services;
 // a static `import` of a builtin is rejected by the plugin lint rules.
@@ -29,7 +33,10 @@ interface ZlibModuleLike {
 }
 
 function zlibModule(): ZlibModuleLike {
-  // eslint-disable-next-line import/no-nodejs-modules -- desktop-only broker; the carried programs are compressed to fit one Linux argv string
+  if (!Platform.isDesktop) {
+    throw new Error('The AI terminal broker is desktop only; zlib is unavailable here.')
+  }
+  // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; the carried programs are compressed to fit one Linux argv string
   return require('zlib') as ZlibModuleLike
 }
 

--- a/src/features/ai-task/services/broker-source/TerminalBrokerPureSource.ts
+++ b/src/features/ai-task/services/broker-source/TerminalBrokerPureSource.ts
@@ -10,7 +10,7 @@ import {
  *
  * The broker runs as `node -e <one string>`, so it cannot require sibling files
  * at runtime. This module is therefore not a runtime boundary — it is spliced
- * into TERMINAL_BROKER_SOURCE verbatim and the composed string is what actually
+ * into the composed broker source verbatim, and that string is what actually
  * executes. What the split buys is a *testing* boundary: tests can evaluate this
  * fragment on its own, because nothing in here touches fs, child_process, net,
  * process, or broker globals. A composition test asserts that the broker source

--- a/src/features/license/index.ts
+++ b/src/features/license/index.ts
@@ -45,10 +45,14 @@ function describePlatform(): string | undefined {
  * cosmetic, so every failure path degrades quietly.
  */
 function readHostname(): string | undefined {
-  if (!Platform?.isDesktop) return undefined
+  // Written without optional chaining on purpose: the plugin review rule only
+  // recognises `Platform.isDesktop` as a guard, and Platform is always present
+  // in Obsidian. describePlatform above keeps its `?.` because it has no
+  // builtin to guard.
+  if (!Platform.isDesktop) return undefined
 
   try {
-    // eslint-disable-next-line import/no-nodejs-modules -- desktop-only label lookup; the hostname comes from Node os (mobile returns undefined above)
+    // eslint-disable-next-line import/no-nodejs-modules -- guarded by Platform.isDesktop above; the hostname comes from Node os
     const os = require('os') as { hostname?: () => string }
     return os.hostname?.()
   } catch {

--- a/tests/features/ai-task/broker-source/broker-source-budget.test.ts
+++ b/tests/features/ai-task/broker-source/broker-source-budget.test.ts
@@ -5,7 +5,7 @@ import {
   gzipBase64,
   INFLATE_PROGRAM_SOURCE,
 } from '../../../../src/features/ai-task/services/broker-source/EmbeddedProgramSource'
-import { TERMINAL_BROKER_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { buildTerminalBrokerSource } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionGuardSource'
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
 
@@ -41,7 +41,7 @@ const PROGRAM_BUDGET = 120_000
 
 describe('broker program size budget', () => {
   test.each([
-    ['broker', TERMINAL_BROKER_SOURCE],
+    ['broker', buildTerminalBrokerSource()],
     ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
     ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
   ])('the %s program fits in one Linux execve argument', (_name, source) => {
@@ -78,21 +78,21 @@ describe('compressed program transport', () => {
     ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
     ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
   ])('the broker carries the %s program compressed, not inline', (_name, source) => {
-    expect(TERMINAL_BROKER_SOURCE).toContain(gzipBase64(source))
-    expect(TERMINAL_BROKER_SOURCE).not.toContain(JSON.stringify(source))
+    expect(buildTerminalBrokerSource()).toContain(gzipBase64(source))
+    expect(buildTerminalBrokerSource()).not.toContain(JSON.stringify(source))
   })
 
   test('the broker defines the inflater before it is called', () => {
-    expect(TERMINAL_BROKER_SOURCE).toContain(INFLATE_PROGRAM_SOURCE)
-    expect(TERMINAL_BROKER_SOURCE.indexOf(INFLATE_PROGRAM_SOURCE)).toBeLessThan(
-      TERMINAL_BROKER_SOURCE.indexOf('inflateProgram('.concat('"')),
+    expect(buildTerminalBrokerSource()).toContain(INFLATE_PROGRAM_SOURCE)
+    expect(buildTerminalBrokerSource().indexOf(INFLATE_PROGRAM_SOURCE)).toBeLessThan(
+      buildTerminalBrokerSource().indexOf('inflateProgram('.concat('"')),
     )
   })
 })
 
 describe('program syntax', () => {
   test.each([
-    ['broker', TERMINAL_BROKER_SOURCE],
+    ['broker', buildTerminalBrokerSource()],
     ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
     ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
   ])('the composed %s program parses', (_name, source) => {

--- a/tests/features/ai-task/broker-source/owner-sentinel-probe-source.test.ts
+++ b/tests/features/ai-task/broker-source/owner-sentinel-probe-source.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { createContext, runInContext } from 'vm'
 
 import { OWNER_SENTINEL_PROBE_SOURCE } from '../../../../src/features/ai-task/services/broker-source/OwnerSentinelProbeSource'
-import { TERMINAL_BROKER_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { buildTerminalBrokerSource } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionGuardSource'
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
 
@@ -71,7 +71,7 @@ const identityOf = (path: string): Identity => ({
 })
 
 const PROGRAMS = [
-  ['broker', TERMINAL_BROKER_SOURCE],
+  ['broker', buildTerminalBrokerSource()],
   ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
   ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
 ] as const

--- a/tests/features/ai-task/broker-source/posix-process-snapshot-source.test.ts
+++ b/tests/features/ai-task/broker-source/posix-process-snapshot-source.test.ts
@@ -1,7 +1,7 @@
 import { createContext, runInContext } from 'vm'
 
 import { POSIX_PROCESS_SNAPSHOT_SOURCE } from '../../../../src/features/ai-task/services/broker-source/PosixProcessSnapshotSource'
-import { TERMINAL_BROKER_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { buildTerminalBrokerSource } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionGuardSource'
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
 import {
@@ -77,7 +77,7 @@ const posix = context as unknown as {
 }
 
 const PROGRAMS = [
-  ['broker', TERMINAL_BROKER_SOURCE],
+  ['broker', buildTerminalBrokerSource()],
   ['session guard', TERMINAL_SESSION_GUARD_SOURCE],
   ['owner watchdog', TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE],
 ] as const

--- a/tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts
+++ b/tests/features/ai-task/broker-source/terminal-broker-pure-source.test.ts
@@ -1,13 +1,13 @@
 import { createContext, runInContext } from 'vm'
 
 import { TERMINAL_BROKER_PURE_SOURCE } from '../../../../src/features/ai-task/services/broker-source/TerminalBrokerPureSource'
-import { TERMINAL_BROKER_SOURCE } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { buildTerminalBrokerSource } from '../../../../src/features/ai-task/services/TerminalSessionBrokerSource'
 import { buildTerminalShellLaunch } from '../../../../src/features/ai-task/services/dispatchers/TerminalShellBootstrap'
 import { NodeProcessGateway } from '../../../../src/features/ai-task/services/NodeProcessGateway'
 
 /**
  * The broker ships as `node -e <one string>`, so these functions cannot be
- * imported at runtime — they are spliced into TERMINAL_BROKER_SOURCE. The
+ * imported at runtime — they are spliced into buildTerminalBrokerSource(). The
  * fragment is free of fs, child_process, net and process, which is what lets it
  * be exercised here instead of through a spawned broker: the cases below used
  * to require real pipes, and their outcome then depended on how much a single
@@ -70,7 +70,7 @@ function feed(
 
 describe('broker pure fragment composition', () => {
   test('the shipped broker program embeds the fragment verbatim', () => {
-    expect(TERMINAL_BROKER_SOURCE).toContain(TERMINAL_BROKER_PURE_SOURCE)
+    expect(buildTerminalBrokerSource()).toContain(TERMINAL_BROKER_PURE_SOURCE)
   })
 
   test('the fragment reaches no host facility, so it can run detached', () => {

--- a/tests/features/ai-task/create-ai-task-manager.test.ts
+++ b/tests/features/ai-task/create-ai-task-manager.test.ts
@@ -39,11 +39,18 @@ describe('createAiTaskManager gating', () => {
     expect(manager).toBeUndefined()
   })
 
-  test('returns undefined when Platform is unavailable (mock has no Platform)', () => {
-    // The shared obsidian mock intentionally does not export Platform, which
-    // mirrors non-desktop runtimes where Platform?.isDesktop is falsy.
-    const manager = createAiTaskManager(makePlugin({ aiTaskEnabled: true }))
-    expect(manager).toBeUndefined()
+  test('returns undefined when Platform is unavailable', () => {
+    // The shared mock now supplies a desktop Platform, so the defensive path —
+    // createAiTaskManager reads Platform?.isDesktop rather than assuming the
+    // export exists — needs the absence staged explicitly.
+    jest.isolateModules(() => {
+      jest.doMock('obsidian', () => ({
+        ...jest.requireActual<Record<string, unknown>>('obsidian'),
+        Platform: undefined,
+      }))
+      const mod = require('../../../src/features/ai-task') as FactoryModule
+      expect(mod.createAiTaskManager(makePlugin({ aiTaskEnabled: true }))).toBeUndefined()
+    })
   })
 
   test('returns undefined on mobile platforms', () => {

--- a/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
+++ b/tests/features/ai-task/terminal-session-broker-resilience.integration.test.ts
@@ -22,7 +22,7 @@ import {
   type TerminalBrokerSessionCallbacks,
 } from '../../../src/features/ai-task/services/TerminalSessionBroker'
 import { NodeProcessGateway } from '../../../src/features/ai-task/services/NodeProcessGateway'
-import { TERMINAL_BROKER_SOURCE } from '../../../src/features/ai-task/services/TerminalSessionBrokerSource'
+import { buildTerminalBrokerSource } from '../../../src/features/ai-task/services/TerminalSessionBrokerSource'
 import { TERMINAL_SESSION_GUARD_SOURCE } from '../../../src/features/ai-task/services/TerminalSessionGuardSource'
 import { TERMINAL_SESSION_OWNER_WATCHDOG_SOURCE } from '../../../src/features/ai-task/services/TerminalSessionOwnerWatchdogSource'
 import { describePosix, testWithBinaries } from '../../support/platform'
@@ -1515,7 +1515,7 @@ describePosix('TerminalSessionBroker resilience', () => {
       'scanOwnedPids',
       'pidOwnershipState',
       `${sourceSection(
-        TERMINAL_BROKER_SOURCE,
+        buildTerminalBrokerSource(),
         'function runWindowsTaskkill',
         'function requestGuardStop',
       )}\nreturn signalTree;`,

--- a/tests/guardrails/mobile-plugin-load.test.ts
+++ b/tests/guardrails/mobile-plugin-load.test.ts
@@ -1,0 +1,133 @@
+import { execFileSync } from 'child_process'
+import path from 'path'
+
+const ROOT = path.resolve(__dirname, '../..')
+
+/**
+ * Bundles src/main.ts the way esbuild.config.mjs does, then loads it the way a
+ * runtime without Node would, and reports every Node built-in the module graph
+ * pulls in while it initialises.
+ *
+ * Runs in a child process: esbuild refuses to work under jsdom's TextEncoder,
+ * and the shared jest setup needs jsdom. The probe builds its own jsdom window
+ * so the bundled browser libraries (xterm vendors VS Code's platform
+ * detection) initialise against a real DOM instead of hand-rolled stubs.
+ */
+const PROBE_SOURCE = `
+const vm = require('vm')
+const { builtinModules } = require('module')
+const { buildSync } = require('esbuild')
+const { JSDOM } = require('jsdom')
+
+// The externals esbuild.config.mjs declares; Obsidian supplies them at runtime.
+const EXTERNALS = [
+  'obsidian', 'electron',
+  '@codemirror/autocomplete', '@codemirror/collab', '@codemirror/commands',
+  '@codemirror/language', '@codemirror/lint', '@codemirror/search',
+  '@codemirror/state', '@codemirror/view',
+  '@lezer/common', '@lezer/highlight', '@lezer/lr',
+  ...builtinModules,
+]
+
+const built = buildSync({
+  entryPoints: ['src/main.ts'],
+  absWorkingDir: process.cwd(),
+  bundle: true,
+  format: 'cjs',
+  target: 'es2018',
+  external: EXTERNALS,
+  treeShaking: true,
+  logLevel: 'silent',
+  write: false,
+})
+
+// Whatever the host provides answers with an endlessly chainable stub, so the
+// load gets as far as it can instead of stopping at the first call into
+// Obsidian's own API surface.
+const hostModuleStub = () => new Proxy(function () {}, {
+  get: (target, property) => {
+    if (property === Symbol.iterator) return function* () {}
+    if (typeof property === 'symbol') return undefined
+    return hostModuleStub()
+  },
+  apply: () => hostModuleStub(),
+  construct: () => hostModuleStub(),
+})
+
+const requested = []
+const hostRequire = (id) => {
+  if (!builtinModules.includes(id)) return hostModuleStub()
+  requested.push(id)
+  // Hand back the real module so the load continues and every offending
+  // require is collected, not just the first one.
+  return require(id)
+}
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'app://obsidian.md/',
+  pretendToBeVisual: true,
+  runScripts: 'outside-only',
+})
+const context = dom.getInternalVMContext()
+const moduleObject = { exports: {} }
+Object.assign(context, {
+  module: moduleObject,
+  exports: moduleObject.exports,
+  require: hostRequire,
+  // A phone: no Node, and process.platform is not something to branch on.
+  process: { env: {}, platform: 'android' },
+  Buffer,
+  // jsdom leaves these off the window it hands back.
+  TextEncoder,
+  TextDecoder,
+  // Obsidian's ambient globals, present on every platform.
+  activeDocument: context.document,
+  activeWindow: context.window,
+})
+
+let failure = null
+try {
+  vm.runInContext(built.outputFiles[0].text, context, { filename: 'main.js' })
+} catch (error) {
+  failure = error && error.stack ? error.stack : String(error)
+}
+
+console.log(JSON.stringify({ builtins: [...new Set(requested)], failure }))
+`
+
+interface ProbeResult {
+  builtins: string[]
+  failure: string | null
+}
+
+function loadOnHostWithoutNode(): ProbeResult {
+  const stdout = execFileSync(process.execPath, ['-e', PROBE_SOURCE], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    // jsdom prints "Not implemented: HTMLCanvasElement.prototype.getContext"
+    // while xterm probes for a renderer. Capture it rather than letting it
+    // land in the reporter; a real crash still arrives through the JSON.
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  return JSON.parse(stdout) as ProbeResult
+}
+
+/**
+ * manifest.json declares isDesktopOnly: false, so main.js has to survive being
+ * loaded on a runtime that has no Node.
+ *
+ * Lint cannot see this. Every require() in src/ already sits inside a loader
+ * function, but TERMINAL_BROKER_SOURCE used to call one of those loaders from
+ * module scope to gzip the carried programs, so plugin load on mobile died
+ * with "Cannot find module 'zlib'" long before any Platform check could run.
+ * The lint rule looks at the require site; this looks at what actually runs on
+ * import.
+ */
+describe('mobile plugin load', () => {
+  test('no Node built-in is required while the bundle initialises', () => {
+    const { builtins, failure } = loadOnHostWithoutNode()
+    expect(failure).toBeNull()
+    expect(builtins).toEqual([])
+  }, 180_000)
+})


### PR DESCRIPTION
## The bug

`manifest.json` declares `isDesktopOnly: false`, but **the plugin does not start on mobile.** Loading `main.js` on a runtime that has no Node throws before anything else runs:

```
RESULT: threw at load -> Cannot find module 'zlib'
modules requested before the failure: ["obsidian","obsidian","obsidian","obsidian","zlib"]
```

`main.js` pulls in the whole feature graph on every platform and only decides against *running* it afterwards. `bootstrap.ts` → `features/ai-task/index.ts` → `TerminalSessionBroker` → `TerminalSessionBrokerSource`, and that last module built `TERMINAL_BROKER_SOURCE` as a **module-scope constant**. Composing it gzips the two carried programs, so `require('zlib')` executed during plugin load — long before `createAiTaskManager`'s `if (!Platform?.isDesktop) return undefined` could have any say.

`zlib` was the only Node built-in reached at load time; the other twelve sit in functions that only desktop code paths call.

## The fix

**Build the broker source on demand.** `TERMINAL_BROKER_SOURCE` becomes `buildTerminalBrokerSource()`, memoised, so the ~1 ms of compression is paid once by the desktop runtime that actually spawns a broker. One production call site (the `spawn` argv), one re-export, and six test files follow the rename.

**Make the desktop-only boundary explicit for the other twelve.** Every `require()` already sat inside a loader function, but nothing told a reader — or the review — that those functions are desktop-only. Each loader in `TerminalSessionBroker` (6) and `NodeProcessGateway` (5) now opens with `if (!Platform.isDesktop) throw`, which is also the only shape `obsidianmd/no-nodejs-modules` recognises. `readHostname` in the license feature already had the guard as its first statement and only needed to drop its `?.` — the rule does not see through optional chaining.

The `eslint-disable import/no-nodejs-modules` directives stay: that rule does not understand the Platform guard, and removing them would just move the error. Their descriptions now say what the guard is.

## Test-mock change

The guards read `Platform.isDesktop` without optional chaining, so the shared `__mocks__/obsidian.js` now supplies `Platform: { isDesktop: true, isMobile: false }` — an ordinary desktop app, which is what the suites simulate. Exactly one test depended on the export being absent; it now stages that absence explicitly with `jest.doMock` instead of relying on the mock being incomplete.

## Regression test

`tests/guardrails/mobile-plugin-load.test.ts` bundles `src/main.ts` with the same externals as `esbuild.config.mjs`, then loads it in a jsdom window whose `require()` resolves nothing but Obsidian's own externals, and asserts **no Node built-in is pulled in while the module graph initialises**.

Lint cannot catch this class of defect: the `require` was inside a function, and it was the *caller* that ran at module scope. **This test fails on the commit before this one** (`builtins: ["zlib"]`) and passes after.

It runs in a child process because esbuild refuses to work under jsdom's `TextEncoder` while the shared jest setup needs jsdom. Cost: ~1s.

## Verification

| | before | after |
| --- | --- | --- |
| `npm run review:obsidian` | 0 errors, **14 warnings** | 0 errors, **1 warning** |
| `npm run test:unit` | 3075 passed | **3076 passed** (220 suites) |
| `npm run test:integration` | 82 passed | **82 passed** |
| `npm run lint` / `npm run typecheck` | clean | clean |

The remaining warning is `settings-tab/prefer-setting-definitions` on the 1457-line settings tab. Adopting Obsidian 1.13's declarative settings API means bumping the `obsidian` typings from 1.8.7 and keeping `display()` as the pre-1.13 fallback, so it is deliberately left for its own change. Warnings do not block the release gate.
