### PR TITLE
chore(ci): drop the skip_tests input from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,6 @@ on:
         default: "patch"
         type: choice
         options: [patch, minor, major]
-      skip_tests:
-        description: "Skip the integration suite only; the unit suite always runs"
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: write
@@ -57,14 +52,11 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      # The unit suite has no escape hatch. A hotfix at 2am is a reason to skip
-      # a ten-minute real-process suite; it is never a reason to ship without
-      # the unit tests.
+      # Neither suite has an escape hatch: a release never ships untested.
       - name: Test (unit)
         run: npm run test:unit
 
       - name: Test (integration)
-        if: ${{ !inputs.skip_tests }}
         env:
           TASKCHUTE_TEST_REQUIRE_BINARIES: "1"
         run: npm run test:integration


### PR DESCRIPTION
## Summary

Removes the `skip_tests` workflow_dispatch input from the release workflow. It was added as an escape hatch back when the integration suite could not pass reliably; that is no longer the case, so a release can now always run both suites.

## Changes

- Drop the `skip_tests` boolean input from `workflow_dispatch.inputs`.
- Drop `if: ${{ !inputs.skip_tests }}` from the `Test (integration)` step, so it always runs.
- Update the neighbouring comment: neither suite has an escape hatch now.

## Notes

`skip_tests` had no other references in the repository. The only behavioural change is that a manually dispatched release can no longer skip the integration suite.