### PR TITLE
Type the resize test's tv stub so main typechecks again

### DIFF
--- a/tests/features/ai-task/ai-run-pane-resize.test.ts
+++ b/tests/features/ai-task/ai-run-pane-resize.test.ts
@@ -101,7 +101,7 @@ describe('AI run pane drag resize', () => {
       stored.set(key, value)
     })
     host = {
-      tv: (_key, fallback) => fallback,
+      tv: (_key: string, fallback: string) => fallback,
       manager,
       createTerminalAdapter: () => {
         throw new Error('resize tests never open a terminal adapter')


### PR DESCRIPTION
## Summary

`main` has been red since #145. The Test workflow stops at the Typecheck step:

```
tests/features/ai-task/ai-run-pane-resize.test.ts(104,12): error TS7006: Parameter '_key' implicitly has an 'any' type.
tests/features/ai-task/ai-run-pane-resize.test.ts(104,18): error TS7006: Parameter 'fallback' implicitly has an 'any' type.
```

The host stub in `ai-run-pane-resize.test.ts` is built as an object literal and then cast with `as unknown as AiRunPaneControllerHost`. The inner `as unknown` erases the contextual type, so the `tv` arrow gets none of `AiRunPaneControllerHost`'s signature and `noImplicitAny` rejects both of its parameters.

Spelling the two types out is enough. `AiRunPaneControllerHost.tv` is declared as `(key: string, fallback: string, vars?: Record<string, string | number>) => string`; the stub ignores the third parameter, so a two-parameter arrow stays assignable.

Because typecheck runs before jest, the suite has not actually run on `main` for the last two commits — this unblocks it, and it unblocks the checks on #147 as well.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — no errors (one pre-existing unrelated warning in `SettingsTab.ts`)
- `npm run test` — 226 suites, 3192 tests, all passing