### PR TITLE
chore(ci): move the actions to their node 24 releases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload plugin review report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: obsidian-review-${{ github.run_id }}
           path: obsidian-review.json
@@ -192,7 +192,7 @@ jobs:
           echo "dir=${PKG_DIR}" >> "$GITHUB_OUTPUT"
 
       - name: Generate artifact attestations
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             ${{ steps.prep.outputs.dir }}/main.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -109,10 +109,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm


### PR DESCRIPTION
Every workflow run currently prints:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4.

The previous CI change (#141) moved the *jobs* to Node 22; this moves the *actions themselves* off the Node 20 runtime, which is what the warning is about.

- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v7
- `actions/upload-artifact` v4 → v7
- `actions/attest-build-provenance` v2 → v4

Node 24 arrived in the v5 majors of the `actions/*` runs; the releases after that are picked up here so the same bump does not have to happen again shortly.

Notes on the breaking changes in between:

- setup-node v5 caches automatically when `package.json` has a `packageManager` field, and v6 narrows that to npm. Every setup-node step here either sets `cache: npm` explicitly or (in the release workflow) runs against a `package.json` with no `packageManager` field, so behaviour is unchanged.
- checkout v7 blocks checking out fork PRs under `pull_request_target` / `workflow_run`. Neither trigger is used in this repo.
- upload-artifact v7 adds an optional `archive` input; the existing usage is unaffected.
- attest-build-provenance v4 is a wrapper over `actions/attest` with the same inputs.

`softprops/action-gh-release@v2` in the release workflow is third-party and left alone.

CI on this PR is the check: the deprecation warning should no longer appear on the `test` and `integration` jobs.
