### PR TITLE
feat(ai-task): let the AI run pane be dragged to any height

### DIFF
--- a/src/features/ai-task/ui/AiPaneResizer.ts
+++ b/src/features/ai-task/ui/AiPaneResizer.ts
@@ -1,0 +1,179 @@
+/** Smallest usable pane height: the header plus a couple of body rows. */
+export const AI_PANE_MIN_HEIGHT_PX = 120
+/** Largest share of the view the pane may take, leaving the task list a strip. */
+export const AI_PANE_MAX_HEIGHT_RATIO = 0.9
+/** Height change per ArrowUp/ArrowDown press on the focused handle. */
+const KEYBOARD_STEP_PX = 16
+
+export interface AiPaneResizerOptions {
+  /** Host container (.ai-pane-container); the handle becomes its first child. */
+  container: HTMLElement
+  /** Accessible name for the separator. */
+  label: string
+  /** Height the ratio is measured against (the .main-container column). */
+  getViewHeight: () => number
+  /** Current pane height in pixels. */
+  getPaneHeight: () => number
+  /** Continuous feedback while the pointer moves (not a persistence point). */
+  onResize: (ratio: number) => void
+  /** The gesture settled on this ratio — persist it. */
+  onCommit: (ratio: number) => void
+  /** Drop the user height and fall back to the stylesheet default. */
+  onReset: () => void
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Splitter between the task list and the AI run pane.
+ *
+ * The handle lives inside the pane container rather than between the two
+ * columns, so it inherits the container's visibility (`--visible`) without
+ * any extra synchronisation — a previous sibling cannot be selected in CSS.
+ *
+ * Heights are carried as a ratio of the view height, never as pixels: the
+ * leaf can be split or the window resized after the value was stored, and a
+ * ratio survives both.
+ */
+export class AiPaneResizer {
+  private readonly handle: HTMLElement
+  private readonly onPointerDown: (event: PointerEvent) => void
+  private readonly onPointerMove: (event: PointerEvent) => void
+  private readonly onPointerEnd: (event: PointerEvent) => void
+  private readonly onKeyDown: (event: KeyboardEvent) => void
+  private readonly onDoubleClick: () => void
+  private pointerId: number | null = null
+  private startY = 0
+  private startHeight = 0
+  private lastRatio: number | null = null
+
+  constructor(private readonly options: AiPaneResizerOptions) {
+    const handle = options.container.createDiv({
+      cls: 'ai-pane-resizer',
+      attr: {
+        role: 'separator',
+        'aria-orientation': 'horizontal',
+        'aria-label': options.label,
+        title: options.label,
+        tabindex: '0',
+      },
+    })
+    // createDiv appends; the splitter must sit above .ai-run-pane regardless
+    // of the order the pane itself was mounted in.
+    options.container.prepend(handle)
+    this.handle = handle
+
+    this.onPointerDown = (event) => this.handlePointerDown(event)
+    this.onPointerMove = (event) => this.handlePointerMove(event)
+    this.onPointerEnd = (event) => this.handlePointerEnd(event)
+    this.onKeyDown = (event) => this.handleKeyDown(event)
+    this.onDoubleClick = () => this.options.onReset()
+
+    handle.addEventListener('pointerdown', this.onPointerDown)
+    handle.addEventListener('pointermove', this.onPointerMove)
+    handle.addEventListener('pointerup', this.onPointerEnd)
+    handle.addEventListener('pointercancel', this.onPointerEnd)
+    handle.addEventListener('keydown', this.onKeyDown)
+    handle.addEventListener('dblclick', this.onDoubleClick)
+  }
+
+  get element(): HTMLElement {
+    return this.handle
+  }
+
+  dispose(): void {
+    this.releasePointer()
+    this.handle.removeEventListener('pointerdown', this.onPointerDown)
+    this.handle.removeEventListener('pointermove', this.onPointerMove)
+    this.handle.removeEventListener('pointerup', this.onPointerEnd)
+    this.handle.removeEventListener('pointercancel', this.onPointerEnd)
+    this.handle.removeEventListener('keydown', this.onKeyDown)
+    this.handle.removeEventListener('dblclick', this.onDoubleClick)
+    this.handle.remove()
+  }
+
+  /**
+   * Ratio a pixel height maps to, clamped to the usable band. Null while the
+   * view has no measurable height (hidden leaf, jsdom) — there is no sane
+   * ratio to report and the gesture must be ignored.
+   */
+  private ratioFor(heightPx: number): number | null {
+    const viewHeight = this.options.getViewHeight()
+    if (!(viewHeight > 0)) return null
+    const minRatio = Math.min(
+      AI_PANE_MIN_HEIGHT_PX / viewHeight,
+      AI_PANE_MAX_HEIGHT_RATIO,
+    )
+    return clamp(heightPx / viewHeight, minRatio, AI_PANE_MAX_HEIGHT_RATIO)
+  }
+
+  private handlePointerDown(event: PointerEvent): void {
+    if (event.button !== undefined && event.button !== 0) return
+    const paneHeight = this.options.getPaneHeight()
+    if (!(paneHeight > 0)) return
+    if (this.ratioFor(paneHeight) === null) return
+
+    event.preventDefault()
+    this.pointerId = event.pointerId ?? null
+    this.startY = event.clientY
+    this.startHeight = paneHeight
+    this.lastRatio = null
+    this.handle.classList.add('is-dragging')
+    if (this.pointerId !== null) {
+      this.handle.setPointerCapture?.(this.pointerId)
+    }
+  }
+
+  private handlePointerMove(event: PointerEvent): void {
+    if (this.pointerId === null) return
+    // Dragging upward grows the pane, so the delta is subtracted.
+    const ratio = this.ratioFor(this.startHeight - (event.clientY - this.startY))
+    if (ratio === null || ratio === this.lastRatio) return
+    this.lastRatio = ratio
+    this.options.onResize(ratio)
+  }
+
+  private handlePointerEnd(event: PointerEvent): void {
+    if (this.pointerId === null) return
+    if (event.type !== 'pointercancel') {
+      const ratio = this.ratioFor(
+        this.startHeight - (event.clientY - this.startY),
+      )
+      if (ratio !== null) {
+        this.lastRatio = ratio
+        this.options.onCommit(ratio)
+      }
+    }
+    this.releasePointer()
+  }
+
+  private releasePointer(): void {
+    if (this.pointerId !== null) {
+      this.handle.releasePointerCapture?.(this.pointerId)
+    }
+    this.pointerId = null
+    this.lastRatio = null
+    this.handle.classList.remove('is-dragging')
+  }
+
+  private handleKeyDown(event: KeyboardEvent): void {
+    if (event.key === 'Home') {
+      event.preventDefault()
+      this.options.onReset()
+      return
+    }
+    const step =
+      event.key === 'ArrowUp'
+        ? KEYBOARD_STEP_PX
+        : event.key === 'ArrowDown'
+          ? -KEYBOARD_STEP_PX
+          : 0
+    if (step === 0) return
+    const ratio = this.ratioFor(this.options.getPaneHeight() + step)
+    if (ratio === null) return
+    event.preventDefault()
+    this.options.onCommit(ratio)
+  }
+}

--- a/src/features/ai-task/ui/AiRunPaneController.ts
+++ b/src/features/ai-task/ui/AiRunPaneController.ts
@@ -119,6 +119,7 @@ import type {
   TerminalViewAdapterLike,
 } from './TerminalViewAdapter'
 import type { FileEditorAdapterFactory } from './FileEditorAdapter'
+import { AI_PANE_MAX_HEIGHT_RATIO, AiPaneResizer } from './AiPaneResizer'
 import { WorkspaceFileEditorController } from './WorkspaceFileEditorController'
 import { WorkspaceFileTreeController } from './WorkspaceFileTreeController'
 
@@ -334,7 +335,10 @@ const TERMINAL_VERTICAL_INSET_PX = 64
  * screen.
  */
 export const RUN_SIDEBAR_WIDTH_PX = 180
-/** Share of the view height the terminal pane occupies (mirrors styles.css) */
+/**
+ * Default share of the view height the terminal pane occupies (mirrors
+ * styles.css). A drag-resized pane reports its own share instead.
+ */
 const TERMINAL_PANE_HEIGHT_RATIO = 0.4
 /** Share of the view height while expanded (mirrors styles.css) */
 const TERMINAL_PANE_EXPANDED_HEIGHT_RATIO = 1
@@ -358,6 +362,12 @@ const TERMINAL_CONTAINER_CLASS = 'ai-pane-container--terminal'
 const EXPANDED_CONTAINER_CLASS = 'ai-pane-container--expanded'
 /** Layout participation class while the pane (or a future artifact) is visible. */
 const VISIBLE_CONTAINER_CLASS = 'ai-pane-container--visible'
+/** Chrome class while the user dragged the splitter to an explicit height */
+const SIZED_CONTAINER_CLASS = 'ai-pane-container--sized'
+/** Chrome class while the pane is collapsed to its header row */
+const COLLAPSED_CONTAINER_CLASS = 'ai-pane-container--collapsed'
+/** Custom property carrying the drag-resized height (mirrors styles.css) */
+const PANE_HEIGHT_PROPERTY = '--tc-ai-pane-height'
 
 /**
  * Per-device persistence key of the pane's expanded state
@@ -367,6 +377,12 @@ export const AI_PANE_EXPANDED_STORAGE_KEY = 'taskchute-plus.ai-pane-expanded'
 /** Device-local preference for the independent left sidebar rail. */
 export const AI_PANE_SIDEBAR_COLLAPSED_STORAGE_KEY =
   'taskchute-plus.ai-pane-sidebar-collapsed'
+/**
+ * Device-local drag-resized pane height, stored as a share of the view
+ * height so it survives leaf splits and window resizes.
+ */
+export const AI_PANE_HEIGHT_RATIO_STORAGE_KEY =
+  'taskchute-plus.ai-pane-height-ratio'
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))
@@ -412,6 +428,9 @@ export class AiRunPaneController {
   private composerSend: HTMLButtonElement | null = null
   private expanded = false
   private sidebarCollapsed = false
+  private paneResizer: AiPaneResizer | null = null
+  /** Drag-resized height share; null while the stylesheet default applies. */
+  private paneHeightRatio: number | null = null
   private sidebarMode: 'runs' | 'files' = 'runs'
   private unsubscribe: (() => void) | null = null
   private unregisterSnapshotProvider: (() => void) | null = null
@@ -427,6 +446,26 @@ export class AiRunPaneController {
   mount(container: HTMLElement): void {
     if (this.root) return
     this.containerEl = container
+
+    this.paneResizer = new AiPaneResizer({
+      container,
+      label: this.host.tv('aiTask.resizePane', 'Resize AI run pane'),
+      // Same measurement source computeTerminalSize uses, so the PTY grid
+      // and the CSS share always describe the same box.
+      getViewHeight: () => container.parentElement?.clientHeight ?? 0,
+      getPaneHeight: () => container.getBoundingClientRect().height,
+      onResize: (ratio) => {
+        // Dragging out of ⤢ hands control back to the splitter; the toggle
+        // then flips between this height and full height.
+        if (this.expanded) this.setExpanded(false, true)
+        this.applyPaneHeightRatio(ratio, false)
+      },
+      onCommit: (ratio) => {
+        if (this.expanded) this.setExpanded(false, true)
+        this.applyPaneHeightRatio(ratio, true)
+      },
+      onReset: () => this.applyPaneHeightRatio(null, true),
+    })
 
     const root = container.createDiv({ cls: 'ai-run-pane is-hidden' })
     this.root = root
@@ -569,6 +608,12 @@ export class AiRunPaneController {
       this.host.loadLocalStorage?.(AI_PANE_SIDEBAR_COLLAPSED_STORAGE_KEY) === true,
       false,
     )
+    const storedHeightRatio = this.host.loadLocalStorage?.(
+      AI_PANE_HEIGHT_RATIO_STORAGE_KEY,
+    )
+    if (typeof storedHeightRatio === 'number' && Number.isFinite(storedHeightRatio)) {
+      this.applyPaneHeightRatio(storedHeightRatio, false)
+    }
 
     this.unsubscribe = this.host.manager.onChange((record, changeType) => {
       this.handleChange(record, changeType)
@@ -636,9 +681,15 @@ export class AiRunPaneController {
     for (const view of this.runViews.values()) {
       this.disposeTerminalBinding(view)
     }
+    this.paneResizer?.dispose()
+    this.paneResizer = null
+    this.paneHeightRatio = null
     this.containerEl?.classList.remove(TERMINAL_CONTAINER_CLASS)
     this.containerEl?.classList.remove(EXPANDED_CONTAINER_CLASS)
     this.containerEl?.classList.remove(VISIBLE_CONTAINER_CLASS)
+    this.containerEl?.classList.remove(SIZED_CONTAINER_CLASS)
+    this.containerEl?.classList.remove(COLLAPSED_CONTAINER_CLASS)
+    this.containerEl?.style.removeProperty(PANE_HEIGHT_PROPERTY)
     this.containerEl = null
     this.root?.remove()
     this.root = null
@@ -843,7 +894,7 @@ export class AiRunPaneController {
     }
     const heightRatio = this.expanded
       ? TERMINAL_PANE_EXPANDED_HEIGHT_RATIO
-      : TERMINAL_PANE_HEIGHT_RATIO
+      : (this.paneHeightRatio ?? TERMINAL_PANE_HEIGHT_RATIO)
     const bodyHeight = parentHeight * heightRatio - TERMINAL_VERTICAL_INSET_PX
     const cols = clamp(
       Math.floor((width - TERMINAL_HORIZONTAL_INSET_PX) / TERMINAL_CELL_WIDTH_PX),
@@ -891,6 +942,38 @@ export class AiRunPaneController {
   private revealPane(): void {
     this.root?.classList.remove('is-hidden')
     this.updateContainerChrome()
+    this.fitVisibleTerminalViews()
+  }
+
+  /**
+   * Adopt a drag-resized pane height, or `null` to drop back to the
+   * stylesheet default (content height, or the fixed terminal share).
+   * `persist` is true only for settled gestures — continuous pointer moves
+   * and the mount-time restore must not write to storage.
+   */
+  private applyPaneHeightRatio(ratio: number | null, persist: boolean): void {
+    const container = this.containerEl
+    if (!container) return
+    const next =
+      ratio === null || !Number.isFinite(ratio)
+        ? null
+        : clamp(ratio, 0, AI_PANE_MAX_HEIGHT_RATIO)
+    this.paneHeightRatio = next
+    if (next === null) {
+      container.style.removeProperty(PANE_HEIGHT_PROPERTY)
+      container.classList.remove(SIZED_CONTAINER_CLASS)
+    } else {
+      container.style.setProperty(
+        PANE_HEIGHT_PROPERTY,
+        `${(next * 100).toFixed(2)}%`,
+      )
+      container.classList.add(SIZED_CONTAINER_CLASS)
+    }
+    if (persist) {
+      this.host.saveLocalStorage?.(AI_PANE_HEIGHT_RATIO_STORAGE_KEY, next)
+    }
+    // The xterm viewport just changed height; refitting propagates the new
+    // grid to the PTY.
     this.fitVisibleTerminalViews()
   }
 
@@ -2272,6 +2355,10 @@ export class AiRunPaneController {
     )
     container.classList.toggle(EXPANDED_CONTAINER_CLASS, this.expanded && visible)
     container.classList.toggle(VISIBLE_CONTAINER_CLASS, paneVisible)
+    container.classList.toggle(
+      COLLAPSED_CONTAINER_CLASS,
+      this.isCollapsed() && paneVisible,
+    )
   }
 
   // -------------------------------------------------------------------------

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -280,6 +280,7 @@ export const en = {
       closeTab: "Close run tab",
       stopAndClose: "Stop and close run",
       togglePane: "Toggle AI run pane",
+      resizePane: "Resize AI run pane",
       toggleSidebar: "Toggle terminal sidebar",
       expandPane: "Expand AI run pane",
       restorePane: "Restore AI run pane size",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -273,6 +273,7 @@ export const ja = {
       closeTab: "実行タブを閉じる",
       stopAndClose: "実行を停止して閉じる",
       togglePane: "AI実行ペインを開閉",
+      resizePane: "AI実行ペインの高さを調整",
       toggleSidebar: "ターミナルサイドバーを開閉",
       expandPane: "AI実行ペインを拡大",
       restorePane: "AI実行ペインの高さを戻す",

--- a/styles.css
+++ b/styles.css
@@ -7436,6 +7436,11 @@ textarea.form-textarea {
 /* Bottom pane participates in the column layout while visible, shrinking the
    scrollable task-list sibling instead of covering its final rows. */
 .ai-pane-container {
+  /* Drag-resized height, as a share of the view. Overridden inline by the
+     pane controller once the user sizes the pane (see --sized below); the
+     value here is only the fallback that keeps the variable resolvable. */
+  --tc-ai-pane-height: 40%;
+
   display: none;
   width: 100%;
   max-height: 40%;
@@ -7446,6 +7451,64 @@ textarea.form-textarea {
 
 .ai-pane-container--visible {
   display: flex;
+}
+
+/* Splitter between the task list and the pane. It lives INSIDE the container
+   so it inherits --visible instead of needing its own visibility sync — a
+   previous sibling cannot be selected in CSS. */
+.ai-pane-resizer {
+  position: relative;
+  flex-shrink: 0;
+  height: 6px;
+  cursor: row-resize;
+  background: transparent;
+  transition: background 120ms ease;
+}
+
+/* Widen the hit area past the visible 6px without changing the layout. */
+.ai-pane-resizer::before {
+  content: '';
+  position: absolute;
+  inset: -3px 0;
+}
+
+/* Resting affordance: a short centred grip, so the splitter is discoverable
+   without painting a band across the whole view. */
+.ai-pane-resizer::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 28px;
+  height: 2px;
+  transform: translate(-50%, -50%);
+  border-radius: 1px;
+  background: var(--background-modifier-border);
+  transition: background 120ms ease;
+}
+
+.ai-pane-resizer:hover::after,
+.ai-pane-resizer:focus-visible::after,
+.ai-pane-resizer.is-dragging::after {
+  background: var(--background-modifier-border-hover);
+}
+
+/* Tinted rather than filled: a solid accent bar reads as an error state at
+   this width, so the active states stay translucent. */
+.ai-pane-resizer:hover,
+.ai-pane-resizer:focus-visible {
+  background: color-mix(in srgb, var(--interactive-accent) 20%, transparent);
+  outline: none;
+}
+
+.ai-pane-resizer.is-dragging {
+  background: color-mix(in srgb, var(--interactive-accent) 32%, transparent);
+  outline: none;
+}
+
+/* Nothing to resize while the pane is collapsed to its header row. */
+.ai-pane-container--collapsed .ai-pane-resizer {
+  display: none;
 }
 
 .ai-run-pane {
@@ -8285,6 +8348,21 @@ textarea.form-textarea {
 }
 
 .ai-pane-container--terminal .ai-run-pane {
+  flex: 1;
+  min-height: 0;
+}
+
+/* A height the user dragged the splitter to. Declared after the terminal
+   chrome so an explicit height beats the fixed 40% share, and before the
+   expanded chrome so ⤢ still wins over it — this ordering is part of the
+   contract (tests/styles/style-regressions.test.ts asserts it). */
+.ai-pane-container--sized {
+  height: var(--tc-ai-pane-height);
+  flex-basis: var(--tc-ai-pane-height);
+  max-height: 90%;
+}
+
+.ai-pane-container--sized .ai-run-pane {
   flex: 1;
   min-height: 0;
 }

--- a/tests/features/ai-task/ai-run-pane-resize.test.ts
+++ b/tests/features/ai-task/ai-run-pane-resize.test.ts
@@ -1,0 +1,296 @@
+import {
+  AI_PANE_EXPANDED_STORAGE_KEY,
+  AI_PANE_HEIGHT_RATIO_STORAGE_KEY,
+  AiRunPaneController,
+} from '../../../src/features/ai-task/ui/AiRunPaneController'
+import type { AiRunPaneControllerHost } from '../../../src/features/ai-task/ui/AiRunPaneController'
+import type { AiRunRecord } from '../../../src/features/ai-task/types'
+
+type ChangeListener = (record: AiRunRecord) => void
+
+/** The pane only needs a manager that can be subscribed to and emit a run. */
+class FakeManager {
+  readonly listeners = new Set<ChangeListener>()
+  readonly records: AiRunRecord[] = []
+  readonly stopRun = jest.fn()
+  readonly followUp = jest.fn(() => Promise.resolve())
+  readonly sendTerminalInput = jest.fn()
+
+  onTerminalData(): () => void {
+    return () => undefined
+  }
+
+  getRuns(): AiRunRecord[] {
+    return [...this.records]
+  }
+
+  getRun(runId: string): AiRunRecord | undefined {
+    return this.records.find((record) => record.id === runId)
+  }
+
+  getActiveRunForTask(): AiRunRecord | undefined {
+    return undefined
+  }
+
+  onChange(listener: ChangeListener): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  emit(record: AiRunRecord): void {
+    if (!this.records.includes(record)) this.records.push(record)
+    for (const listener of this.listeners) listener(record)
+  }
+}
+
+const VIEW_HEIGHT = 1000
+const START_PANE_HEIGHT = 400
+
+describe('AI run pane drag resize', () => {
+  let container: HTMLElement
+  let manager: FakeManager
+  let host: AiRunPaneControllerHost
+  let controller: AiRunPaneController
+  let stored: Map<string, unknown>
+  let saveLocalStorage: jest.Mock
+  let paneHeight: number
+
+  const handle = (): HTMLElement =>
+    container.querySelector('.ai-pane-resizer') as HTMLElement
+
+  /** jsdom has no PointerEvent; a MouseEvent carrying pointerId is enough. */
+  const pointer = (type: string, clientY: number): Event => {
+    const event = new MouseEvent(type, { clientY, bubbles: true, button: 0 })
+    Object.defineProperty(event, 'pointerId', { value: 1 })
+    return event
+  }
+
+  const drag = (deltaY: number): void => {
+    handle().dispatchEvent(pointer('pointerdown', 500))
+    handle().dispatchEvent(pointer('pointermove', 500 + deltaY))
+    handle().dispatchEvent(pointer('pointerup', 500 + deltaY))
+  }
+
+  const heightProperty = (): string =>
+    container.style.getPropertyValue('--tc-ai-pane-height')
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    document.body.replaceChildren()
+    container = document.body.createDiv({ cls: 'ai-pane-container' })
+    paneHeight = START_PANE_HEIGHT
+
+    // jsdom reports zero for every box, so the two measurements the resizer
+    // and computeTerminalSize rely on are stubbed explicitly.
+    Object.defineProperty(document.body, 'clientHeight', {
+      configurable: true,
+      value: VIEW_HEIGHT,
+    })
+    Object.defineProperty(container, 'clientWidth', {
+      configurable: true,
+      value: 800,
+    })
+    container.getBoundingClientRect = () =>
+      ({ height: paneHeight }) as DOMRect
+
+    manager = new FakeManager()
+    stored = new Map()
+    saveLocalStorage = jest.fn((key: string, value: unknown) => {
+      stored.set(key, value)
+    })
+    host = {
+      tv: (_key, fallback) => fallback,
+      manager,
+      createTerminalAdapter: () => {
+        throw new Error('resize tests never open a terminal adapter')
+      },
+      registerManagedDisposer: () => () => undefined,
+      saveLocalStorage,
+      loadLocalStorage: (key: string) => stored.get(key),
+    } as unknown as AiRunPaneControllerHost
+    controller = new AiRunPaneController(host)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('mounts the splitter as the container first child', () => {
+    controller.mount(container)
+
+    expect(container.firstElementChild).toBe(handle())
+    expect(handle().getAttribute('role')).toBe('separator')
+    expect(handle().getAttribute('aria-orientation')).toBe('horizontal')
+    expect(handle().getAttribute('tabindex')).toBe('0')
+    expect(handle().getAttribute('aria-label')).toBe('Resize AI run pane')
+  })
+
+  test('dragging upward grows the pane and marks it as user-sized', () => {
+    controller.mount(container)
+
+    drag(-100)
+
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(true)
+    expect(heightProperty()).toBe('50.00%')
+  })
+
+  test('dragging downward shrinks the pane', () => {
+    controller.mount(container)
+
+    drag(100)
+
+    expect(heightProperty()).toBe('30.00%')
+  })
+
+  test('clamps to the minimum pane height and the maximum view share', () => {
+    controller.mount(container)
+
+    drag(350)
+    expect(heightProperty()).toBe('12.00%')
+
+    paneHeight = START_PANE_HEIGHT
+    drag(-700)
+    expect(heightProperty()).toBe('90.00%')
+  })
+
+  test('persists the height once the gesture settles, not during the drag', () => {
+    controller.mount(container)
+
+    handle().dispatchEvent(pointer('pointerdown', 500))
+    handle().dispatchEvent(pointer('pointermove', 450))
+    expect(saveLocalStorage).not.toHaveBeenCalled()
+
+    handle().dispatchEvent(pointer('pointerup', 450))
+    expect(saveLocalStorage).toHaveBeenCalledWith(
+      AI_PANE_HEIGHT_RATIO_STORAGE_KEY,
+      0.45,
+    )
+  })
+
+  test('a cancelled gesture leaves the previous stored height alone', () => {
+    controller.mount(container)
+
+    handle().dispatchEvent(pointer('pointerdown', 500))
+    handle().dispatchEvent(pointer('pointermove', 450))
+    handle().dispatchEvent(pointer('pointercancel', 450))
+
+    expect(saveLocalStorage).not.toHaveBeenCalled()
+  })
+
+  test('restores the stored height on mount without writing it back', () => {
+    stored.set(AI_PANE_HEIGHT_RATIO_STORAGE_KEY, 0.62)
+
+    controller.mount(container)
+
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(true)
+    expect(heightProperty()).toBe('62.00%')
+    expect(saveLocalStorage).not.toHaveBeenCalled()
+  })
+
+  test('dragging out of the expanded mode hands control back to the splitter', () => {
+    stored.set(AI_PANE_EXPANDED_STORAGE_KEY, true)
+    controller.mount(container)
+    manager.emit({
+      id: 'run-1',
+      taskPath: 'TASKS/ai-sample.md',
+      taskName: 'AI sample',
+      host: 'claude',
+      mode: 'headless',
+      status: 'running',
+      startedAt: Date.now(),
+      events: [],
+    })
+    expect(container.classList.contains('ai-pane-container--expanded')).toBe(true)
+
+    drag(-100)
+
+    expect(container.classList.contains('ai-pane-container--expanded')).toBe(
+      false,
+    )
+    expect(saveLocalStorage).toHaveBeenCalledWith(
+      AI_PANE_EXPANDED_STORAGE_KEY,
+      false,
+    )
+    expect(heightProperty()).toBe('50.00%')
+  })
+
+  test('arrow keys nudge the height and Home restores the default', () => {
+    controller.mount(container)
+
+    handle().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }),
+    )
+    expect(heightProperty()).toBe('41.60%')
+
+    handle().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Home', bubbles: true }),
+    )
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(false)
+    expect(heightProperty()).toBe('')
+    expect(saveLocalStorage).toHaveBeenLastCalledWith(
+      AI_PANE_HEIGHT_RATIO_STORAGE_KEY,
+      null,
+    )
+  })
+
+  test('a double click on the handle drops back to the default height', () => {
+    controller.mount(container)
+    drag(-100)
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(true)
+
+    handle().dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(false)
+  })
+
+  test('the collapsed chrome class follows the header toggle', () => {
+    controller.mount(container)
+    manager.emit({
+      id: 'run-1',
+      taskPath: 'TASKS/ai-sample.md',
+      taskName: 'AI sample',
+      host: 'claude',
+      mode: 'headless',
+      status: 'running',
+      startedAt: Date.now(),
+      events: [],
+    })
+    expect(container.classList.contains('ai-pane-container--collapsed')).toBe(
+      false,
+    )
+
+    controller.setCollapsed(true)
+    expect(container.classList.contains('ai-pane-container--collapsed')).toBe(
+      true,
+    )
+
+    controller.setCollapsed(false)
+    expect(container.classList.contains('ai-pane-container--collapsed')).toBe(
+      false,
+    )
+  })
+
+  test('the PTY grid follows the dragged height', () => {
+    controller.mount(container)
+    const before = controller.computeTerminalSize()
+
+    drag(-300)
+    const after = controller.computeTerminalSize()
+
+    expect(after.rows).toBeGreaterThan(before.rows)
+    expect(after.cols).toBe(before.cols)
+  })
+
+  test('unmount removes the handle and the height it applied', () => {
+    controller.mount(container)
+    drag(-100)
+
+    controller.unmount()
+
+    expect(container.querySelector('.ai-pane-resizer')).toBeNull()
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(false)
+    expect(heightProperty()).toBe('')
+  })
+})

--- a/tests/styles/style-regressions.test.ts
+++ b/tests/styles/style-regressions.test.ts
@@ -70,6 +70,39 @@ describe('style regressions', () => {
     expect(visiblePane).toMatch(/display:\s*flex;/)
   })
 
+  test('the AI pane splitter is a row-resize handle that hides while collapsed', () => {
+    const css = styles()
+    const resizer = readRule(css, '.ai-pane-resizer {')
+    expect(resizer).toMatch(/cursor:\s*row-resize;/)
+    expect(resizer).toMatch(/flex-shrink:\s*0;/)
+
+    // A resting grip keeps the splitter discoverable, and the active states
+    // stay translucent — a solid accent band is too loud at 6px.
+    const grip = readRule(css, '.ai-pane-resizer::after {')
+    expect(grip).toMatch(/background:\s*var\(--background-modifier-border\);/)
+    const dragging = readRule(css, '.ai-pane-resizer.is-dragging {')
+    expect(dragging).toMatch(/color-mix\(in srgb, var\(--interactive-accent\)/)
+    expect(dragging).not.toMatch(/background:\s*var\(--interactive-accent\);/)
+    // The handle sits inside the container so it inherits --visible; it must
+    // still disappear when the pane is collapsed to its header row.
+    const collapsed = readRule(css, '.ai-pane-container--collapsed .ai-pane-resizer {')
+    expect(collapsed).toMatch(/display:\s*none;/)
+  })
+
+  test('a drag-resized AI pane height beats the terminal share but loses to expanded', () => {
+    const css = styles()
+    const sized = readRule(css, '.ai-pane-container--sized {')
+    expect(sized).toMatch(/height:\s*var\(--tc-ai-pane-height\);/)
+    expect(sized).toMatch(/flex-basis:\s*var\(--tc-ai-pane-height\);/)
+
+    // Same specificity throughout, so source order decides the winner.
+    const terminalIndex = css.indexOf('.ai-pane-container--terminal {')
+    const sizedIndex = css.indexOf('.ai-pane-container--sized {')
+    const expandedIndex = css.indexOf('.ai-pane-container--expanded {')
+    expect(terminalIndex).toBeLessThan(sizedIndex)
+    expect(sizedIndex).toBeLessThan(expandedIndex)
+  })
+
   test('AI terminal close controls reveal on hover/focus and remain usable on touch', () => {
     const css = styles()
     const runClose = readRule(css, '.ai-run-pane__run-close {')


### PR DESCRIPTION
## Why

The AI run pane below the task list could only be one of two heights: the 40% share the stylesheet hardcodes, or the full view via the ⤢ toggle. There was no way to give the log a little more room, or to keep the task list dominant while a run streams.

## What

A splitter row between the task list and the pane, dragged with the pointer.

- **`src/features/ai-task/ui/AiPaneResizer.ts`** (new) — the handle and the pointer math. Heights are carried as a **share of the view height**, never pixels, so a stored value survives a leaf split or a window resize. Clamped to a 120px floor and a 90% ceiling.
- **Placement** — the handle is the first child of `.ai-pane-container` rather than a sibling between the two columns. That way it inherits the container's `--visible` state instead of needing its own visibility sync (CSS cannot select a previous sibling), and `TaskViewLayout` stays untouched.
- **Persistence** — the ratio goes to `App#saveLocalStorage` under `taskchute-plus.ai-pane-height-ratio`, next to the existing expanded and sidebar preferences. Written when the gesture settles, not on every pointer move.
- **⤢ interaction** — dragging out of the expanded mode clears it, so the toggle then flips between the dragged height and full height.
- **PTY sizing** — `computeTerminalSize()` reports the dragged share instead of the fixed `0.4`, so the terminal grid follows the new pane height.
- **Accessibility** — `role="separator"`, focusable, ArrowUp/ArrowDown nudge by 16px, Home (or a double click) drops back to the stylesheet default.

Unsized panes behave exactly as before — content height capped at 40%, a fixed 40% for terminals, 100% while expanded — so nothing changes until the splitter is used.

## Visual

The handle rests as a short centred grip and tints translucently on hover and while dragging; a solid accent band read as an error state at 6px tall.

## Tests

- `tests/features/ai-task/ai-run-pane-resize.test.ts` (new, 13 cases): drag in both directions, both clamps, persistence only on settle, `pointercancel` leaving the stored value alone, mount-time restore not writing back, expanded handoff, keyboard and reset, the collapsed chrome class, the PTY grid following the drag, and unmount cleanup.
- `tests/styles/style-regressions.test.ts`: the handle's `row-resize` affordance and collapsed hiding, plus the source-order contract that `--sized` beats `--terminal` and loses to `--expanded` (all three have equal specificity).

Full suite green (3192 tests), build and lint clean.