### PR TITLE
Draw the icon controls with Lucide instead of emoji and ASCII

### DIFF
--- a/src/features/ai-task/ui/AiRunPaneController.ts
+++ b/src/features/ai-task/ui/AiRunPaneController.ts
@@ -1009,9 +1009,9 @@ export class AiRunPaneController {
     const addLabel = this.host.tv('aiTask.newShell', 'New terminal session')
     const addButton = tabstrip.createEl('button', {
       cls: 'ai-run-pane__add',
-      text: '+',
       attr: { 'aria-label': addLabel, title: addLabel },
     })
+    setIcon(addButton, 'plus')
     addButton.addEventListener('click', (event) => {
       event.stopPropagation()
       this.handleNewShell(panel)
@@ -1802,7 +1802,6 @@ export class AiRunPaneController {
       )
       tab.createSpan({
         cls: `ai-run-pane__tab-dot ai-run-pane__tab-dot--${record.status}`,
-        text: '●',
         attr: { title: statusLabel },
       })
       tab.createSpan({

--- a/src/features/ai-task/ui/WorkspaceFileEditorController.ts
+++ b/src/features/ai-task/ui/WorkspaceFileEditorController.ts
@@ -442,7 +442,7 @@ export class WorkspaceFileEditorController {
     })
     tabElement.createSpan({ cls: 'ai-run-pane__file-tab-title', text: tab.title })
     if (isDirty(tab)) {
-      tabElement.createSpan({ cls: 'ai-run-pane__file-tab-dirty', text: '•' })
+      tabElement.createSpan({ cls: 'ai-run-pane__file-tab-dirty' })
     }
     const close = tabElement.createEl('button', {
       cls: 'ai-run-pane__file-tab-close ai-run-pane__work-tab-close',

--- a/src/features/log/modals/BackupRestoreModal.ts
+++ b/src/features/log/modals/BackupRestoreModal.ts
@@ -1,6 +1,7 @@
 import { App, Modal } from 'obsidian'
 import type { BackupEntry, BackupPreview } from '../services/BackupRestoreService'
 import { getCurrentLocale } from '../../../i18n'
+import { applyIcon } from '../../../ui/icons'
 
 const JA_WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
 const EN_WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -292,10 +293,10 @@ class BackupConfirmModal extends Modal {
 
     // Left arrow
     const prevButton = headerEl.createEl('button', {
-      text: '←',
       cls: 'backup-preview-nav-button',
       attr: { 'aria-label': this.tv('prevDay', 'Previous day') },
     })
+    applyIcon(prevButton, 'chevron-left')
     prevButton.addEventListener('click', () => {
       void this.navigateDate(-1)
     })
@@ -308,10 +309,10 @@ class BackupConfirmModal extends Modal {
 
     // Right arrow
     const nextButton = headerEl.createEl('button', {
-      text: '→',
       cls: 'backup-preview-nav-button',
       attr: { 'aria-label': this.tv('nextDay', 'Next day') },
     })
+    applyIcon(nextButton, 'chevron-right')
     nextButton.addEventListener('click', () => {
       void this.navigateDate(1)
     })

--- a/src/features/recipe/ui/RecipeEditorForm.ts
+++ b/src/features/recipe/ui/RecipeEditorForm.ts
@@ -1,4 +1,5 @@
 import { t } from '../../../i18n'
+import { applyIcon } from '../../../ui/icons'
 
 let recipeEditorFormId = 0
 
@@ -307,7 +308,6 @@ export class RecipeEditorForm {
 
       const remove = row.createEl('button', {
         cls: 'form-button cancel recipe-step-remove-button',
-        text: '×',
         attr: {
           type: 'button',
           title: isQuality
@@ -318,6 +318,7 @@ export class RecipeEditorForm {
             : t('recipes.manager.removeStep', '手順を削除'),
         },
       })
+      applyIcon(remove, 'x')
       remove.addEventListener('click', () => {
         const next = [...this.getValues(kind)]
         next.splice(index, 1)

--- a/src/features/routine/modals/RoutineManagerModal.ts
+++ b/src/features/routine/modals/RoutineManagerModal.ts
@@ -2,6 +2,7 @@ import { App, Modal, Notice, TFile, WorkspaceLeaf } from 'obsidian'
 ;
 
 import { t } from '../../../i18n';
+import { applyIcon } from '../../../ui/icons';
 
 import {
   RoutineFrontmatter,
@@ -307,10 +308,10 @@ export class RoutineManagerModal extends Modal {
       cls: 'routine-table__action-button',
     });
     const deleteBtn = actionsCell.createEl('button', {
-      text: '🗑️',
       cls: 'routine-table__action-button routine-table__action-button--danger',
       attr: { title: this.tv('tooltips.removeRoutine', 'Remove from routine') },
     });
+    applyIcon(deleteBtn, 'trash-2');
 
     editBtn.addEventListener('click', () => {
       const { file: currentFile } = this.filtered[index];

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -254,6 +254,8 @@ export const en = {
     header: {
       openNavigation: "Open navigation",
       openCalendar: "Open calendar",
+      previousDay: "Previous day",
+      nextDay: "Next day",
       addTask: "Add new task",
       openTerminal: `Open ${TERMINAL_NAME}`,
       terminalOpenFailed: "Failed to open terminal: {message}",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -247,6 +247,8 @@ export const ja = {
     header: {
       openNavigation: "ナビゲーションを開く",
       openCalendar: "カレンダーを開く",
+      previousDay: "前日",
+      nextDay: "翌日",
       addTask: "新しいタスクを追加",
       openTerminal: "ターミナルを開く",
       terminalOpenFailed: "ターミナルを開けませんでした: {message}",

--- a/src/ui/components/TaskMoveCalendar.ts
+++ b/src/ui/components/TaskMoveCalendar.ts
@@ -1,6 +1,7 @@
 import 'obsidian'
 import type { LocaleKey } from "../../i18n"
 import { getCurrentLocale, t } from "../../i18n"
+import { applyIcon } from "../icons"
 
 export interface TaskMoveCalendarOptions {
   anchor: HTMLElement
@@ -159,7 +160,7 @@ export class TaskMoveCalendar implements TaskMoveCalendarHandle {
         ),
       },
     })
-    prevBtn.textContent = "‹"
+    applyIcon(prevBtn, 'chevron-left')
     prevBtn.addEventListener("click", () => {
       this.changeMonth(-1)
     })
@@ -178,7 +179,7 @@ export class TaskMoveCalendar implements TaskMoveCalendarHandle {
         ),
       },
     })
-    nextBtn.textContent = "›"
+    applyIcon(nextBtn, 'chevron-right')
     nextBtn.addEventListener("click", () => {
       this.changeMonth(1)
     })

--- a/src/ui/header/TaskHeaderController.ts
+++ b/src/ui/header/TaskHeaderController.ts
@@ -1,4 +1,5 @@
 import { Notice, App, setIcon } from 'obsidian'
+import { applyIcon, createIconSpan } from '../icons'
 import TaskMoveCalendar, {
   TaskMoveCalendarFactory,
   TaskMoveCalendarHandle,
@@ -124,7 +125,7 @@ export default class TaskHeaderController {
         'aria-label': this.host.tv('header.openNavigation', 'Open navigation'),
       },
     })
-    drawerToggle.createSpan( { cls: 'drawer-toggle-icon', text: '☰' })
+    createIconSpan(drawerToggle, 'menu', 'drawer-toggle-icon')
     this.host.registerManagedDomEvent(drawerToggle, 'click', (event) => {
       event.stopPropagation()
       this.host.toggleNavigation()
@@ -137,21 +138,29 @@ export default class TaskHeaderController {
 
     const leftBtn = navContainer.createEl('button', {
       cls: 'date-nav-arrow',
-      text: '<',
+      attr: {
+        title: this.host.tv('header.previousDay', 'Previous day'),
+        'aria-label': this.host.tv('header.previousDay', 'Previous day'),
+      },
     })
+    applyIcon(leftBtn, 'chevron-left')
     const calendarBtn = navContainer.createEl('button', {
       cls: 'calendar-btn',
-      text: '🗓️',
       attr: {
         title: this.host.tv('header.openCalendar', 'Open calendar'),
         'aria-label': this.host.tv('header.openCalendar', 'Open calendar'),
       },
     })
+    applyIcon(calendarBtn, 'calendar')
     const dateLabel = navContainer.createSpan( { cls: 'date-nav-label' })
     const rightBtn = navContainer.createEl('button', {
       cls: 'date-nav-arrow',
-      text: '>',
+      attr: {
+        title: this.host.tv('header.nextDay', 'Next day'),
+        'aria-label': this.host.tv('header.nextDay', 'Next day'),
+      },
     })
+    applyIcon(rightBtn, 'chevron-right')
 
     this.dateLabelEl = dateLabel
     this.refreshDateLabel()
@@ -188,12 +197,12 @@ export default class TaskHeaderController {
     if (this.host.plugin.settings.aiRobotButtonEnabled === true) {
       const robotButton = actionSection.createEl('button', {
         cls: 'robot-terminal-button',
-        text: '🤖',
         attr: {
           title: this.host.tv('header.openTerminal', 'Open terminal'),
           'aria-label': this.host.tv('header.openTerminal', 'Open terminal'),
         },
       })
+      applyIcon(robotButton, 'bot')
       this.host.registerManagedDomEvent(robotButton, 'click', (event) => {
         void (async () => {
           event.stopPropagation()
@@ -231,12 +240,12 @@ export default class TaskHeaderController {
 
     const addTaskButton = actionSection.createEl('button', {
       cls: 'add-task-button repositioned',
-      text: '+',
       attr: {
         title: this.host.tv('header.addTask', 'Add new task'),
         'aria-label': this.host.tv('header.addTask', 'Add new task'),
       },
     })
+    applyIcon(addTaskButton, 'plus')
 
     this.host.registerManagedDomEvent(addTaskButton, 'click', (event) => {
       event.stopPropagation()

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1,0 +1,28 @@
+import { setIcon } from 'obsidian'
+
+/**
+ * Lucide icon helpers.
+ *
+ * Obsidian bundles Lucide and exposes it through `setIcon()`, so the plugin
+ * never ships an icon font or an extra dependency of its own. Everything that
+ * used to be a literal emoji or an ASCII glyph ('<', '+', '×' …) goes through
+ * these helpers so the markup stays uniform: an element carrying
+ * `taskchute-icon` whose `<svg>` inherits `currentColor` and is sized by the
+ * `--taskchute-icon-size` custom property (16px unless a caller overrides it).
+ */
+const ICON_CLASS = 'taskchute-icon'
+
+/** Replace an element's content with `icon`, tagging it for the shared sizing rules. */
+export function applyIcon(el: HTMLElement, icon: string): void {
+  el.empty()
+  el.addClass(ICON_CLASS)
+  el.setAttr('data-icon', icon)
+  setIcon(el, icon)
+}
+
+/** Create a `<span>` holding `icon`, optionally keeping a caller-owned class. */
+export function createIconSpan(parent: HTMLElement, icon: string, cls?: string): HTMLSpanElement {
+  const span = parent.createSpan(cls ? { cls } : {})
+  applyIcon(span, icon)
+  return span
+}

--- a/src/ui/navigation/NavigationController.ts
+++ b/src/ui/navigation/NavigationController.ts
@@ -1,3 +1,4 @@
+import { createIconSpan } from '../icons'
 import NavigationSectionController, {
   NavigationSection,
   NavigationSectionHost,
@@ -88,14 +89,14 @@ export default class NavigationController {
 
   private renderNavigationItems(navMenu: HTMLElement): void {
     const items: NavigationItem[] = [
-      { key: 'routine', label: this.view.tv('navigation.routine', 'ルーチン'), icon: '🔄' },
-      { key: 'review', label: this.view.tv('navigation.review', 'デビュー'), icon: '📋' },
-      { key: 'log', label: this.view.tv('navigation.log', 'ログ'), icon: '📊' },
+      { key: 'routine', label: this.view.tv('navigation.routine', 'ルーチン'), icon: 'repeat' },
+      { key: 'review', label: this.view.tv('navigation.review', 'デビュー'), icon: 'clipboard-list' },
+      { key: 'log', label: this.view.tv('navigation.log', 'ログ'), icon: 'bar-chart-3' },
       ...(this.isRecipeFeatureEnabled()
-        ? [{ key: 'recipes' as const, label: this.view.tv('navigation.recipes', 'レシピ'), icon: '📄' }]
+        ? [{ key: 'recipes' as const, label: this.view.tv('navigation.recipes', 'レシピ'), icon: 'file-text' }]
         : []),
-      { key: 'projects', label: this.view.tv('navigation.projects', 'プロジェクト'), icon: '📁' },
-      { key: 'settings', label: this.view.tv('navigation.settings', '設定'), icon: '⚙️' },
+      { key: 'projects', label: this.view.tv('navigation.projects', 'プロジェクト'), icon: 'folder' },
+      { key: 'settings', label: this.view.tv('navigation.settings', '設定'), icon: 'settings' },
     ]
 
     items.forEach((item) => {
@@ -103,7 +104,7 @@ export default class NavigationController {
         cls: 'navigation-nav-item',
         attr: { 'data-section': item.key },
       })
-      navItem.createSpan( { cls: 'navigation-nav-icon', text: item.icon })
+      createIconSpan(navItem, item.icon, 'navigation-nav-icon')
       navItem.createSpan( { cls: 'navigation-nav-label', text: item.label })
       this.bindDomEvent(navItem, 'click', () => {
         void this.handleNavigationItemClick(item.key)

--- a/src/ui/project/ProjectBoardView.ts
+++ b/src/ui/project/ProjectBoardView.ts
@@ -1,6 +1,7 @@
 import { App, EventRef, ItemView, Notice, TFile, WorkspaceLeaf } from 'obsidian'
 
 import type { TaskChutePluginLike } from '../../types'
+import { applyIcon } from '../icons'
 import {
   ProjectBoardItem,
   ProjectBoardStatus,
@@ -187,9 +188,9 @@ export class ProjectBoardView extends ItemView {
     const actions = header.createDiv( { cls: 'project-board-column__actions' })
     const addButton = actions.createEl('button', {
       cls: 'project-board-button project-board-button--add',
-      text: '+',
       attr: { 'aria-label': this.translate('projectBoard.actions.addProject', 'Add new project') },
     })
+    applyIcon(addButton, 'plus')
     addButton.addEventListener('click', () => this.handleCreateProject(definition.id))
   }
 

--- a/src/ui/project/ProjectController.ts
+++ b/src/ui/project/ProjectController.ts
@@ -2,6 +2,7 @@ import { Notice, TFile } from 'obsidian'
 import { TaskData, TaskInstance, TaskChutePluginLike, ProjectBoardStatus } from '../../types'
 import ProjectSettingsModal from '../modals/ProjectSettingsModal'
 import { listFilesInFolder } from '../../utils/vaultFiles'
+import { applyIcon, createIconSpan } from '../icons'
 
 export interface ProjectControllerHost {
   app: TaskChutePluginLike['app']
@@ -213,7 +214,7 @@ export default class ProjectController {
           title: this.host.tv('project.tooltipAssigned', 'Project: {title}', { title: displayName }),
         },
       })
-      projectButton.createSpan( { cls: 'taskchute-project-icon', text: '📁' })
+      createIconSpan(projectButton, 'folder', 'taskchute-project-icon')
       projectButton.createSpan( { cls: 'taskchute-project-name', text: displayName })
       projectButton.addEventListener('click', (event) => {
         event.stopPropagation()
@@ -222,9 +223,9 @@ export default class ProjectController {
 
       const externalLink = projectDisplay.createSpan( {
         cls: 'taskchute-external-link',
-        text: '🔗',
         attr: { title: this.host.tv('project.openNote', 'Open project note') },
       })
+      applyIcon(externalLink, 'external-link')
       externalLink.addEventListener('click', (event) => {
         void (async () => {
           event.stopPropagation()

--- a/src/ui/task/TaskCompletionController.ts
+++ b/src/ui/task/TaskCompletionController.ts
@@ -4,6 +4,7 @@ import { ProjectNoteSyncService } from '../../features/project/services/ProjectN
 import type { TaskInstance, PathManagerLike } from '../../types'
 import type { TaskLogEntry } from '../../types/ExecutionLog'
 import { parseTaskLogSnapshot } from '../../utils/executionLogUtils'
+import { applyIcon } from '../icons'
 
 export interface TaskCompletionControllerHost {
   tv: (key: string, fallback: string, vars?: Record<string, string | number>) => string
@@ -177,8 +178,8 @@ export default class TaskCompletionController {
     for (let i = 1; i <= 5; i += 1) {
       const star = ratingEl.createSpan( {
         cls: `star ${i <= options.initial ? 'taskchute-star-filled' : 'taskchute-star-empty'}`,
-        text: '⭐',
       })
+      applyIcon(star, 'star')
       star.addEventListener('click', () => this.setRating(ratingEl, i))
       star.addEventListener('mouseenter', () => this.highlightRating(ratingEl, i))
       star.addEventListener('mouseleave', () => this.resetRatingHighlight(ratingEl))

--- a/src/ui/task/TaskCreationController.ts
+++ b/src/ui/task/TaskCreationController.ts
@@ -7,6 +7,7 @@ import {
   TaskNameSuggestion,
 } from "../components/TaskNameAutocomplete"
 import { createNameModal } from "../components/NameModal"
+import { applyIcon } from "../icons"
 import type {
   CreateTaskFileAiTaskOptions,
   TaskCreationService,
@@ -121,14 +122,15 @@ const AI_AGENT_CARDS: ReadonlyArray<{
 }> = [
   {
     host: "claude",
-    // Reference parity: main-agents.ts gives Claude Code the 👑 icon.
-    icon: "👑",
+    // Reference parity: main-agents.ts crowns Claude Code; Lucide's `crown`
+    // stands in for the reference's 👑 emoji.
+    icon: "crown",
     labelKey: "addTask.aiAgentClaude",
     labelFallback: "Claude Code",
   },
   {
     host: "codex",
-    icon: "📜",
+    icon: "scroll",
     labelKey: "addTask.aiAgentCodex",
     labelFallback: "Codex",
   },
@@ -811,7 +813,7 @@ export default class TaskCreationController {
       card.dataset.aiHost = cardDef.host
       const icon = doc.win.createSpan()
       icon.className = "ai-task-agent-icon"
-      icon.textContent = cardDef.icon
+      applyIcon(icon, cardDef.icon)
       const name = doc.win.createSpan()
       name.className = "ai-task-agent-name"
       name.textContent = this.host.tv(cardDef.labelKey, cardDef.labelFallback)

--- a/src/ui/tasklist/TaskItemActionController.ts
+++ b/src/ui/tasklist/TaskItemActionController.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'obsidian'
+import { applyIcon, createIconSpan } from '../icons'
 import type { TaskInstance } from '../../types'
 
 export interface TaskItemActionHost {
@@ -83,7 +84,7 @@ export class TaskItemActionController {
           title: this.host.tv('project.tooltipAssigned', 'Project: {title}', { title: displayTitle }),
         },
       })
-      projectButton.createSpan( { cls: 'taskchute-project-icon', text: '📁' })
+      createIconSpan(projectButton, 'folder', 'taskchute-project-icon')
       projectButton.createSpan( { cls: 'taskchute-project-name', text: displayTitle })
       this.registerTapEvent(projectButton, (event) => {
         event.stopPropagation()
@@ -96,11 +97,11 @@ export class TaskItemActionController {
 
       const externalLink = wrapper.createSpan( {
         cls: 'taskchute-external-link',
-        text: '🔗',
         attr: {
           title: this.host.tv('project.openNote', 'Open project note'),
         },
       })
+      applyIcon(externalLink, 'external-link')
       this.registerTapEvent(externalLink, (event) => {
         event.stopPropagation()
         const path = inst.task.projectPath ?? ''
@@ -132,9 +133,9 @@ export class TaskItemActionController {
   renderCommentButton(taskItem: HTMLElement, inst: TaskInstance): void {
     const button = taskItem.createEl('button', {
       cls: 'comment-button',
-      text: '💬',
       attr: { 'data-task-state': inst.state },
     })
+    applyIcon(button, 'message-square')
 
     if (inst.state !== 'done') {
       button.classList.add('disabled')
@@ -165,13 +166,13 @@ export class TaskItemActionController {
     const isRoutineEnabled = inst.task.isRoutine && inst.task.routine_enabled !== false
     const button = taskItem.createEl('button', {
       cls: `routine-button ${isRoutineEnabled ? 'active' : ''}`,
-      text: '🔄',
       attr: {
         title: inst.task.isRoutine
           ? this.host.tv('tooltips.routineAssigned', 'Routine task')
           : this.host.tv('tooltips.routineSet', 'Set as routine'),
       },
     })
+    applyIcon(button, 'repeat')
 
     this.registerTapEvent(button, (event) => {
       event.stopPropagation()
@@ -190,9 +191,9 @@ export class TaskItemActionController {
   renderSettingsButton(taskItem: HTMLElement, inst: TaskInstance): void {
     const button = taskItem.createEl('button', {
       cls: 'settings-task-button',
-      text: '⚙️',
       attr: { title: this.host.tv('forms.taskSettings', 'Task settings') },
     })
+    applyIcon(button, 'settings')
 
     this.registerTapEvent(button, (event) => {
       event.stopPropagation()

--- a/src/ui/tasklist/TaskRowController.ts
+++ b/src/ui/tasklist/TaskRowController.ts
@@ -1,4 +1,5 @@
 import { Notice, Platform } from 'obsidian'
+import { applyIcon } from '../icons'
 import type { TaskInstance } from '../../types'
 import { ReminderIconRenderer } from '../../features/reminder/ui/ReminderIconRenderer'
 import { RecipeIconRenderer, type RecipeProgressSummary } from '../../features/recipe/ui/RecipeIconRenderer'
@@ -82,27 +83,27 @@ export default class TaskRowController {
 
   renderPlayStopButton(taskItem: HTMLElement, inst: TaskInstance, isFutureTask: boolean): void {
     let cls = 'play-stop-button'
-    let label = '▶️'
+    let icon = 'play'
     let title = this.host.tv('buttons.start', 'Start')
 
     if (isFutureTask) {
       cls += ' future-task-button'
-      label = '—'
+      icon = 'minus'
       title = this.host.tv('notices.futureTaskPrevented', 'Cannot start future tasks')
     } else if (inst.state === 'running') {
       cls += ' stop'
-      label = '⏹'
+      icon = 'square'
       title = this.host.tv('buttons.stop', 'Stop')
     } else if (inst.state === 'done') {
-      label = '☑️'
+      icon = 'check-square'
       title = this.host.tv('buttons.remeasureCompleted', 'Re-measure completed task')
     }
 
     const button = taskItem.createEl('button', {
       cls,
-      text: label,
       attr: { title },
     })
+    applyIcon(button, icon)
 
     if (isFutureTask) {
       button.disabled = true

--- a/src/ui/time/MobileTimePicker.ts
+++ b/src/ui/time/MobileTimePicker.ts
@@ -1,4 +1,5 @@
 import { Notice } from 'obsidian'
+import { applyIcon } from '../icons'
 import type { TimePicker, TimePickerOptions } from './TimePickerFactory'
 
 /**
@@ -117,7 +118,7 @@ export class MobileTimePicker implements TimePicker {
       'taskchute-mobile-time-picker-btn',
       'taskchute-mobile-time-picker-btn-reset',
     )
-    resetBtn.textContent = '↺'
+    applyIcon(resetBtn, 'rotate-ccw')
     resetBtn.setAttribute('aria-label', 'Reset')
     resetBtn.addEventListener('click', this.handleReset)
     buttonsContainer.appendChild(resetBtn)

--- a/src/ui/time/TimeEditPopup.ts
+++ b/src/ui/time/TimeEditPopup.ts
@@ -1,4 +1,5 @@
 import { Notice } from 'obsidian'
+import { applyIcon } from '../icons'
 import type { TimePicker, TimePickerOptions } from './TimePickerFactory'
 
 /** @deprecated Use TimePickerOptions from TimePickerFactory instead */
@@ -25,19 +26,19 @@ export default class TimeEditPopup implements TimePicker {
     input.classList.add('taskchute-time-popup-input')
     container.appendChild(input)
 
-    // Save button (✓)
+    // Save button
     const saveBtn = createEl('button')
     saveBtn.type = 'button'
     saveBtn.classList.add('taskchute-time-popup-btn', 'taskchute-time-popup-btn-save')
-    saveBtn.textContent = '✓'
+    applyIcon(saveBtn, 'check')
     saveBtn.setAttribute('aria-label', 'Save')
     container.appendChild(saveBtn)
 
-    // Cancel button (✕)
+    // Cancel button
     const cancelBtn = createEl('button')
     cancelBtn.type = 'button'
     cancelBtn.classList.add('taskchute-time-popup-btn', 'taskchute-time-popup-btn-cancel')
-    cancelBtn.textContent = '✕'
+    applyIcon(cancelBtn, 'x')
     cancelBtn.setAttribute('aria-label', 'Cancel')
     container.appendChild(cancelBtn)
 
@@ -45,7 +46,7 @@ export default class TimeEditPopup implements TimePicker {
     const resetBtn = createEl('button')
     resetBtn.type = 'button'
     resetBtn.classList.add('taskchute-time-popup-btn', 'taskchute-time-popup-btn-reset')
-    resetBtn.textContent = '↺'
+    applyIcon(resetBtn, 'rotate-ccw')
     resetBtn.setAttribute('aria-label', 'Reset')
     container.appendChild(resetBtn)
 

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,31 @@
   --tc-shadow-popup: 0 2px 8px rgba(0, 0, 0, 0.15);
   --tc-shadow-modal: 0 4px 20px rgba(0, 0, 0, 0.3);
   --tc-focus-ring: 0 0 0 2px rgba(var(--interactive-accent-rgb), 0.2);
+
+  /* Default edge length for every Lucide glyph rendered through
+     `applyIcon()` / `createIconSpan()`. Individual call sites override it by
+     redeclaring the property on the icon host. */
+  --taskchute-icon-size: 18px;
+}
+
+/* ===== Lucide icons =====
+   Obsidian bundles Lucide and exposes it via setIcon(), so the plugin ships
+   no icon font of its own. Every element that used to hold a literal emoji or
+   an ASCII glyph ('<', '+', 'x') now carries `taskchute-icon`, and these two
+   rules give all of them one sizing and colouring contract: inherit the
+   surrounding text colour, size from --taskchute-icon-size. */
+.taskchute-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: currentcolor;
+  line-height: 0;
+}
+
+.taskchute-icon svg {
+  width: var(--taskchute-icon-size, 18px);
+  height: var(--taskchute-icon-size, 18px);
+  stroke-width: 1.8;
 }
 
 /* ===== Time Edit Popup ===== */
@@ -1493,7 +1518,8 @@
 }
 
 .ai-task-agent-icon {
-  font-size: 18px;
+  --taskchute-icon-size: 18px;
+
   line-height: 1;
 }
 
@@ -1781,7 +1807,7 @@
 }
 
 .star-rating .star.taskchute-star-filled {
-  /* 選択された星は元の絵文字の色をそのまま使用（濃い金色） */
+  /* 選択された星は塗りつぶし + 等倍より少し大きく */
   opacity: 1;
   transform: scale(1.1);
 }
@@ -2000,11 +2026,12 @@
 }
 
 .taskchute-move-calendar__nav {
+  --taskchute-icon-size: 18px;
+
   background: none;
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 18px;
   padding: 4px 6px;
   border-radius: var(--tc-radius-sm);
 }
@@ -3083,16 +3110,22 @@
 
 /* Drawer Toggle Button */
 .drawer-toggle {
+  --taskchute-icon-size: 18px;
+
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--tc-radius-sm);
-  padding: 0 10px;
-  cursor: pointer;
-  font-size: 16px;
-  transition: background-color 0.2s ease;
+
+  /* Square: the box takes its edge length from the header row height it
+     already stretches to, so the menu glyph sits dead centre. */
+  padding: 0;
   height: 100%;
+  aspect-ratio: 1;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
   display: flex;
   align-items: center;
+  justify-content: center;
   grid-column: 1;
   justify-self: start;
 }
@@ -3551,9 +3584,10 @@
 }
 
 .routine-button {
+  --taskchute-icon-size: 15px;
+
   background: none;
   border: none;
-  font-size: 14px;
   cursor: pointer;
   padding: 2px;
   padding-top: 4px;
@@ -3579,7 +3613,8 @@
 
 /* コメントボタンスタイル */
 .comment-button {
-  font-size: 15px;
+  --taskchute-icon-size: 15px;
+
   border: none;
   background: none;
   cursor: pointer;
@@ -3685,7 +3720,8 @@
 
 /* フォルダアイコン */
 .taskchute-project-icon {
-  font-size: 14px;
+  --taskchute-icon-size: 14px;
+
   flex-shrink: 0;
 }
 
@@ -3698,7 +3734,8 @@
 
 /* External Linkアイコン */
 .taskchute-external-link {
-  font-size: 14px;
+  --taskchute-icon-size: 14px;
+
   cursor: pointer;
   padding: 2px 4px;
   border-radius: var(--tc-radius-sm);
@@ -3922,16 +3959,24 @@ textarea.form-textarea {
   color: var(--link-color-hover);
 }
 .play-stop-button {
-  font-size: 18px;
+  --taskchute-icon-size: 18px;
+
   border: none;
   background: none;
   cursor: pointer;
   transition: color 0.2s;
   color: #3498db;
-  padding: 2px;
-  padding-top: 4px;
+  padding: 0;
   border-radius: var(--tc-radius-sm);
-  width: 100%;
+
+  /* Square control: the icon sits in a 28x28 box centred in its cell rather
+     than stretching to the cell width, so the hover/active background reads
+     as a square button. */
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  flex-shrink: 0;
+  margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3966,7 +4011,8 @@ textarea.form-textarea {
 
 /* 設定ボタンスタイル */
 .settings-task-button {
-  font-size: 15px;
+  --taskchute-icon-size: 15px;
+
   border: none;
   background: none;
   cursor: pointer;
@@ -4114,20 +4160,24 @@ textarea.form-textarea {
   justify-content: center;
 }
 
+/* The three date-nav controls (prev / calendar / next) are one set: 24px
+   squares carrying identically sized Lucide glyphs. */
 .date-nav-arrow {
+  --taskchute-icon-size: 18px;
+
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  padding: 0;
+  flex-shrink: 0;
   background: none;
   border: none;
-  font-size: 28px;
   color: #888888;
   cursor: pointer;
-  padding: 0 8px;
   transition: color 0.2s;
 }
 
-.date-nav-container.compact .date-nav-arrow {
-  font-size: 20px;
-  padding: 0 4px;
-}
+/* Compact keeps the same square; only the surrounding gaps tighten. */
 
 .date-nav-arrow:hover {
   color: #1976d2;
@@ -4165,17 +4215,20 @@ textarea.form-textarea {
   height: 24px;
 }
 .calendar-btn {
+  --taskchute-icon-size: 18px;
+
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  padding: 0;
+  flex-shrink: 0;
   background: none;
   border: none;
-  font-size: 16px;
-  padding: 2px;
   margin-left: 6px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 24px;
-  width: 24px;
   border-radius: var(--tc-radius-md);
   transition: background 0.2s;
 }
@@ -4428,12 +4481,21 @@ textarea.form-textarea {
 }
 
 .star-rating .star {
-  font-size: 20px;
+  --taskchute-icon-size: 20px;
+
+  color: var(--color-yellow, #e0a800);
   cursor: pointer;
   transition: all var(--tc-transition);
-  display: inline-block;
   user-select: none;
   opacity: 0.3;
+}
+
+.star-rating .star svg {
+  fill: none;
+}
+
+.star-rating .star.taskchute-star-filled svg {
+  fill: currentcolor;
 }
 
 .star-rating .star:hover {
@@ -7156,11 +7218,12 @@ textarea.form-textarea {
 
 /* Reset button */
 .taskchute-mobile-time-picker-btn-reset {
+  --taskchute-icon-size: 20px;
+
   width: 44px;
   height: 44px;
   background: var(--background-modifier-border);
   color: var(--text-muted);
-  font-size: 20px;
 }
 
 .taskchute-mobile-time-picker-btn-reset:hover,
@@ -7844,7 +7907,11 @@ textarea.form-textarea {
 }
 
 .ai-run-pane__file-tab-dirty {
-  color: var(--interactive-accent);
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--interactive-accent);
+  flex-shrink: 0;
 }
 
 .ai-run-pane__work-tab-close {
@@ -8030,6 +8097,7 @@ textarea.form-textarea {
 
 .ai-run-pane__add {
   --ai-run-control-line-height: 20px;
+  --taskchute-icon-size: 14px;
 
   border: none;
   background: none;
@@ -8157,14 +8225,8 @@ textarea.form-textarea {
 }
 
 .ai-run-pane__work-tab .ai-run-pane__tab-dot {
-  display: inline;
-  width: auto;
-  height: auto;
-  border-radius: 0;
-  background: transparent;
-  color: inherit;
-  font-size: 12px;
-  line-height: 16px;
+  /* The horizontal tab strip stays calmer than the sidebar: same circle,
+     no pulse. */
   animation: none;
 }
 

--- a/tests/features/ai-task/ai-run-pane-now-playing.test.ts
+++ b/tests/features/ai-task/ai-run-pane-now-playing.test.ts
@@ -474,9 +474,11 @@ describe('AiRunPaneController NOW PLAYING layout', () => {
       expect(tabs[0].classList).toContain('ai-run-pane__work-tab')
       expect(tabs[0].querySelector('.ai-run-pane__work-tab-close')).not.toBeNull()
       expect(tabs[0].getAttribute('data-run-id')).toBe('run-a')
+      // The status dot is a CSS circle, not a '●' glyph: presence of the
+      // status-modifier class is what marks the run as running.
       expect(
-        tabs[0].querySelector('.ai-run-pane__tab-dot--running')?.textContent,
-      ).toBe('●')
+        tabs[0].querySelector('.ai-run-pane__tab-dot--running'),
+      ).not.toBeNull()
       // Terminal runs read "Terminal"; the label is the content type, not
       // the task name (that lives in the sidebar).
       expect(

--- a/tests/styles/style-regressions.test.ts
+++ b/tests/styles/style-regressions.test.ts
@@ -233,12 +233,20 @@ describe('style regressions', () => {
     const separator = readRule(css, '.ai-run-pane__work-tab::after {')
     expect(separator).toMatch(/width:\s*1px;/)
     expect(separator).toMatch(/background:\s*var\(--tc-code-border\);/)
+    // The content-tab status dot is the same CSS circle the sidebar rows use
+    // (declared once on `.ai-run-pane__tab-dot, .ai-run-pane__run-dot`); the
+    // tab strip only opts out of the pulse so it stays calmer.
+    const sharedDot = readRule(
+      css,
+      '.ai-run-pane__tab-dot,\n.ai-run-pane__run-dot {',
+    )
+    expect(sharedDot).toMatch(/border-radius:\s*50%;/)
+    expect(sharedDot).toMatch(/width:\s*8px;/)
     const terminalDot = readRule(
       css,
       '.ai-run-pane__work-tab .ai-run-pane__tab-dot {',
     )
-    expect(terminalDot).toMatch(/font-size:\s*12px;/)
-    expect(terminalDot).toMatch(/background:\s*transparent;/)
+    expect(terminalDot).toMatch(/animation:\s*none;/)
     expect(close).toMatch(/opacity:\s*0;/)
     expect(close).toMatch(/pointer-events:\s*none;/)
     expect(close).toMatch(/cursor:\s*pointer;/)

--- a/tests/ui/modals/backup-restore-modal.test.ts
+++ b/tests/ui/modals/backup-restore-modal.test.ts
@@ -63,6 +63,9 @@ jest.mock('obsidian', () => {
     App: MockApp,
     Modal,
     Notice: jest.fn(),
+    setIcon: jest.fn((element: HTMLElement, iconId: string) => {
+      element.setAttribute('data-icon', iconId)
+    }),
   }
 })
 

--- a/tests/ui/task/task-creation-controller-ai.test.ts
+++ b/tests/ui/task/task-creation-controller-ai.test.ts
@@ -725,18 +725,19 @@ describe('AI mode UI', () => {
     expect(agentCard(modal, 'codex').textContent).toContain('Codex')
   })
 
-  test('agent cards carry the reference icons (👑 Claude Code / 📜 Codex)', () => {
-    // Carried fix: the reference main-agents.ts uses 👑 for Claude Code.
+  test('agent cards carry the reference icons (crown Claude Code / scroll Codex)', () => {
+    // Carried fix: the reference main-agents.ts crowns Claude Code. The emoji
+    // pair is now drawn with the matching Lucide glyphs.
     const { host } = createHost()
     const modal = openModal(host)
     typeButton(modal, 'ai').click()
 
     expect(
-      agentCard(modal, 'claude').querySelector('.ai-task-agent-icon')?.textContent,
-    ).toBe('👑')
+      agentCard(modal, 'claude').querySelector('.ai-task-agent-icon')?.getAttribute('data-icon'),
+    ).toBe('crown')
     expect(
-      agentCard(modal, 'codex').querySelector('.ai-task-agent-icon')?.textContent,
-    ).toBe('📜')
+      agentCard(modal, 'codex').querySelector('.ai-task-agent-icon')?.getAttribute('data-icon'),
+    ).toBe('scroll')
   })
 
   test('clicking the Codex card selects it and deselects Claude Code', () => {

--- a/tests/ui/time/time-edit-popup.test.ts
+++ b/tests/ui/time/time-edit-popup.test.ts
@@ -4,6 +4,9 @@ import type { TimeEditPopupOptions } from '../../../src/ui/time/TimeEditPopup'
 
 jest.mock('obsidian', () => ({
   Notice: jest.fn(),
+  setIcon: jest.fn((element: HTMLElement, iconId: string) => {
+    element.setAttribute('data-icon', iconId)
+  }),
 }))
 
 const setActiveDocument = (doc: Document): void => {

--- a/tests/ui/time/time-picker.test.ts
+++ b/tests/ui/time/time-picker.test.ts
@@ -10,6 +10,9 @@ jest.mock('obsidian', () => ({
   Platform: {
     isMobile: false,
   },
+  setIcon: jest.fn((element: HTMLElement, iconId: string) => {
+    element.setAttribute('data-icon', iconId)
+  }),
 }))
 
 import TimeEditPopup from '../../../src/ui/time/TimeEditPopup'


### PR DESCRIPTION
## Summary

The plugin carried two visual vocabularies. The AI task surfaces, the workspace file tree and the settings tab already called `setIcon()`, which draws the Lucide set Obsidian bundles. The older core UI still spelled its controls out as characters — emoji for the navigation entries, the row actions and the star rating, and bare ASCII for the date arrows (`<`, `>`), the add buttons (`+`), the time popup and the tab closes.

Emoji render from a platform font, so they ignore the theme's colours, size unpredictably across Windows, macOS and mobile, and never match the Obsidian chrome they sit beside. Everything in that second vocabulary now goes through Lucide as well.

**No dependency is added.** `setIcon()` is what Obsidian already exposes; the change is about routing the remaining call sites through it.

## What changed

- **New helper** `src/ui/icons.ts` — `applyIcon()` / `createIconSpan()`. Every call site produces the same markup: an element carrying `taskchute-icon` and a `data-icon` attribute.
- **One styling contract** in `styles.css` — the svg inherits `currentColor` and takes its edge length from `--taskchute-icon-size`, which individual controls override.
- **ASCII glyphs replaced**: date navigation `<` `>`, drawer `☰`, add `+` (header / project board / AI pane), month arrows `‹` `›`, backup navigation `←` `→`, time popup save/cancel/reset, mobile time picker reset, recipe step remove `×`.
- **Emoji replaced**: the six navigation entries, the calendar and terminal buttons, the play/stop/complete control, the star rating, the project chip and its external link, the comment / routine / settings row actions, the routine manager's delete button, and the AI agent cards.

## Two glyphs became CSS rather than icons

- The AI pane's **status dot** rendered a `●` that a later rule forced back to inline text with `color: inherit`, quietly discarding the running / succeeded / failed colours its modifier classes already set. It is now the same circle the sidebar rows use, minus the pulse — so the tab strip finally shows run status by colour.
- The **unsaved-file marker** is a 6px dot instead of a `•`.

## Deliberately left alone

- The emoji embedded in the i18n button labels (`buttons.*`, `comment.*`, …). Removing those means stripping them from every locale and re-homing them as menu icons, which is a larger change worth its own PR.
- The ` → ` between a task's start and stop times, which is baseline-aligned text rather than a control.
- The per-extension file icons in the workspace editor, where the emoji colour carries the distinction a single-tone svg would lose.

## Sizing

Lucide strokes read lighter than the text they replace, so the shared default is 18px. The date-nav arrows, the calendar button, the drawer toggle and the play/stop control are now squares rather than boxes sized by their old glyph's advance width.

## Testing

- `npm run test` — 225 suites, 3177 tests, all passing
- `npm run lint` — no errors (one pre-existing unrelated warning in `SettingsTab.ts`)
- `npm run build` — clean

Tests that asserted on the old glyphs now assert on `data-icon`, and three suites with local `obsidian` mocks gained a `setIcon` stub.