### PR TITLE
test: silence console for the whole run, not just inside a test

### DIFF
--- a/tests/setup/console-silence.ts
+++ b/tests/setup/console-silence.ts
@@ -1,28 +1,52 @@
-// テストは意図的に失敗パスを踏むため、src 側の console.error / warn がそのまま
-// 出力されると CI ログが埋まってしまう。ここで no-op に差し替えてノイズを抑える。
+// テストは意図的に失敗パスを踏むため、src 側の console 出力がそのまま流れると
+// CI ログが埋まってしまう。ここで no-op に差し替えてノイズを抑える。
 // 調査したいときは TASKCHUTE_TEST_LOGS=1 を付けて実行すると従来どおり全部出る。
+//
+// jest.spyOn ではなく直接代入しているのは意図的:
+//   - setupFilesAfterEnv 評価時（各テストの import より前）に差し替わるので、
+//     モジュールトップレベル・beforeAll・afterEach 後に発火する非同期コールバック
+//     （浮いた Promise の catch など）からの出力も捕まえられる。
+//   - jest のモックレジストリに載らないため、テスト側の jest.restoreAllMocks() /
+//     resetAllMocks() で剥がれない。
+// テスト側が jest.spyOn(console, 'warn') を張るケースは従来どおり動く。spy は
+// 「現在の値 = この no-op」を控えて mockRestore() でそこへ戻すだけなので影響しない。
 
-type SilencedMethod = 'error' | 'warn' | 'debug'
+type SilencedMethod = 'error' | 'warn' | 'debug' | 'log' | 'info' | 'trace'
 
-const SILENCED_METHODS: SilencedMethod[] = ['error', 'warn', 'debug']
+const SILENCED_METHODS: SilencedMethod[] = [
+  'error',
+  'warn',
+  'debug',
+  'log',
+  'info',
+  'trace',
+]
 
 const shouldSilence = process.env.TASKCHUTE_TEST_LOGS !== '1'
 
 if (shouldSilence) {
-  let spies: jest.SpyInstance[] = []
+  const noops = new Map<SilencedMethod, () => void>()
 
-  beforeEach(() => {
-    spies = SILENCED_METHODS.map((method) =>
-      jest.spyOn(console, method).mockImplementation(() => {}),
-    )
-  })
-
-  afterEach(() => {
-    for (const spy of spies) {
-      spy.mockRestore()
+  const install = (): void => {
+    for (const method of SILENCED_METHODS) {
+      let noop = noops.get(method)
+      if (!noop) {
+        noop = () => {}
+        noops.set(method, noop)
+      }
+      // テストが自前 spy を張っている最中に横取りしないよう、既に自分の no-op が
+      // 載っている場合は触らない。剥がされていたときだけ貼り直す。
+      if (console[method] !== noop) {
+        console[method] = noop
+      }
     }
-    spies = []
-  })
+  }
+
+  install()
+
+  // 直接代入なので restoreAllMocks では剥がれないが、テストが console を自前で
+  // 書き換えたまま戻さなかった場合に備え、テスト境界で既定状態へ戻す。
+  afterEach(install)
 }
 
 export {}


### PR DESCRIPTION
## Problem

The test workflow's log carries `console.warn` and `console.error` blocks from `src/`. The last run on `main` (`32929251550`) had seventeen of them, all from passing suites — pure noise.

`tests/setup/console-silence.ts` has replaced `console.error`, `warn` and `debug` with no-ops since #13, but it installed the spies in `beforeEach` and restored them in `afterEach`. Anything logged outside that window escaped. Both leaks in CI were floating promises whose `catch` resolved after the test body had already finished:

- `ExecutionLogService.ts:442` — the reconcile `.catch()`, from `tests/execution/execution-log-service.test.ts`
- `TaskRowController.ts:166` — the open-file handler, from `tests/ui/tasklist/task-row-controller.test.ts` (the test does spy on `console.error`, but the log arrives after the test ends)

Both stacks end in `processTicksAndRejections`, by which point the spies were gone.

## Change

Assign the no-ops once, when the setup file is evaluated — before any test file is imported — instead of per test. That covers module scope, `beforeAll` and late microtasks too.

Plain assignment rather than `jest.spyOn` also keeps the replacement out of jest's mock registry, so a `jest.restoreAllMocks()` inside a test cannot strip it. An `afterEach` re-applies the no-ops if a test overwrote `console` by hand and did not put it back.

`log`, `info` and `trace` join the silenced set. `TASKCHUTE_TEST_LOGS=1` still turns everything back on.

Tests that spy on `console` themselves are unaffected: `jest.spyOn` records the current value, which is now the no-op, and `mockRestore` puts that back. The four suites that assert on `console` calls, and the five that call `restoreAllMocks` / `resetAllMocks`, all pass unchanged.

## Verification

- `npm run typecheck` — clean
- `npm run test:unit` — 220 suites / 3076 tests pass
- `npm run test:integration` — 3 suites / 82 tests pass
- After this lands, `gh run view <run-id> --log | grep -c "console\."` should be 0 (17 before)
