### PR TITLE
chore(ci): move the workflows to node 22

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
 
       - name: Install deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install deps
         run: npm ci || npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
 
       - name: Install deps
@@ -114,7 +114,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
 
       - name: Install deps

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "lint": "eslint --config eslint.config.mjs \"src/**/*.{ts,tsx,js}\" \"tests/**/*.{ts,tsx,js}\"",
     "review:obsidian": "node scripts/obsidian-review.mjs"
   },
+  "engines": {
+    "node": ">=22.22.1"
+  },
   "lint-staged": {
     "src/**/*.{ts,tsx,js}": "eslint --config eslint.config.mjs --no-warn-ignored",
     "tests/**/*.{ts,tsx,js}": "eslint --config eslint.config.mjs --no-warn-ignored"


### PR DESCRIPTION
## Summary

CI installs were emitting `npm warn EBADENGINE` on every run: `lint-staged@17.3.0` requires `node >=22.22.1`, while the workflows pinned Node 20.

- Bump `node-version` from `20` to `22` in the lint, test (both jobs), and release workflows.
- Add `engines.node: ">=22.22.1"` to `package.json` so the requirement is recorded and local installs warn on a mismatch too.

## Testing

- `npm run lint` — passes (one pre-existing `obsidianmd/settings-tab/prefer-setting-definitions` warning, unchanged).