### PR TITLE
fix(ai-task): hide the AI task UI on vaults without an active license

### DIFF
--- a/src/features/ai-task/AiTaskAmbientRuntime.ts
+++ b/src/features/ai-task/AiTaskAmbientRuntime.ts
@@ -1,5 +1,6 @@
 import type { TaskChutePluginLike } from '../../types'
 import type { TaskChuteViewController } from '../../app/taskchute/TaskChuteViewController'
+import { isAiTaskFeatureAvailable } from './availability'
 import {
   findAiTaskAmbientCandidates,
   type AiTaskAmbientCandidate,
@@ -32,12 +33,7 @@ export function createAiTaskAmbientScheduler(
   return new AiTaskAmbientScheduler({
     stateStore,
     findCandidates: (now) => {
-      if (
-        plugin.settings.aiTaskEnabled !== true ||
-        !plugin.aiTaskManager
-      ) {
-        return []
-      }
+      if (!isAiTaskFeatureAvailable(plugin)) return []
       return findAiTaskAmbientCandidates(
         plugin.app,
         plugin.pathManager.getTaskFolderPath(),

--- a/src/features/ai-task/availability.ts
+++ b/src/features/ai-task/availability.ts
@@ -1,0 +1,101 @@
+/**
+ * AI Task - the single source of truth for "is the AI feature on?".
+ *
+ * The answer used to be spelled out in five different places (the factory, the
+ * license gate, the ambient runtime, the view, the add-task modal), and one of
+ * them had drifted: the add-task modal checked settings and platform but never
+ * the license, so an unlicensed vault carrying `aiTaskEnabled: true` still
+ * showed the human/AI task type selector. Every gate now lives here.
+ *
+ * Deliberately NOT one boolean. Callers ask genuinely different questions —
+ * the settings tab renders the AI section whenever the license is active even
+ * though the toggle is off — so each question gets its own name.
+ *
+ * This module must never import ./index: the factory imports it, and the cycle
+ * would leave `createAiTaskManager` undefined at module-eval time.
+ */
+
+import { Platform } from 'obsidian'
+import type { PathManagerLike, TaskChuteSettings } from '../../types'
+
+/**
+ * Structural host. Both AiTaskPluginLike and TaskChutePluginLike satisfy it,
+ * and a test stub only needs the fields for the gate it exercises.
+ */
+export interface AiTaskAvailabilityHost {
+  settings: Pick<TaskChuteSettings, 'aiTaskEnabled'>
+  pathManager?: Partial<Pick<PathManagerLike, 'getAiLogsPath' | 'getAiLogsMonthPath'>>
+  /** Entitlement gate; structural so tests fake it with a single method. */
+  licenseManager?: { isActive: () => boolean }
+  /** Present only once the runtime has actually been built. */
+  aiTaskManager?: unknown
+}
+
+export type AiTaskUnavailableReason =
+  /** The settings toggle is off. */
+  | 'disabled'
+  /** Mobile: there is no local CLI to spawn. */
+  | 'not-desktop'
+  /** No active license. */
+  | 'unlicensed'
+  /** The path manager predates the AI log paths (lightweight stubs). */
+  | 'unsupported-paths'
+
+export type AiTaskAvailability =
+  | { available: true }
+  | { available: false; reason: AiTaskUnavailableReason }
+
+const AVAILABLE: AiTaskAvailability = { available: true }
+
+/** Whether the user turned the feature on, ignoring entitlement and platform. */
+export function isAiTaskSettingEnabled(host: AiTaskAvailabilityHost): boolean {
+  return host.settings.aiTaskEnabled === true
+}
+
+/**
+ * Whether the license is active, ignoring the settings toggle. The Pro
+ * settings section needs this on its own: it renders the AI toggle, so it
+ * cannot depend on that toggle already being on.
+ */
+export function isAiTaskLicensed(host: AiTaskAvailabilityHost): boolean {
+  return host.licenseManager?.isActive() === true
+}
+
+/**
+ * Evaluate every gate, in the order the factory used to. The reason is what
+ * lets callers log or explain the refusal instead of failing silently.
+ */
+export function evaluateAiTaskAvailability(
+  host: AiTaskAvailabilityHost,
+): AiTaskAvailability {
+  if (!isAiTaskSettingEnabled(host)) return { available: false, reason: 'disabled' }
+  if (!Platform?.isDesktop) return { available: false, reason: 'not-desktop' }
+  if (!isAiTaskLicensed(host)) return { available: false, reason: 'unlicensed' }
+
+  const pathManager = host.pathManager
+  if (
+    typeof pathManager?.getAiLogsPath !== 'function' ||
+    typeof pathManager?.getAiLogsMonthPath !== 'function'
+  ) {
+    return { available: false, reason: 'unsupported-paths' }
+  }
+
+  return AVAILABLE
+}
+
+/**
+ * Whether a runtime may be built. Used by the factory and the license gate,
+ * i.e. by the code that decides whether `aiTaskManager` should exist at all.
+ */
+export function canStartAiTaskRuntime(host: AiTaskAvailabilityHost): boolean {
+  return evaluateAiTaskAvailability(host).available
+}
+
+/**
+ * The predicate every UI surface uses. Stricter than "a manager exists" on
+ * purpose: a gate that has just closed (toggle off, license revoked) hides the
+ * AI UI on the very next render, without waiting for the teardown to land.
+ */
+export function isAiTaskFeatureAvailable(host: AiTaskAvailabilityHost): boolean {
+  return host.aiTaskManager !== undefined && canStartAiTaskRuntime(host)
+}

--- a/src/features/ai-task/index.ts
+++ b/src/features/ai-task/index.ts
@@ -2,15 +2,15 @@
  * AI Task - feature entry point
  *
  * createAiTaskManager wires the whole feature (Node gateway, binary locator,
- * dispatchers, log writer, run manager) and gates it twice: the feature must
- * be enabled in settings AND the runtime must be desktop. When either gate
- * fails it returns undefined and nothing AI-related is instantiated, keeping
- * mobile and opted-out vaults completely inert.
+ * dispatchers, log writer, run manager) behind the shared gate in
+ * ./availability. When any gate fails it returns undefined and nothing
+ * AI-related is instantiated, keeping mobile, unlicensed and opted-out vaults
+ * completely inert.
  */
 
-import { Platform } from 'obsidian'
 import type { App } from 'obsidian'
 import type { PathManagerLike, TaskChutePluginLike, TaskChuteSettings } from '../../types'
+import { evaluateAiTaskAvailability } from './availability'
 import type { AiRunMode, AiTaskHost } from './types'
 import { AiTaskLogWriter } from './services/AiTaskLogWriter'
 import {
@@ -75,23 +75,19 @@ function getVaultBrokerIdentity(app: App): string | undefined {
  */
 export function createAiTaskManager(plugin: AiTaskPluginLike): AiTaskManager | undefined {
   plugin.aiTaskRuntimeLeaseGeneration = undefined
-  if (plugin.settings.aiTaskEnabled !== true) return undefined
-  if (!Platform?.isDesktop) return undefined
-  if (plugin.licenseManager?.isActive() !== true) {
-    plugin._log?.('debug', '[AiTask] No active license; feature disabled')
+  const availability = evaluateAiTaskAvailability(plugin)
+  if (!availability.available) {
+    if (availability.reason === 'unlicensed') {
+      plugin._log?.('debug', '[AiTask] No active license; feature disabled')
+    } else if (availability.reason === 'unsupported-paths') {
+      plugin._log?.('warn', '[AiTask] Path manager lacks AI log paths; feature disabled')
+    }
     return undefined
   }
 
-  const pathManager = plugin.pathManager
-  if (
-    typeof pathManager.getAiLogsPath !== 'function' ||
-    typeof pathManager.getAiLogsMonthPath !== 'function'
-  ) {
-    plugin._log?.('warn', '[AiTask] Path manager lacks AI log paths; feature disabled')
-    return undefined
-  }
-  // Runtime-validated above; the cast makes the optional methods required.
-  const logPathManager = pathManager as PathManagerLike & {
+  // Runtime-validated by the availability gate; the cast makes the optional
+  // path methods required.
+  const logPathManager = plugin.pathManager as PathManagerLike & {
     getAiLogsPath: () => string
     getAiLogsMonthPath: (yearMonth: string) => string
   }

--- a/src/features/ai-task/licenseGate.ts
+++ b/src/features/ai-task/licenseGate.ts
@@ -6,6 +6,7 @@
  * unattended, when a background token refresh flips the entitlement, so it
  * stays silent and errs toward tearing the runtime down.
  */
+import { canStartAiTaskRuntime, isAiTaskLicensed } from './availability'
 import { createAiTaskManager, type AiTaskPluginLike } from './index'
 import { disposeAiTaskManagerTracked } from './registerProcessCleanup'
 import type { AiTaskManager } from './services/AiTaskManager'
@@ -22,9 +23,7 @@ export interface AiTaskLicenseGateHost extends AiTaskPluginLike {
 export async function syncAiTaskManagerToLicense(
   plugin: AiTaskLicenseGateHost,
 ): Promise<boolean> {
-  const licensed = plugin.licenseManager?.isActive() === true
-
-  if (!licensed) {
+  if (!isAiTaskLicensed(plugin)) {
     const manager = plugin.aiTaskManager
     if (manager) {
       // Revocation must take effect now, not at the next restart: an already
@@ -38,7 +37,9 @@ export async function syncAiTaskManagerToLicense(
   }
 
   if (plugin.aiTaskManager) return true
-  if (plugin.settings.aiTaskEnabled !== true) return false
+  // Checked before the pending-disposal wait below: there is no point draining
+  // a previous runtime for a manager the factory would refuse to build.
+  if (!canStartAiTaskRuntime(plugin)) return false
 
   // A new manager reuses the vault-scoped broker identity, so it must not start
   // while a previous one is still shutting down or that shutdown would kill it.
@@ -59,7 +60,6 @@ export async function syncAiTaskManagerToLicense(
     }
   }
 
-  // The factory owns the remaining gates (settings, desktop, license).
   plugin.aiTaskManager = createAiTaskManager(plugin)
 
   return plugin.aiTaskManager !== undefined

--- a/src/features/ai-task/notifyAiTaskSettingsChanged.ts
+++ b/src/features/ai-task/notifyAiTaskSettingsChanged.ts
@@ -1,0 +1,31 @@
+/**
+ * Push an AI availability change into every open TaskChute view.
+ *
+ * Tearing the runtime down is not enough on its own: an already rendered view
+ * keeps its AI run pane, board switch and row controls until something asks it
+ * to re-render. The settings toggle had this wired up, but a background license
+ * refresh that revoked the entitlement did not, so the AI UI stayed on screen
+ * for a feature that could no longer run. Both paths now call this.
+ */
+import type { App } from 'obsidian'
+import { VIEW_TYPE_TASKCHUTE } from '../../types'
+
+export function notifyAiTaskSettingsChanged(app: App): void {
+  const workspace = app.workspace as {
+    getLeavesOfType?: (type: string) => Array<{ view?: unknown }>
+  }
+  const leaves = typeof workspace.getLeavesOfType === 'function'
+    ? workspace.getLeavesOfType(VIEW_TYPE_TASKCHUTE)
+    : []
+  leaves.forEach((leaf) => {
+    const view = leaf.view as {
+      onAiTaskSettingsChanged?: () => void
+      renderTaskList?: () => void
+    } | undefined
+    if (typeof view?.onAiTaskSettingsChanged === 'function') {
+      view.onAiTaskSettingsChanged()
+      return
+    }
+    view?.renderTaskList?.()
+  })
+}

--- a/src/features/core/views/TaskChuteView.ts
+++ b/src/features/core/views/TaskChuteView.ts
@@ -65,6 +65,7 @@ import { TaskRecipeAssignmentService } from "../../recipe/services/TaskRecipeAss
 import { RecipeRunPopover } from "../../recipe/ui/RecipeRunPopover"
 import { RecipeSelectModal } from "../../recipe/modals/RecipeSelectModal"
 import RecipeManagerModal from "../../recipe/modals/RecipeManagerModal"
+import { isAiTaskFeatureAvailable } from "../../ai-task/availability"
 import { AiRunPaneController } from "../../ai-task/ui/AiRunPaneController"
 import { createTerminalViewAdapter } from "../../ai-task/ui/TerminalViewAdapter"
 import {
@@ -816,7 +817,7 @@ export class TaskChuteView
   // ===========================================
 
   private isAiTaskFeatureEnabled(): boolean {
-    return this.plugin.aiTaskManager !== undefined
+    return isAiTaskFeatureAvailable(this.plugin)
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import type { AiTaskManager } from "./features/ai-task/services/AiTaskManager"
 import type { LicenseManager } from "./features/license/services/LicenseManager"
 import { LICENSE_REFRESH_INTERVAL_MS } from "./features/license/config"
 import { syncAiTaskManagerToLicense } from "./features/ai-task/licenseGate"
+import { notifyAiTaskSettingsChanged } from "./features/ai-task/notifyAiTaskSettingsChanged"
 import {
   getSharedAiTaskManagersPendingDisposal,
   registerAiTaskAppShutdownCleanup,
@@ -118,9 +119,16 @@ export default class TaskChutePlusPlugin extends Plugin {
 
     this.register(
       manager.onChange(() => {
-        void syncAiTaskManagerToLicense(this).catch((error) => {
-          this._log('warn', '[License] Failed to apply license change', error)
-        })
+        void syncAiTaskManagerToLicense(this)
+          .catch((error) => {
+            this._log('warn', '[License] Failed to apply license change', error)
+          })
+          // Even a failed sync leaves the views describing an entitlement that
+          // may be gone, so re-render either way; the view reads the current
+          // state rather than trusting what it drew last.
+          .finally(() => {
+            notifyAiTaskSettingsChanged(this.app)
+          })
       }),
     )
 

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -3,6 +3,8 @@ import { TaskChuteSettings, SectionBoundary, PathManagerLike, VIEW_TYPE_TASKCHUT
 import { getCurrentLocale, t } from "../i18n"
 import { TERMINAL_NAME } from "../constants"
 import { createAiTaskManager } from "../features/ai-task"
+import { isAiTaskLicensed } from "../features/ai-task/availability"
+import { notifyAiTaskSettingsChanged } from "../features/ai-task/notifyAiTaskSettingsChanged"
 import type { AiTaskManager } from "../features/ai-task/services/AiTaskManager"
 import { disposeAiTaskManagerTracked } from "../features/ai-task/registerProcessCleanup"
 import { syncAiTaskManagerToLicense } from "../features/ai-task/licenseGate"
@@ -114,7 +116,7 @@ export class TaskChuteSettingTab extends PluginSettingTab {
     // Deliberately not latched: releasing this device drops the state back to
     // unlicensed, and the section has to disappear with it rather than leave
     // an activation form behind for a feature that is hidden again.
-    return this.plugin.licenseManager?.getState().status === "active"
+    return isAiTaskLicensed(this.plugin)
   }
 
   /**
@@ -737,7 +739,7 @@ export class TaskChuteSettingTab extends PluginSettingTab {
       return
     }
 
-    if (manager.getState().status === "active") {
+    if (manager.isActive()) {
       this.renderActiveLicense(content, manager)
       this.renderAiTaskSection(content)
       return
@@ -1181,23 +1183,7 @@ export class TaskChuteSettingTab extends PluginSettingTab {
   }
 
   private notifyAiTaskSettingsChanged(): void {
-    const workspace = this.app.workspace as {
-      getLeavesOfType?: (type: string) => Array<{ view?: unknown }>
-    }
-    const leaves = typeof workspace.getLeavesOfType === "function"
-      ? workspace.getLeavesOfType(VIEW_TYPE_TASKCHUTE)
-      : []
-    leaves.forEach((leaf) => {
-      const view = leaf.view as {
-        onAiTaskSettingsChanged?: () => void
-        renderTaskList?: () => void
-      } | undefined
-      if (typeof view?.onAiTaskSettingsChanged === "function") {
-        view.onAiTaskSettingsChanged()
-        return
-      }
-      view?.renderTaskList?.()
-    })
+    notifyAiTaskSettingsChanged(this.app)
   }
 
   private renderSectionCustomization(container: HTMLElement): void {

--- a/src/ui/task/TaskCreationController.ts
+++ b/src/ui/task/TaskCreationController.ts
@@ -1,4 +1,4 @@
-import { App, Notice, Platform } from 'obsidian'
+import { App, Notice } from 'obsidian'
 import type { TFile } from "obsidian"
 import { t } from "../../i18n"
 import {
@@ -13,6 +13,7 @@ import type {
 } from "../../features/core/services/TaskCreationService"
 import type { TaskReuseService } from "../../features/core/services/TaskReuseService"
 import { normalizeReminderTime } from "../../features/reminder/services/ReminderFrontmatterService"
+import { isAiTaskFeatureAvailable } from "../../features/ai-task/availability"
 import type { AiTaskHost } from "../../features/ai-task/types"
 import { buildTerminalArgs } from "../../features/ai-task/services/TerminalArguments"
 import type {
@@ -720,12 +721,7 @@ export default class TaskCreationController {
     onTaskTypeChange: () => void,
     initialValue?: AiTaskControlsInitialValue,
   ): AiTaskControls | null {
-    if (
-      this.host.plugin.settings.aiTaskEnabled !== true ||
-      Platform?.isDesktop !== true
-    ) {
-      return null
-    }
+    if (!isAiTaskFeatureAvailable(this.host.plugin)) return null
 
     let taskType: TaskType = initialValue ? "ai" : "human"
     let selectedHost: AiTaskHost = initialValue?.host ?? "claude"

--- a/tests/features/ai-task/ai-task-ambient-runtime.test.ts
+++ b/tests/features/ai-task/ai-task-ambient-runtime.test.ts
@@ -4,6 +4,7 @@ import { createAiTaskAmbientScheduler } from '../../../src/features/ai-task/AiTa
 import { AI_TASK_AMBIENT_SCHEDULE_STATE_STORAGE_KEY } from '../../../src/features/ai-task/services/AiTaskAmbientScheduleStateStore'
 import type { TaskChuteViewController } from '../../../src/app/taskchute/TaskChuteViewController'
 import type { TaskChutePluginLike } from '../../../src/types'
+import { createFakeLicenseManager } from '../license/fakeLicenseManager'
 
 const TASK_PATH = 'TaskChute/Task/Ambient review.md'
 const DUE_AT = new Date(2026, 6, 15, 8, 0)
@@ -27,6 +28,7 @@ function createFile(path: string): TFile {
 function createHarness(options: {
   enabled?: boolean
   manager?: boolean
+  licensed?: boolean
   linked?: boolean
 } = {}) {
   const file = createFile(TASK_PATH)
@@ -79,9 +81,12 @@ function createHarness(options: {
     settings: {
       aiTaskEnabled: options.enabled !== false,
     },
+    licenseManager: createFakeLicenseManager(options.licensed !== false),
     aiTaskManager: options.manager === false ? undefined : {},
     pathManager: {
       getTaskFolderPath: () => 'TaskChute/Task',
+      getAiLogsPath: () => 'TaskChute/AI/Logs',
+      getAiLogsMonthPath: (yearMonth: string) => `TaskChute/AI/Logs/${yearMonth}`,
     },
     _log: jest.fn(),
   } as unknown as TaskChutePluginLike
@@ -207,6 +212,7 @@ describe('AI Task Ambient runtime composition', () => {
   test.each([
     ['feature disabled', { enabled: false }],
     ['manager unavailable', { manager: false }],
+    ['license inactive', { licensed: false }],
   ])('stays inert when %s', async (_label, options) => {
     const harness = createHarness(options)
 

--- a/tests/features/ai-task/ai-task-availability.test.ts
+++ b/tests/features/ai-task/ai-task-availability.test.ts
@@ -1,0 +1,134 @@
+import {
+  canStartAiTaskRuntime,
+  evaluateAiTaskAvailability,
+  isAiTaskFeatureAvailable,
+  isAiTaskLicensed,
+  isAiTaskSettingEnabled,
+  type AiTaskAvailabilityHost,
+} from '../../../src/features/ai-task/availability'
+import { createFakeLicenseManager } from '../license/fakeLicenseManager'
+
+type AvailabilityModule = typeof import('../../../src/features/ai-task/availability')
+
+function makeHost(
+  overrides: Partial<AiTaskAvailabilityHost> = {},
+): AiTaskAvailabilityHost {
+  return {
+    settings: { aiTaskEnabled: true },
+    pathManager: {
+      getAiLogsPath: () => 'TaskChute/AI/Logs',
+      getAiLogsMonthPath: (yearMonth: string) => `TaskChute/AI/Logs/${yearMonth}`,
+    },
+    licenseManager: createFakeLicenseManager(),
+    aiTaskManager: {},
+    ...overrides,
+  }
+}
+
+describe('evaluateAiTaskAvailability', () => {
+  test('reports available when every gate passes', () => {
+    expect(evaluateAiTaskAvailability(makeHost())).toEqual({ available: true })
+    expect(canStartAiTaskRuntime(makeHost())).toBe(true)
+  })
+
+  test('reports "disabled" when the settings toggle is off', () => {
+    const host = makeHost({ settings: { aiTaskEnabled: false } })
+    expect(evaluateAiTaskAvailability(host)).toEqual({
+      available: false,
+      reason: 'disabled',
+    })
+  })
+
+  test('reports "not-desktop" on mobile', () => {
+    jest.isolateModules(() => {
+      jest.doMock('obsidian', () => ({
+        ...jest.requireActual<Record<string, unknown>>('obsidian'),
+        Platform: { isDesktop: false, isMobile: true },
+      }))
+      const mod = require('../../../src/features/ai-task/availability') as AvailabilityModule
+      expect(mod.evaluateAiTaskAvailability(makeHost())).toEqual({
+        available: false,
+        reason: 'not-desktop',
+      })
+    })
+  })
+
+  test('reports "not-desktop" when the Platform export is missing entirely', () => {
+    jest.isolateModules(() => {
+      jest.doMock('obsidian', () => ({
+        ...jest.requireActual<Record<string, unknown>>('obsidian'),
+        Platform: undefined,
+      }))
+      const mod = require('../../../src/features/ai-task/availability') as AvailabilityModule
+      expect(mod.evaluateAiTaskAvailability(makeHost())).toEqual({
+        available: false,
+        reason: 'not-desktop',
+      })
+    })
+  })
+
+  test('reports "unlicensed" when the license is inactive', () => {
+    const host = makeHost({ licenseManager: createFakeLicenseManager(false) })
+    expect(evaluateAiTaskAvailability(host)).toEqual({
+      available: false,
+      reason: 'unlicensed',
+    })
+  })
+
+  test('reports "unlicensed" when no license manager exists at all', () => {
+    // Fails closed: a bootstrap failure must not hand out the paid feature.
+    const host = makeHost({ licenseManager: undefined })
+    expect(evaluateAiTaskAvailability(host)).toEqual({
+      available: false,
+      reason: 'unlicensed',
+    })
+  })
+
+  test('reports "unsupported-paths" when the path manager lacks AI log paths', () => {
+    expect(evaluateAiTaskAvailability(makeHost({ pathManager: {} }))).toEqual({
+      available: false,
+      reason: 'unsupported-paths',
+    })
+    expect(
+      evaluateAiTaskAvailability(
+        makeHost({ pathManager: { getAiLogsPath: () => 'TaskChute/AI/Logs' } }),
+      ),
+    ).toEqual({ available: false, reason: 'unsupported-paths' })
+    expect(evaluateAiTaskAvailability(makeHost({ pathManager: undefined }))).toEqual({
+      available: false,
+      reason: 'unsupported-paths',
+    })
+  })
+})
+
+describe('the individual questions stay independent', () => {
+  test('a licensed vault with the toggle off is licensed but not enabled', () => {
+    const host = makeHost({ settings: { aiTaskEnabled: false } })
+    expect(isAiTaskSettingEnabled(host)).toBe(false)
+    expect(isAiTaskLicensed(host)).toBe(true)
+  })
+
+  test('an unlicensed vault with the toggle on is enabled but not licensed', () => {
+    const host = makeHost({ licenseManager: createFakeLicenseManager(false) })
+    expect(isAiTaskSettingEnabled(host)).toBe(true)
+    expect(isAiTaskLicensed(host)).toBe(false)
+  })
+})
+
+describe('isAiTaskFeatureAvailable', () => {
+  test('is false while no runtime exists, even with every gate open', () => {
+    expect(isAiTaskFeatureAvailable(makeHost({ aiTaskManager: undefined }))).toBe(false)
+  })
+
+  test('is false as soon as a gate closes, before the runtime is torn down', () => {
+    // Revocation hides the UI on the next render rather than waiting for the
+    // asynchronous dispose to clear plugin.aiTaskManager.
+    const host = makeHost({ licenseManager: createFakeLicenseManager(false) })
+    expect(host.aiTaskManager).toBeDefined()
+    expect(isAiTaskFeatureAvailable(host)).toBe(false)
+  })
+
+  test('is true when the gates are open and the runtime exists', () => {
+    expect(isAiTaskFeatureAvailable(makeHost())).toBe(true)
+  })
+})

--- a/tests/features/ai-task/ai-task-license-gate.test.ts
+++ b/tests/features/ai-task/ai-task-license-gate.test.ts
@@ -19,7 +19,11 @@ function createHost(overrides: Partial<Record<string, unknown>> = {}): Host {
   return {
     app: {},
     settings: { aiTaskEnabled: true },
-    pathManager: {},
+    // The gate now asks canStartAiTaskRuntime, which includes the AI log paths.
+    pathManager: {
+      getAiLogsPath: () => 'TaskChute/AI/Logs',
+      getAiLogsMonthPath: (yearMonth: string) => `TaskChute/AI/Logs/${yearMonth}`,
+    },
     licenseManager: createFakeLicenseManager(),
     aiTaskManagersPendingDisposal: new Set(),
     _log: jest.fn(),

--- a/tests/features/ai-task/notify-ai-task-settings-changed.test.ts
+++ b/tests/features/ai-task/notify-ai-task-settings-changed.test.ts
@@ -1,0 +1,65 @@
+import type { App } from 'obsidian'
+
+import { notifyAiTaskSettingsChanged } from '../../../src/features/ai-task/notifyAiTaskSettingsChanged'
+import { VIEW_TYPE_TASKCHUTE } from '../../../src/types'
+
+function makeApp(leaves: Array<{ view?: unknown }>): {
+  app: App
+  getLeavesOfType: jest.Mock
+} {
+  const getLeavesOfType = jest.fn((type: string) =>
+    type === VIEW_TYPE_TASKCHUTE ? leaves : [],
+  )
+  return {
+    app: { workspace: { getLeavesOfType } } as unknown as App,
+    getLeavesOfType,
+  }
+}
+
+describe('notifyAiTaskSettingsChanged', () => {
+  test('pushes the change into every open TaskChute view', () => {
+    const first = { onAiTaskSettingsChanged: jest.fn() }
+    const second = { onAiTaskSettingsChanged: jest.fn() }
+    const { app, getLeavesOfType } = makeApp([{ view: first }, { view: second }])
+
+    notifyAiTaskSettingsChanged(app)
+
+    expect(getLeavesOfType).toHaveBeenCalledWith(VIEW_TYPE_TASKCHUTE)
+    expect(first.onAiTaskSettingsChanged).toHaveBeenCalledTimes(1)
+    expect(second.onAiTaskSettingsChanged).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to a plain re-render for a view without the hook', () => {
+    const view = { renderTaskList: jest.fn() }
+    const { app } = makeApp([{ view }])
+
+    notifyAiTaskSettingsChanged(app)
+
+    expect(view.renderTaskList).toHaveBeenCalledTimes(1)
+  })
+
+  test('prefers the hook over the re-render fallback', () => {
+    const view = {
+      onAiTaskSettingsChanged: jest.fn(),
+      renderTaskList: jest.fn(),
+    }
+    const { app } = makeApp([{ view }])
+
+    notifyAiTaskSettingsChanged(app)
+
+    expect(view.onAiTaskSettingsChanged).toHaveBeenCalledTimes(1)
+    expect(view.renderTaskList).not.toHaveBeenCalled()
+  })
+
+  test('tolerates detached leaves and a workspace without getLeavesOfType', () => {
+    const { app } = makeApp([{ view: undefined }, {}])
+    expect(() => {
+      notifyAiTaskSettingsChanged(app)
+    }).not.toThrow()
+
+    const bareApp = { workspace: {} } as unknown as App
+    expect(() => {
+      notifyAiTaskSettingsChanged(bareApp)
+    }).not.toThrow()
+  })
+})

--- a/tests/features/ai-task/task-chute-view-board-view.test.ts
+++ b/tests/features/ai-task/task-chute-view-board-view.test.ts
@@ -15,6 +15,7 @@ import {
   AI_TASK_BOARD_VIEW_STORAGE_KEY,
 } from '../../../src/features/core/views/TaskChuteView'
 import type { TaskChutePluginLike, TaskInstance } from '../../../src/types'
+import { createFakeLicenseManager } from '../license/fakeLicenseManager'
 
 interface LocalStorageMocks {
   loadLocalStorage: jest.Mock
@@ -82,7 +83,10 @@ function createPluginStub(storedBoardView?: unknown): {
       getLogYearPath: (year: string | number) => `${year}`,
       ensureYearFolder: jest.fn(async (year: string | number) => `${year}`),
       validatePath: () => ({ valid: true }),
+      getAiLogsPath: () => 'TaskChute/AI/Logs',
+      getAiLogsMonthPath: (yearMonth: string) => `TaskChute/AI/Logs/${yearMonth}`,
     },
+    licenseManager: createFakeLicenseManager(),
     dayStateService: {
       loadDay: jest.fn(async () => ({
         hiddenRoutines: [],

--- a/tests/ui/task/task-creation-controller-ai.test.ts
+++ b/tests/ui/task/task-creation-controller-ai.test.ts
@@ -25,6 +25,7 @@ import type { App } from 'obsidian'
 import { en } from '../../../src/i18n/locales/en'
 import { ja } from '../../../src/i18n/locales/ja'
 import type { Recipe } from '../../../src/features/recipe/types'
+import { createFakeLicenseManager } from '../../features/license/fakeLicenseManager'
 
 jest.mock('obsidian', () => {
   const Actual = jest.requireActual('obsidian')
@@ -70,6 +71,10 @@ interface CreateHostOptions {
   storedWorkingDirectories?: string[]
   selectDirectory?: (defaultPath?: string) => Promise<string | null>
   recipes?: Recipe[]
+  /** Defaults to an active license; set false to stage an unlicensed vault. */
+  licensed?: boolean
+  /** Defaults to a live runtime; set false to stage a vault without one. */
+  aiTaskManager?: boolean
 }
 
 function createHost(
@@ -124,7 +129,11 @@ function createHost(
       getLogYearPath: jest.fn(),
       ensureYearFolder: jest.fn(),
       validatePath: jest.fn(() => ({ valid: true })),
+      getAiLogsPath: () => 'TaskChute/AI/Logs',
+      getAiLogsMonthPath: (yearMonth: string) => `TaskChute/AI/Logs/${yearMonth}`,
     },
+    licenseManager: createFakeLicenseManager(options.licensed !== false),
+    aiTaskManager: options.aiTaskManager === false ? undefined : {},
     routineAliasService: { loadAliases: jest.fn() },
     dayStateService: {
       loadDay: jest.fn(),
@@ -626,6 +635,28 @@ describe('task-type selector gating', () => {
       mockPlatformState.isDesktop = true
       mockPlatformState.isMobile = false
     }
+  })
+
+  /**
+   * Regression: this gate used to read the settings flag and the platform but
+   * not the license, unlike every other AI surface. A vault that carried
+   * `aiTaskEnabled: true` from a licensed machine — via sync, or because the
+   * license later lapsed — kept offering an AI mode it could not run.
+   */
+  test('renders no selector without an active license, even when enabled on desktop', () => {
+    const { host } = createHost({ aiTaskEnabled: true }, { licensed: false })
+    const modal = openModal(host)
+
+    expect(modal.querySelector('.task-type-group')).toBeNull()
+    expect(modal.querySelector('.ai-task-section')).toBeNull()
+  })
+
+  test('renders no selector while no AI runtime exists', () => {
+    const { host } = createHost({ aiTaskEnabled: true }, { aiTaskManager: false })
+    const modal = openModal(host)
+
+    expect(modal.querySelector('.task-type-group')).toBeNull()
+    expect(modal.querySelector('.ai-task-section')).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Problem

The `Task type: Human task / AI task` selector appeared in the add-task modal on vaults that were never activated.

Two independent causes:

1. `TaskCreationController.createAiTaskControls` checked `settings.aiTaskEnabled` and `Platform.isDesktop`, but not the license. Every other AI surface goes through `plugin.aiTaskManager`, which `createAiTaskManager` only builds for an active license. Nothing resets `aiTaskEnabled` when a license lapses, and a synced `data.json` carries it across machines, so the selector was permanently visible rather than flashing.
2. A background license refresh that revoked the entitlement disposed the runtime without re-rendering the open views, leaving the run pane, board switch and row controls on screen.

## Change

`src/features/ai-task/availability.ts` is now the single source of truth. It keeps the questions separate instead of collapsing them into one boolean, since callers genuinely differ — the settings tab renders the AI section whenever the license is active, even with the toggle off:

| function | question |
| --- | --- |
| `isAiTaskSettingEnabled` | is the toggle on? |
| `isAiTaskLicensed` | is the license active? |
| `evaluateAiTaskAvailability` | all four gates, with a reason |
| `canStartAiTaskRuntime` | may a runtime be built? |
| `isAiTaskFeatureAvailable` | may the UI show? (gates + a live runtime) |

Call sites updated: the factory, `licenseGate`, `AiTaskAmbientRuntime`, `TaskChuteView.isAiTaskFeatureEnabled`, `TaskCreationController` and the two status checks in `SettingsTab`.

`notifyAiTaskSettingsChanged` moved out of `SettingsTab` into its own module so `main.ts`'s license listener can call it after a background state change.

The license activation form is unaffected: `getState().status === "active"` became `isActive()`, which is the same predicate.

## Tests

- `tests/features/ai-task/ai-task-availability.test.ts` — every gate and reason
- `tests/features/ai-task/notify-ai-task-settings-changed.test.ts` — dispatch and fallback
- Regression in `task-creation-controller-ai.test.ts` — no selector when unlicensed, and none without a runtime
- Existing AI fixtures gained a `licenseManager` and the AI log paths, since the predicate is stricter now

3177 tests pass, lint clean, build ok.
