### PR TITLE
Drop the local token when the server no longer lists this device

### DIFF
--- a/src/features/license/config.ts
+++ b/src/features/license/config.ts
@@ -36,6 +36,15 @@ export const LICENSE_REFRESH_THRESHOLD_SEC = 24 * 60 * 60
 export const LICENSE_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000
 
 /**
+ * Floor between two device-presence checks.
+ *
+ * The check runs whenever the settings tab builds its definitions, which
+ * happens again after every control change, so without a floor a few seconds
+ * of fiddling in settings would become a burst of requests.
+ */
+export const LICENSE_DEVICE_CHECK_MIN_INTERVAL_SEC = 60
+
+/**
  * Reject a stored token when the local clock has rewound at least this far
  * behind the last time the server told us (SPEC 11-5). Offline verification
  * trusts the device clock, so winding it back would otherwise defeat expiry.

--- a/src/features/license/services/LicenseManager.ts
+++ b/src/features/license/services/LicenseManager.ts
@@ -8,6 +8,7 @@
  */
 import {
   LICENSE_CLOCK_ROLLBACK_TOLERANCE_SEC,
+  LICENSE_DEVICE_CHECK_MIN_INTERVAL_SEC,
   LICENSE_PRODUCT_ID,
   LICENSE_PUBLIC_KEY,
   LICENSE_REFRESH_THRESHOLD_SEC,
@@ -43,6 +44,14 @@ export type LicenseState =
 
 export type LicenseChangeListener = (state: LicenseState) => void
 
+/**
+ * Outcome of asking the server whether this device still holds a seat.
+ *
+ * `unknown` covers both "there was nothing to check" and "we could not ask":
+ * offline is never a reason to revoke.
+ */
+export type DeviceRegistrationCheck = 'registered' | 'released' | 'unknown'
+
 /** Why an activation attempt did not produce a token. */
 export type ActivationFailure =
   | { kind: 'invalid-input' }
@@ -72,6 +81,8 @@ export class LicenseManager {
   private state: LicenseState = { status: 'unlicensed' }
   private readonly listeners = new Set<LicenseChangeListener>()
   private refreshInFlight?: Promise<void>
+  private deviceCheckInFlight?: Promise<DeviceRegistrationCheck>
+  private lastDeviceCheckSec?: number
 
   constructor(private readonly deps: LicenseManagerDeps) {}
 
@@ -137,6 +148,70 @@ export class LicenseManager {
     return run
   }
 
+  /** Whether a device check found this device gone and latched the token off. */
+  isSeatReleased(): boolean {
+    return this.deps.store.isSeatReleased()
+  }
+
+  /**
+   * Ask the server whether this device still holds a seat.
+   *
+   * Offline verification cannot notice a seat released from another machine:
+   * the stored token stays valid for the rest of its 7-day life, and a refresh
+   * would simply claim the seat again under the same device id. So the device
+   * list is the only thing that can tell us, and only a real answer counts —
+   * every failure returns `unknown` and leaves entitlement alone.
+   */
+  async verifyDeviceRegistration(): Promise<DeviceRegistrationCheck> {
+    if (this.state.status !== 'active') return 'unknown'
+
+    const code = this.deps.getCode()
+    if (code === undefined || code.length === 0) return 'unknown'
+
+    if (this.deviceCheckInFlight) return this.deviceCheckInFlight
+
+    const now = this.now()
+    if (
+      this.lastDeviceCheckSec !== undefined &&
+      now - this.lastDeviceCheckSec < LICENSE_DEVICE_CHECK_MIN_INTERVAL_SEC
+    ) {
+      return 'unknown'
+    }
+    this.lastDeviceCheckSec = now
+
+    const run = this.doVerifyDeviceRegistration().finally(() => {
+      this.deviceCheckInFlight = undefined
+    })
+    this.deviceCheckInFlight = run
+
+    return run
+  }
+
+  private async doVerifyDeviceRegistration(): Promise<DeviceRegistrationCheck> {
+    const result = await this.listDevices()
+    if (!result.ok) {
+      // Unreachable server, rate limit, revoked license: none of these prove
+      // the seat is gone, which is the only thing this check may act on.
+      this.deps.log?.('warn', '[License] Device check failed', result.failure.kind)
+      return 'unknown'
+    }
+
+    const deviceId = this.getDeviceId()
+    if (result.devices.some((device) => device.device_id === deviceId)) return 'registered'
+
+    // The state can have moved while the request was in flight — a release from
+    // this very screen, say. Acting on a stale reading would clobber it.
+    if (this.state.status !== 'active') return 'unknown'
+
+    // The code stays in settings on purpose: data.json is synced, so clearing it
+    // here would strip the license from every other vault that shares it. The
+    // latch is device-local and stops this device alone from renewing.
+    this.deps.store.markSeatReleased(this.now())
+    this.setState({ status: 'unlicensed' })
+
+    return 'released'
+  }
+
   async listDevices(): Promise<
     { ok: true; devices: DeviceView[]; maxDevices: number } | { ok: false; failure: LicenseApiFailure }
   > {
@@ -185,6 +260,11 @@ export class LicenseManager {
     const code = this.deps.getCode()
     if (code === undefined || code.length === 0) return
 
+    // A seat released elsewhere left the code in place so other synced vaults
+    // keep working. Refreshing here would hand this device the seat straight
+    // back, undoing the release the user made deliberately.
+    if (this.deps.store.isSeatReleased()) return
+
     if (!force && !this.needsRefresh()) return
 
     await this.requestToken(code)
@@ -227,6 +307,9 @@ export class LicenseManager {
       return { ok: false, failure: { kind: 'untrusted-token', reason: verification.error } }
     }
 
+    // Only activate() gets this far while the latch is on — doRefresh() bails
+    // out first — so a new token here is always the user asking for the seat.
+    this.deps.store.clearSeatReleased()
     this.deps.store.saveToken(token, expiresAt, license, this.now())
     this.setState({ status: 'active', token: verification.token, license })
 

--- a/src/features/license/services/LicenseStore.ts
+++ b/src/features/license/services/LicenseStore.ts
@@ -32,6 +32,13 @@ export interface LicenseDeviceState {
   lastServerTimeSec?: number
   /** Last known seat/expiry figures, for display while offline. */
   license?: LicenseSummary
+  /**
+   * When this device was found missing from the license's device list, in unix
+   * seconds. Set only by a real server answer; while it is present the token is
+   * never renewed automatically, so a seat released elsewhere is not silently
+   * retaken on the next refresh.
+   */
+  seatReleasedAt?: number
 }
 
 /** Duck-typed App#loadLocalStorage / App#saveLocalStorage bridge. */
@@ -130,9 +137,36 @@ export class LicenseStore {
 
   /** Drop the token but keep the device id, so re-activation reuses the seat. */
   clearToken(): void {
-    const { deviceId, lastServerTimeSec } = this.state
-    this.state = { deviceId, ...(lastServerTimeSec !== undefined ? { lastServerTimeSec } : {}) }
+    const { deviceId, lastServerTimeSec, seatReleasedAt } = this.state
+    this.state = {
+      deviceId,
+      ...(lastServerTimeSec !== undefined ? { lastServerTimeSec } : {}),
+      ...(seatReleasedAt !== undefined ? { seatReleasedAt } : {}),
+    }
     this.write()
+  }
+
+  /**
+   * Record that the server no longer lists this device. Drops the token like
+   * clearToken(), and latches the reason so no background refresh claims the
+   * seat back — only an explicit activation may do that.
+   */
+  markSeatReleased(now: number): void {
+    this.clearToken()
+    this.state = { ...this.state, seatReleasedAt: now }
+    this.write()
+  }
+
+  /** Lift the latch. Only a successful token request has the right to do this. */
+  clearSeatReleased(): void {
+    if (this.state.seatReleasedAt === undefined) return
+    const { seatReleasedAt: _removed, ...rest } = this.state
+    this.state = rest
+    this.write()
+  }
+
+  isSeatReleased(): boolean {
+    return this.state.seatReleasedAt !== undefined
   }
 
   /**
@@ -171,6 +205,7 @@ export class LicenseStore {
     const expiresAt = readPositiveInt(record['expiresAt'])
     const lastServerTimeSec = readPositiveInt(record['lastServerTimeSec'])
     const license = readLicenseSummary(record['license'])
+    const seatReleasedAt = readPositiveInt(record['seatReleasedAt'])
 
     return {
       deviceId,
@@ -178,6 +213,7 @@ export class LicenseStore {
       ...(expiresAt !== undefined ? { expiresAt } : {}),
       ...(lastServerTimeSec !== undefined ? { lastServerTimeSec } : {}),
       ...(license !== undefined ? { license } : {}),
+      ...(seatReleasedAt !== undefined ? { seatReleasedAt } : {}),
     }
   }
 

--- a/src/features/license/ui/notifySeatReleased.ts
+++ b/src/features/license/ui/notifySeatReleased.ts
@@ -1,0 +1,56 @@
+/**
+ * The user-facing half of the device-presence check.
+ *
+ * Losing the seat is not something the user did on this machine, so it cannot
+ * pass as a Notice that scrolls away: the AI task UI simply disappears, and the
+ * only way to get it back is to activate the code again. A dialog states that.
+ */
+import type { App } from 'obsidian'
+
+import { t } from '../../../i18n'
+import { showInfoModal } from '../../../ui/modals/ConfirmModal'
+import type { DeviceRegistrationCheck, LicenseManager } from '../services/LicenseManager'
+
+export interface SeatCheckHost {
+  app: App
+  licenseManager?: LicenseManager
+  _log?: (level?: string, ...args: unknown[]) => void
+}
+
+/**
+ * Check whether this device still holds a seat and tell the user if it does
+ * not. Returns what the check found, so a caller that draws license state can
+ * redraw itself.
+ *
+ * Never throws: it runs on startup and on every settings render, neither of
+ * which may be derailed by the license server.
+ */
+export async function checkSeatRegistration(
+  host: SeatCheckHost,
+): Promise<DeviceRegistrationCheck> {
+  const manager = host.licenseManager
+  if (!manager) return 'unknown'
+
+  let result: DeviceRegistrationCheck
+  try {
+    result = await manager.verifyDeviceRegistration()
+  } catch (error) {
+    host._log?.('warn', '[License] Device check failed', error)
+    return 'unknown'
+  }
+
+  if (result !== 'released') return result
+
+  // Only ever reached once per release: the check leaves the state unlicensed,
+  // and every later call returns early on that.
+  void showInfoModal(host.app, {
+    title: t('license.seatReleased.title', 'This device was released'),
+    message: t(
+      'license.seatReleased.message',
+      'This device is no longer registered to your license, so AI tasks have been turned off here.\nTo use them on this device again, open the plugin settings and activate your license code.',
+    ),
+    confirmText: t('license.seatReleased.close', 'OK'),
+  })
+
+  return result
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -84,12 +84,9 @@ export const en = {
       statusName: "Status",
       statusActive: "Active",
       statusInactive: "Not activated",
-      statusUnlicensed: "Not activated",
       licenseIdName: "License ID",
       devicesName: "Devices",
       devicesValue: "{used} of {max} in use",
-      expiresName: "Expires",
-      expiresNever: "No expiry",
       activated: "License activated.",
       requiredNotice: "A license is required.",
       // Split so the link sits inside the sentence rather than after it.
@@ -1062,6 +1059,12 @@ export const en = {
       release: "Release",
       releasing: "Releasing…",
       released: "Device released.",
+    },
+    seatReleased: {
+      title: "This device was released",
+      message:
+        "This device is no longer registered to your license, so AI tasks have been turned off here.\nTo use them on this device again, open the plugin settings and activate your license code.",
+      close: "OK",
     },
   },
   recipes: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -80,12 +80,9 @@ export const ja = {
       statusName: "状態",
       statusActive: "有効",
       statusInactive: "未アクティベート",
-      statusUnlicensed: "未有効化",
       licenseIdName: "ライセンスID",
       devicesName: "端末",
       devicesValue: "{max}台中{used}台を使用中",
-      expiresName: "有効期限",
-      expiresNever: "無期限",
       activated: "ライセンスを有効化しました。",
       requiredNotice: "ライセンスが必要です。",
       purchaseName: "ライセンスを購入",
@@ -1058,6 +1055,12 @@ export const ja = {
       release: "解除",
       releasing: "解除しています…",
       released: "端末を解除しました。",
+    },
+    seatReleased: {
+      title: "この端末の登録が解除されました",
+      message:
+        "この端末はライセンスに登録されていないため、AI タスクを無効にしました。\nこの端末で使い直すには、設定画面でライセンスコードをアクティベートしてください。",
+      close: "OK",
     },
   },
   recipes: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import type { ReminderSystemManager } from "./features/reminder/services/Reminde
 import type { AiTaskManager } from "./features/ai-task/services/AiTaskManager"
 import type { LicenseManager } from "./features/license/services/LicenseManager"
 import { LICENSE_REFRESH_INTERVAL_MS } from "./features/license/config"
+import { checkSeatRegistration } from "./features/license/ui/notifySeatReleased"
 import { syncAiTaskManagerToLicense } from "./features/ai-task/licenseGate"
 import { notifyAiTaskSettingsChanged } from "./features/ai-task/notifyAiTaskSettingsChanged"
 import {
@@ -133,9 +134,16 @@ export default class TaskChutePlusPlugin extends Plugin {
     )
 
     const refresh = () => {
-      void manager.refreshIfNeeded().catch((error) => {
-        this._log('warn', '[License] Refresh failed', error)
-      })
+      void manager
+        .refreshIfNeeded()
+        .catch((error) => {
+          this._log('warn', '[License] Refresh failed', error)
+        })
+        // A seat released from another machine leaves this device's token valid
+        // for the rest of its life, so the refresh alone would never notice.
+        // Runs after it so a token just renewed is checked against the list it
+        // renewed from, not the one before.
+        .then(() => checkSeatRegistration(this))
     }
 
     this.app.workspace.onLayoutReady(refresh)

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -1,4 +1,5 @@
 import { App, PluginSettingTab, type SettingDefinitionItem } from "obsidian"
+import { checkSeatRegistration } from "../features/license/ui/notifySeatReleased"
 import type { PluginWithSettings } from "./pluginWithSettings"
 import { ProUnlockState } from "./proUnlockState"
 import { everydaySections, trailingSections } from "./sections"
@@ -78,6 +79,17 @@ export class TaskChuteSettingTab extends PluginSettingTab {
   }
 
   getSettingDefinitions(): SettingDefinitionItem[] {
+    // Obsidian calls this on every display(), which makes it the hook for
+    // "the settings screen was opened" — the moment someone is most likely to
+    // wonder why the AI settings are still there after releasing this device
+    // elsewhere. The manager throttles the request, so the extra calls a
+    // rebuild makes cost nothing.
+    void checkSeatRegistration(this.plugin).then((result) => {
+      // The runtime is torn down by the license listener in main.ts; only the
+      // definitions this tab drew from the old state still need replacing.
+      if (result === "released") this.update()
+    })
+
     return this.modules.flatMap((module) => module.items(this.ctx))
   }
 

--- a/src/settings/sections/pro/license.ts
+++ b/src/settings/sections/pro/license.ts
@@ -181,24 +181,14 @@ function activeLicenseRows(
   applyLicenseChange: () => Promise<void>,
 ): SettingDefinitionItem[] {
   const summary = manager.getLicenseSummary()
-  const rows: SettingDefinitionItem[] = [
-    {
-      name: t("settings.license.statusName", "Status"),
-      desc: t("settings.license.statusActive", "Active"),
-    },
-  ]
+  // No status or expiry rows: the page header already says "Active", and the
+  // seats below are the only part of an active license anyone acts on.
+  const rows: SettingDefinitionItem[] = []
 
   if (summary) {
     rows.push({
       name: t("settings.license.licenseIdName", "License ID"),
       desc: formatLicenseId(summary.license_id),
-    })
-    rows.push({
-      name: t("settings.license.expiresName", "Expires"),
-      desc:
-        summary.expires_at === null
-          ? t("settings.license.expiresNever", "No expiry")
-          : new Date(summary.expires_at * 1000).toLocaleDateString(),
     })
   }
 

--- a/tests/features/license/license-manager.test.ts
+++ b/tests/features/license/license-manager.test.ts
@@ -365,6 +365,109 @@ describe('device management', () => {
   })
 })
 
+describe('verifyDeviceRegistration', () => {
+  function deviceList(...deviceIds: string[]) {
+    return {
+      ok: true,
+      data: {
+        devices: deviceIds.map((device_id) => ({ device_id, last_seen_at: NOW })),
+        max_devices: 3,
+      },
+    }
+  }
+
+  function activeHarness(): Harness {
+    const harness = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    harness.store.saveToken(tokenFor(harness.store), NOW + 7 * DAY, SUMMARY, NOW)
+    harness.manager.initialize()
+    return harness
+  }
+
+  test('leaves an entitled device alone when the server still lists it', async () => {
+    const { manager, client, store } = activeHarness()
+    client.listDevices.mockResolvedValue(deviceList(manager.getDeviceId(), 'DEVICE-OTHER'))
+
+    await expect(manager.verifyDeviceRegistration()).resolves.toBe('registered')
+
+    expect(manager.isActive()).toBe(true)
+    expect(store.getState().token).toBeDefined()
+  })
+
+  test('drops the token when this device is gone from the license', async () => {
+    const { manager, client, store, code } = activeHarness()
+    const listener = jest.fn()
+    manager.onChange(listener)
+    client.listDevices.mockResolvedValue(deviceList('DEVICE-OTHER'))
+
+    await expect(manager.verifyDeviceRegistration()).resolves.toBe('released')
+
+    expect(manager.isActive()).toBe(false)
+    expect(store.getState().token).toBeUndefined()
+    expect(listener).toHaveBeenCalledWith({ status: 'unlicensed' })
+    // data.json is synced: clearing the code here would strip the license from
+    // every other vault that shares it.
+    expect(code.value).toBe('TCP-0000-0000-0000-0001')
+  })
+
+  test('does not retake the seat on the next refresh', async () => {
+    const { manager, client, store } = activeHarness()
+    client.listDevices.mockResolvedValue(deviceList('DEVICE-OTHER'))
+    client.issueToken.mockResolvedValue(issued(tokenFor(store), NOW + 7 * DAY))
+
+    await manager.verifyDeviceRegistration()
+    await manager.refreshIfNeeded(true)
+
+    expect(client.issueToken).not.toHaveBeenCalled()
+    expect(manager.isActive()).toBe(false)
+  })
+
+  test('re-activating lifts the latch', async () => {
+    const { manager, client, store } = activeHarness()
+    client.listDevices.mockResolvedValue(deviceList('DEVICE-OTHER'))
+    await manager.verifyDeviceRegistration()
+
+    client.issueToken.mockResolvedValue(issued(tokenFor(store), NOW + 7 * DAY))
+    const result = await manager.activate('TCP-0000-0000-0000-0001')
+
+    // Entering the code is the user asking for the seat back, which is the one
+    // thing that may claim it.
+    expect(result.ok).toBe(true)
+    expect(manager.isActive()).toBe(true)
+    expect(store.isSeatReleased()).toBe(false)
+  })
+
+  test('an unreachable server never revokes', async () => {
+    const { manager, client, store } = activeHarness()
+    client.listDevices.mockResolvedValue({ ok: false, kind: 'network', status: 0 })
+
+    await expect(manager.verifyDeviceRegistration()).resolves.toBe('unknown')
+
+    expect(manager.isActive()).toBe(true)
+    expect(store.getState().token).toBeDefined()
+    expect(store.isSeatReleased()).toBe(false)
+  })
+
+  test('skips the request when there is nothing to protect', async () => {
+    const { manager, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    manager.initialize()
+
+    await expect(manager.verifyDeviceRegistration()).resolves.toBe('unknown')
+    expect(client.listDevices).not.toHaveBeenCalled()
+  })
+
+  test('throttles repeat checks', async () => {
+    const { manager, client } = activeHarness()
+    client.listDevices.mockResolvedValue(deviceList(manager.getDeviceId()))
+
+    await manager.verifyDeviceRegistration()
+    // The settings tab rebuilds its definitions after every control change; one
+    // request per rebuild would be a burst.
+    await expect(manager.verifyDeviceRegistration()).resolves.toBe('unknown')
+
+    expect(client.listDevices).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('onChange', () => {
   test('notifies on a real transition and stays quiet otherwise', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })

--- a/tests/features/license/license-store.test.ts
+++ b/tests/features/license/license-store.test.ts
@@ -107,6 +107,49 @@ describe('LicenseStore', () => {
     expect(new LicenseStore(bridge).getDeviceId()).toBe(deviceId)
   })
 
+  describe('seat release latch', () => {
+    test('markSeatReleased drops the token and survives a reload', () => {
+      const bridge = createBridge()
+      const store = new LicenseStore(bridge)
+      const deviceId = store.getDeviceId()
+      store.saveToken('TCPT1.a.b', 1787604800, SUMMARY, 1787000000)
+
+      store.markSeatReleased(1787100000)
+
+      expect(store.getState().token).toBeUndefined()
+      expect(store.isSeatReleased()).toBe(true)
+
+      // The latch has to outlive a restart, or the next launch would renew the
+      // token and take the released seat straight back.
+      const reloaded = new LicenseStore(bridge)
+      expect(reloaded.isSeatReleased()).toBe(true)
+      expect(reloaded.getState().seatReleasedAt).toBe(1787100000)
+      // Same seat on re-activation, and the rollback watermark is untouched.
+      expect(reloaded.getDeviceId()).toBe(deviceId)
+      expect(reloaded.getState().lastServerTimeSec).toBe(1787000000)
+    })
+
+    test('clearToken alone leaves an existing latch in place', () => {
+      const store = new LicenseStore(createBridge())
+      store.markSeatReleased(1787100000)
+
+      store.clearToken()
+
+      expect(store.isSeatReleased()).toBe(true)
+    })
+
+    test('clearSeatReleased lifts it', () => {
+      const bridge = createBridge()
+      const store = new LicenseStore(bridge)
+      store.markSeatReleased(1787100000)
+
+      store.clearSeatReleased()
+
+      expect(store.isSeatReleased()).toBe(false)
+      expect(new LicenseStore(bridge).isSeatReleased()).toBe(false)
+    })
+  })
+
   test('survives a storage bridge that throws', () => {
     const bridge: LicenseStorageBridge = {
       loadLocalStorage: () => {

--- a/tests/features/license/pro-settings-section.test.ts
+++ b/tests/features/license/pro-settings-section.test.ts
@@ -41,6 +41,7 @@ function fakeManager(
     listDevices: jest.fn(),
     deactivateDevice: jest.fn(),
     refreshIfNeeded: jest.fn().mockResolvedValue(undefined),
+    verifyDeviceRegistration: jest.fn().mockResolvedValue('unknown'),
     onChange: jest.fn(() => () => undefined),
     ...overrides,
   } as unknown as LicenseManager
@@ -214,12 +215,21 @@ describe('Pro settings section', () => {
       const items = proItems(activeManager())
 
       expect(names(items)).toEqual(
-        expect.arrayContaining(['Status', 'License ID', 'Expires', 'Devices']),
+        expect.arrayContaining(['License ID', 'Devices']),
       )
       const licenseId = items.find(
         (item) => 'name' in item && item.name === 'License ID',
       )
       expect((licenseId as { desc: string }).desc).toBe('8F3K-2M9Q-X7RD-4WPZ')
+    })
+
+    test('drops the status and expiry rows', () => {
+      // The page header already reads "Active", and neither row is something
+      // anyone acts on; the seats below are.
+      const shown = names(proItems(activeManager()))
+
+      expect(shown).not.toContain('Status')
+      expect(shown).not.toContain('Expires')
     })
 
     test('mounts the device list and disposes it on teardown', () => {

--- a/tests/features/license/seat-registration-check.test.ts
+++ b/tests/features/license/seat-registration-check.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Losing the seat happens on another machine, so this dialog is the only thing
+ * that tells the user why the AI task UI vanished here. It must fire on a real
+ * release and never on a failed check.
+ */
+import type { App } from 'obsidian'
+
+import { checkSeatRegistration } from '../../../src/features/license/ui/notifySeatReleased'
+import type { LicenseManager } from '../../../src/features/license/services/LicenseManager'
+
+jest.mock('../../../src/ui/modals/ConfirmModal', () => ({
+  showInfoModal: jest.fn(() => Promise.resolve()),
+}))
+
+const { showInfoModal } = require('../../../src/ui/modals/ConfirmModal') as {
+  showInfoModal: jest.Mock
+}
+
+function createHost(manager?: Partial<LicenseManager>) {
+  return {
+    app: {} as App,
+    licenseManager: manager as LicenseManager | undefined,
+    _log: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  showInfoModal.mockClear()
+})
+
+test('tells the user when the seat is gone', async () => {
+  const host = createHost({
+    verifyDeviceRegistration: jest.fn().mockResolvedValue('released'),
+  })
+
+  await expect(checkSeatRegistration(host)).resolves.toBe('released')
+
+  expect(showInfoModal).toHaveBeenCalledTimes(1)
+  const options = showInfoModal.mock.calls[0][1] as { title: string; message: string }
+  expect(options.title).toBe('This device was released')
+  expect(options.message).toContain('activate your license code')
+})
+
+test('stays quiet while the device is still registered', async () => {
+  const host = createHost({
+    verifyDeviceRegistration: jest.fn().mockResolvedValue('registered'),
+  })
+
+  await expect(checkSeatRegistration(host)).resolves.toBe('registered')
+  expect(showInfoModal).not.toHaveBeenCalled()
+})
+
+test('stays quiet when the check could not run', async () => {
+  const host = createHost({
+    verifyDeviceRegistration: jest.fn().mockResolvedValue('unknown'),
+  })
+
+  await expect(checkSeatRegistration(host)).resolves.toBe('unknown')
+  expect(showInfoModal).not.toHaveBeenCalled()
+})
+
+test('swallows a thrown check so startup is never derailed', async () => {
+  const host = createHost({
+    verifyDeviceRegistration: jest.fn().mockRejectedValue(new Error('boom')),
+  })
+
+  await expect(checkSeatRegistration(host)).resolves.toBe('unknown')
+
+  expect(showInfoModal).not.toHaveBeenCalled()
+  expect(host._log).toHaveBeenCalled()
+})
+
+test('does nothing without a license manager', async () => {
+  await expect(checkSeatRegistration(createHost(undefined))).resolves.toBe('unknown')
+  expect(showInfoModal).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Problem

Entitlement is decided offline, by verifying the stored token against the embedded public key. That leaves a hole: when a seat is released from another machine, this device notices nothing.

- The stored token still verifies for the rest of its 7-day life.
- `refreshIfNeeded()` only runs within 24h of expiry, and `POST /v1/token` would just claim the seat back under the same device id.

So a device the owner removed keeps running AI tasks.

## Change

Ask the license API's device list whether this device still holds a seat, and act only on a real answer:

- `LicenseManager.verifyDeviceRegistration()` — returns `registered` / `released` / `unknown`. Every failure (offline, rate limit, malformed) is `unknown` and leaves entitlement untouched, keeping the existing rule that a failed request never revokes. In-flight deduped and throttled to one request a minute, because the settings tab rebuilds its definitions after every control change.
- On `released`: drop the token and latch renewal off in device-local storage (`seatReleasedAt`), so no background refresh retakes the seat. The activation code stays in `data.json` on purpose — that file is synced, and clearing it would strip the license from every other vault sharing it. Only an explicit activation lifts the latch.
- `checkSeatRegistration()` shows a dialog when the seat is gone; the AI task UI is torn down by the existing license listener.

Runs on startup, on the 12-hour refresh tick, and whenever the settings tab builds its definitions (i.e. every time the settings screen is opened).

## Also

Removed the Status and Expires rows from the active license: the Pro settings page header already reads "Active", and the seats below are the only part of an active license anyone acts on. The i18n keys they orphaned are gone too.

## Testing

- `npm run typecheck`, `npm run lint`, `npm test` (3211 tests), `npm run build` — all pass.
- New coverage: the store latch across a reload, the four check outcomes, refresh-does-not-retake-the-seat, activation lifting the latch, throttling, and the dialog firing only on a real release.