### PR TITLE
Make the Pro settings license panel work

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -180,6 +180,97 @@ class TextComponent {
   }
 }
 
+/**
+ * Enough of ButtonComponent for a `render:` callback that builds its own
+ * button — the activation form does, because the code field and the button
+ * that spends it belong to one row.
+ */
+class ButtonComponent {
+  constructor(containerEl) {
+    this.buttonEl = createMockElement('button')
+    this.text = ''
+    this.cta = false
+    this.disabled = false
+    this._onClick = null
+    this.containerEl = containerEl
+    containerEl?.appendChild?.(this.buttonEl)
+  }
+
+  setButtonText(text) {
+    this.text = text
+    this.buttonEl.textContent = text
+    return this
+  }
+
+  setCta() {
+    this.cta = true
+    return this
+  }
+
+  setDisabled(disabled) {
+    this.disabled = disabled
+    return this
+  }
+
+  setTooltip() {
+    return this
+  }
+
+  setIcon(icon) {
+    this.icon = icon
+    return this
+  }
+
+  onClick(callback) {
+    this._onClick = callback
+    return this
+  }
+
+  async __click() {
+    if (this._onClick) {
+      await this._onClick()
+    }
+  }
+}
+
+class ExtraButtonComponent {
+  constructor(containerEl) {
+    this.extraSettingsEl = createMockElement('div')
+    this.icon = null
+    this.tooltip = null
+    this.disabled = false
+    this._onClick = null
+    this.containerEl = containerEl
+    containerEl?.appendChild?.(this.extraSettingsEl)
+  }
+
+  setIcon(icon) {
+    this.icon = icon
+    return this
+  }
+
+  setTooltip(tooltip) {
+    this.tooltip = tooltip
+    return this
+  }
+
+  setDisabled(disabled) {
+    this.disabled = disabled
+    return this
+  }
+
+  onClick(callback) {
+    this._onClick = callback
+    return this
+  }
+
+  async __click() {
+    if (this._onClick) {
+      await this._onClick()
+    }
+  }
+}
+
 class AbstractInputSuggest {
   constructor(app, inputEl) {
     this.app = app
@@ -238,10 +329,30 @@ const Setting = jest.fn().mockImplementation(() => {
       return this
     }),
     addTextArea: jest.fn().mockReturnThis(),
-    addButton: jest.fn().mockReturnThis(),
+    addButton: jest.fn().mockImplementation(function (callback) {
+      if (!this.__buttons) {
+        this.__buttons = []
+      }
+      const button = new ButtonComponent(this.controlEl)
+      this.__buttons.push(button)
+      if (typeof callback === 'function') {
+        callback(button)
+      }
+      return this
+    }),
     addDropdown: jest.fn().mockReturnThis(),
     addSlider: jest.fn().mockReturnThis(),
-    addExtraButton: jest.fn().mockReturnThis(),
+    addExtraButton: jest.fn().mockImplementation(function (callback) {
+      if (!this.__extraButtons) {
+        this.__extraButtons = []
+      }
+      const button = new ExtraButtonComponent(createMockElement('div'))
+      this.__extraButtons.push(button)
+      if (typeof callback === 'function') {
+        callback(button)
+      }
+      return this
+    }),
   }
   SettingInstances.push(settingInstance)
   return settingInstance
@@ -259,6 +370,7 @@ const createMockElement = (tag = 'div') => {
   const element = {
     tagName: tag.toUpperCase(),
     children: [],
+    __attributes: {},
     style: {},
     textContent: "",
     innerHTML: "",
@@ -296,8 +408,17 @@ const createMockElement = (tag = 'div') => {
     }),
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
-    setAttribute: jest.fn(),
-    getAttribute: jest.fn(),
+    // Attributes are readable back: code under test sets aria-label and the
+    // like through createEl's `attr`, and a test that cannot read them can
+    // only assert against internals.
+    setAttribute: jest.fn(function (name, value) {
+      this.__attributes[name] = String(value)
+    }),
+    getAttribute: jest.fn(function (name) {
+      return Object.hasOwn(this.__attributes, name)
+        ? this.__attributes[name]
+        : null
+    }),
     appendChild: jest.fn(function(child) {
       this.children.push(child)
       return child
@@ -372,6 +493,7 @@ const createMockElement = (tag = 'div') => {
       if (options.attr) {
         Object.entries(options.attr).forEach(([key, value]) => {
           el[key] = value
+          el.setAttribute(key, value)
         })
       }
       this.appendChild(el)
@@ -540,6 +662,8 @@ module.exports = {
   Modal,
   SuggestModal,
   TextComponent,
+  ButtonComponent,
+  ExtraButtonComponent,
   AbstractInputSuggest,
   Notice,
   PluginSettingTab,

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -149,6 +149,18 @@ export async function bootstrapPlugin(
     plugin._log?.("warn", "Failed to assign task IDs", error)
   }
 
+  // Before the settings tab: registering a tab makes Obsidian read its
+  // definitions right away to build the search index, and the pro page decides
+  // its whole shape from whether this manager exists. Created later, that first
+  // read sees nothing and the page keeps offering the "unexpected error" row
+  // instead of the activation form. It is also the third gate in
+  // createAiTaskManager below.
+  try {
+    plugin.licenseManager = createLicenseManager(plugin)
+  } catch (error) {
+    plugin._log?.("warn", "[TaskChute] Failed to initialize license manager:", error)
+  }
+
   try {
     plugin.addSettingTab(new TaskChuteSettingTab(plugin.app, plugin))
   } catch (error) {
@@ -202,14 +214,6 @@ export async function bootstrapPlugin(
     plugin._log?.("debug", "[TaskChute] Reminder system initialized")
   } catch (error) {
     plugin._log?.("warn", "[TaskChute] Failed to initialize reminder system:", error)
-  }
-
-  // The license manager must exist before the AI task manager: it is the third
-  // gate in createAiTaskManager, and the settings tab needs it either way.
-  try {
-    plugin.licenseManager = createLicenseManager(plugin)
-  } catch (error) {
-    plugin._log?.("warn", "[TaskChute] Failed to initialize license manager:", error)
   }
 
   // Initialize the AI task manager (inert unless enabled AND on desktop AND licensed)

--- a/src/features/license/config.ts
+++ b/src/features/license/config.ts
@@ -9,16 +9,18 @@ import type { LocaleKey } from '../../i18n'
  */
 
 /**
- * Ed25519 public key (base64url, raw 32 bytes) matching the API's
+ * Ed25519 public key (base64url, raw 32 bytes) matching the deployed Worker's
  * LICENSE_PRIVATE_KEY.
  *
- * ⚠️ This is currently the key from the API repo's local .dev.vars. The
- * deployed Worker's LICENSE_PRIVATE_KEY is a Cloudflare secret and its public
- * counterpart is not recorded in wrangler.jsonc, so it must be derived and
- * pasted here before a production release — otherwise every real token fails
- * verification with `invalid-signature`.
+ * Rotating the key pair means updating both sides together: the license repo's
+ * `npm run keys:generate` rewrites this constant and `npm run keys:upload` puts
+ * the private half into Cloudflare secrets. Skip either half and the Worker
+ * keeps signing happily while every user is rejected with `invalid-signature`.
+ *
+ * The generator rewrites this line by regex, so keep the declaration shaped as
+ * `export const LICENSE_PUBLIC_KEY = '…'`.
  */
-export const LICENSE_PUBLIC_KEY = 'be-8ZHqidokTIubfzpcEUfk5hZbSQYGn6GyHU1nSrKg'
+export const LICENSE_PUBLIC_KEY = 'YTWhN3Bl5zorbd6wJVRUF50CDee7hSPseXZiUHMoI0I'
 
 /** Baked into the token payload (`p`) and the license-id derivation. */
 export const LICENSE_PRODUCT_ID = 'taskchute-plus'

--- a/src/features/license/ui/DeviceListView.ts
+++ b/src/features/license/ui/DeviceListView.ts
@@ -36,6 +36,7 @@ function formatLastSeen(unixSeconds: number): string {
 export class DeviceListView {
   private devices?: DeviceView[]
   private maxDevices?: number
+  private readonly rootEl: HTMLElement
   private readonly statusEl: HTMLElement
   private readonly listEl: HTMLElement
   private busyDeviceId?: string
@@ -50,6 +51,7 @@ export class DeviceListView {
     this.maxDevices = options.initialMaxDevices
 
     const root = container.createDiv({ cls: 'taskchute-license-devices' })
+    this.rootEl = root
     root.createDiv({
       cls: 'taskchute-license-devices__description',
       text: t(
@@ -57,8 +59,10 @@ export class DeviceListView {
         'This license can be used on a limited number of devices. Release a device you no longer use to make room for another one.',
       ),
     })
-    this.statusEl = root.createDiv({ cls: 'taskchute-license-devices__status' })
     this.listEl = root.createDiv({ cls: 'taskchute-license-devices__list' })
+    // Under the list: the seat count is a summary of what is above it, and a
+    // load or failure message reads as the state of the list it follows.
+    this.statusEl = root.createDiv({ cls: 'taskchute-license-devices__status' })
 
     if (this.devices === undefined) {
       void this.load()
@@ -70,9 +74,13 @@ export class DeviceListView {
   /**
    * Stop touching the DOM. The settings tab rebuilds its whole container on
    * every display(), so an in-flight request must not write into the old tree.
+   *
+   * The tree this view owns goes with it: a host that is reused across renders
+   * would otherwise accumulate one dead list per pass.
    */
   dispose(): void {
     this.disposed = true
+    this.rootEl.remove()
   }
 
   private async load(): Promise<void> {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -89,13 +89,7 @@ export const en = {
       devicesValue: "{used} of {max} in use",
       activated: "License activated.",
       requiredNotice: "A license is required.",
-      // Split so the link sits inside the sentence rather than after it.
       purchaseName: "Buy a license",
-      purchaseBefore: "You can buy an activation code ",
-      // Mid-sentence link text, so it stays lowercase (exempted by the
-      // "^here$" ignoreRegex).
-      purchaseLink: "here",
-      purchaseAfter: ".",
     },
     aiTask: {
       heading: "AI task",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -86,9 +86,6 @@ export const ja = {
       activated: "ライセンスを有効化しました。",
       requiredNotice: "ライセンスが必要です。",
       purchaseName: "ライセンスを購入",
-      purchaseBefore: "アクティベーションコードは",
-      purchaseLink: "こちら",
-      purchaseAfter: "から購入することができます",
     },
     aiTask: {
       heading: "AIタスク",

--- a/src/settings/sections/pro/aiTask.ts
+++ b/src/settings/sections/pro/aiTask.ts
@@ -1,4 +1,5 @@
 import { Notice } from "obsidian"
+import type { Setting, SettingDefinitionRender } from "obsidian"
 import { t } from "../../../i18n"
 import { ElectronDirectoryPicker } from "../../../features/ai-task/services/ElectronDirectoryPicker"
 import type { TaskChuteSettings } from "../../../types"
@@ -97,6 +98,60 @@ async function browseForCliPath(
 }
 
 /**
+ * Rendered imperatively rather than declared: a `control` row cannot also carry
+ * an action, and the picker belongs beside its field rather than on a row of
+ * its own. The picker is an Electron one because these are filesystem paths
+ * outside the vault, where the declarative file control's suggester is no help.
+ */
+function cliPathRow(
+  ctx: SectionContext,
+  path: CliPath,
+): SettingDefinitionRender {
+  return {
+    name: path.name,
+    desc: path.desc,
+    render: (setting: Setting) => {
+      let committed = ctx.plugin.settings[path.key] ?? ""
+
+      setting.addText((input) => {
+        const commit = async (value: string): Promise<void> => {
+          if (value === committed) return
+          await cliPathHandler(path).write(value, ctx)
+          // The handler trims and may reject outright, so the field follows
+          // what was actually stored rather than what was typed.
+          committed = ctx.plugin.settings[path.key] ?? ""
+          if (committed !== value) input.setValue(committed)
+        }
+
+        input
+          .setPlaceholder(
+            t("settings.aiTask.pathPlaceholder", "Auto-detect (recommended)"),
+          )
+          .setValue(committed)
+        // Saving on every keystroke would fire the shim rejection midway
+        // through typing "claude.cmd" and blank the field under the cursor, so
+        // the value is committed on blur instead.
+        input.inputEl.addEventListener("blur", () => {
+          void commit(input.getValue())
+        })
+        input.inputEl.addEventListener("keydown", (event: KeyboardEvent) => {
+          if (event.key === "Enter") input.inputEl.blur()
+        })
+      })
+
+      setting.addExtraButton((button) =>
+        button
+          .setIcon("folder")
+          .setTooltip(t("settings.aiTask.pathBrowse", "Browse"))
+          .onClick(() => {
+            void browseForCliPath(ctx, path)
+          }),
+      )
+    },
+  }
+}
+
+/**
  * Everything a Pro license unlocks. Only reached from the Pro page, which has
  * already checked entitlement.
  */
@@ -143,31 +198,7 @@ export function aiTaskSection(guard: AiTaskToggleGuard): SectionModule {
               },
             },
           },
-          // The picker rows sit beside their fields; these are filesystem
-          // paths outside the vault, so the vault file suggester is no help.
-          ...paths.flatMap((path) => [
-            {
-              name: path.name,
-              desc: path.desc,
-              control: {
-                type: "text" as const,
-                key: path.key,
-                defaultValue: "",
-                placeholder: t(
-                  "settings.aiTask.pathPlaceholder",
-                  "Auto-detect (recommended)",
-                ),
-              },
-            },
-            {
-              name: t("settings.aiTask.pathBrowse", "Browse"),
-              desc: path.name,
-              searchable: false,
-              action: () => {
-                void browseForCliPath(ctx, path)
-              },
-            },
-          ]),
+          ...paths.map((path) => cliPathRow(ctx, path)),
           {
             name: t("settings.aiTask.retentionName", "Run log retention (days)"),
             desc: t(
@@ -211,9 +242,6 @@ export function aiTaskSection(guard: AiTaskToggleGuard): SectionModule {
         min: 1,
         fallback: DEFAULT_SETTINGS.aiTaskLogRetentionDays ?? 30,
       }),
-      ...Object.fromEntries(
-        paths.map((path) => [path.key, cliPathHandler(path)]),
-      ),
     },
   }
 }

--- a/src/settings/sections/pro/index.ts
+++ b/src/settings/sections/pro/index.ts
@@ -10,7 +10,7 @@ import type { AiTaskToggleGuard } from "../../services/aiTaskLifecycle"
 import { notifyAiTaskSettingsChanged } from "../../services/viewNotifications"
 import type { SectionContext, SectionModule } from "../../types"
 import { aiTaskSection } from "./aiTask"
-import { LICENSE_CODE_KEY, licenseCodeHandler, licenseRows } from "./license"
+import { licenseRows } from "./license"
 import { LicenseActivationState } from "./licenseActivationState"
 
 /** Create or dispose the AI runtime to match the new license state. */
@@ -81,9 +81,8 @@ export function proSection(
       ]
     },
 
-    handlers: {
-      ...aiTask.handlers,
-      [LICENSE_CODE_KEY]: licenseCodeHandler(form),
-    },
+    // No license handler: the activation form owns its field imperatively,
+    // because the code being typed is a draft rather than a stored setting.
+    handlers: aiTask.handlers,
   }
 }

--- a/src/settings/sections/pro/license.ts
+++ b/src/settings/sections/pro/license.ts
@@ -1,5 +1,5 @@
 import { Notice, setIcon } from "obsidian"
-import type { SettingDefinitionItem } from "obsidian"
+import type { Setting, SettingDefinitionItem } from "obsidian"
 import { getCurrentLocale, t } from "../../../i18n"
 import { licensePurchaseUrl } from "../../../features/license/config"
 import type { LicenseManager } from "../../../features/license/services/LicenseManager"
@@ -10,41 +10,104 @@ import {
   describeApiFailure,
 } from "../../../features/license/ui/licenseMessages"
 import { showInfoModal } from "../../../ui/modals/ConfirmModal"
-import type { AnyControlHandler, SectionContext } from "../../types"
+import type { SectionContext } from "../../types"
 import { LicenseActivationState } from "./licenseActivationState"
 
-/** Draft only — an unactivated code is not a setting. */
-export const LICENSE_CODE_KEY = "license.code"
-
-export function licenseCodeHandler(
-  form: LicenseActivationState,
-): AnyControlHandler {
-  return {
-    read: (ctx) => form.currentCode(ctx.plugin.settings.licenseCode),
-    write: (value) => {
-      form.code = String(value)
-    },
-  }
+/**
+ * Where the device list mounts.
+ *
+ * The row's own control element, not the group the render callback is handed:
+ * the framework finishes a group by setting its list to exactly the rows'
+ * elements, so anything else put there is removed in the same pass — which is
+ * how the list came to render into nothing at all. `Setting.clear()` empties
+ * the control element before a row is rendered again, so mounting here also
+ * keeps a re-render from stacking two lists.
+ *
+ * The row lays its name and control out side by side, so it takes a class that
+ * turns it into a column and lets the list have the full width.
+ */
+function deviceListHost(setting: Setting): HTMLElement {
+  setting.settingEl.addClass("taskchute-license-devices-item")
+  return setting.controlEl
 }
 
 /**
  * Where the code comes from is a one-time question, so it sits behind an info
- * icon rather than taking a permanent paragraph above the field.
+ * icon on the label rather than taking a row or a standing paragraph.
  */
-function helpRow(ctx: SectionContext): SettingDefinitionItem {
+function helpButton(ctx: SectionContext, setting: Setting): void {
+  const button = setting.nameEl.createEl("button", {
+    cls: "clickable-icon taskchute-license-code__help",
+    attr: {
+      type: "button",
+      "aria-label": t(
+        "settings.license.codeHelpLabel",
+        "About the license code",
+      ),
+    },
+  })
+  setIcon(button, "info")
+
+  button.addEventListener("click", () => {
+    void showInfoModal(ctx.app, {
+      title: t("settings.license.codeHelpTitle", "About the license code"),
+      message: t(
+        "settings.license.codeHelpBody",
+        "AI tasks require a TaskChute Plus Pro license.\nYour license code is in the email you received when you bought it. If you cannot find that email, check your spam folder.",
+      ),
+      confirmText: t("settings.license.codeHelpClose", "OK"),
+    })
+  })
+}
+
+/**
+ * The whole form in one row: the code, the button that spends it, and the note
+ * about where the code comes from.
+ *
+ * Built imperatively rather than from a `control` definition because the three
+ * belong to a single action — a declarative control owns the row's control
+ * area alone, which would push the button onto a row of its own and leave the
+ * field too narrow for a code of this length.
+ */
+function codeRow(
+  ctx: SectionContext,
+  manager: LicenseManager,
+  form: LicenseActivationState,
+  applyLicenseChange: () => Promise<void>,
+): SettingDefinitionItem {
   return {
-    name: t("settings.license.codeHelpLabel", "About the license code"),
+    name: t("settings.license.codeName", "License code"),
+    // A failure belongs under the field it was typed into.
+    desc: form.errorDesc,
     render: (setting) => {
-      setIcon(setting.nameEl.createSpan(), "info")
-      setting.settingEl.addEventListener("click", () => {
-        void showInfoModal(ctx.app, {
-          title: t("settings.license.codeHelpTitle", "About the license code"),
-          message: t(
-            "settings.license.codeHelpBody",
-            "AI tasks require a TaskChute Plus Pro license.\nYour license code is in the email you received when you bought it. If you cannot find that email, check your spam folder.",
-          ),
-          confirmText: t("settings.license.codeHelpClose", "OK"),
-        })
+      setting.settingEl.addClass("taskchute-license-code-item")
+      helpButton(ctx, setting)
+
+      setting.addText((text) => {
+        text
+          .setPlaceholder(
+            t("settings.license.codePlaceholder", "TCP-XXXX-XXXX-XXXX-XXXX"),
+          )
+          // Re-seeded on every render: the row is rebuilt whenever activation
+          // starts or fails, and the draft must survive that.
+          .setValue(form.currentCode(ctx.plugin.settings.licenseCode))
+          .onChange((value) => {
+            form.code = value
+          })
+      })
+
+      setting.addButton((button) => {
+        button
+          .setCta()
+          .setButtonText(
+            form.activating
+              ? t("settings.license.activating", "Activating…")
+              : t("settings.license.activate", "Activate"),
+          )
+          .setDisabled(form.activating)
+          .onClick(() => {
+            void activate(ctx, manager, form, applyLicenseChange)
+          })
       })
     },
   }
@@ -52,26 +115,18 @@ function helpRow(ctx: SectionContext): SettingDefinitionItem {
 
 /** Someone reading this screen without a code needs a way to buy one. */
 function purchaseRow(): SettingDefinitionItem {
-  // A fragment rather than a string: the row's description has to carry a real
-  // link, and its text content still feeds the settings search.
-  const desc = createFragment((fragment) => {
-    fragment.appendText(
-      t("settings.license.purchaseBefore", "You can buy an activation code "),
-    )
-    fragment.createEl("a", {
-      text: t("settings.license.purchaseLink", "here"),
-      attr: {
-        href: licensePurchaseUrl(getCurrentLocale()),
-        target: "_blank",
-        rel: "noopener",
-      },
-    })
-    fragment.appendText(t("settings.license.purchaseAfter", "."))
-  })
-
   return {
     name: t("settings.license.purchaseName", "Buy a license"),
-    desc,
+    // The row itself opens the page — there is nothing else to do with it, and
+    // an inline link inside a description is a smaller target than the row.
+    action: (el) => {
+      const opened = el.ownerDocument.defaultView?.open(
+        licensePurchaseUrl(getCurrentLocale()),
+        "_blank",
+        "noopener,noreferrer",
+      )
+      if (opened) opened.opener = null
+    },
   }
 }
 
@@ -122,51 +177,35 @@ function activationRows(
     })
   }
 
-  rows.push({
-    name: t("settings.license.codeName", "License code"),
-    control: {
-      type: "text",
-      key: LICENSE_CODE_KEY,
-      defaultValue: "",
-      placeholder: t(
-        "settings.license.codePlaceholder",
-        "TCP-XXXX-XXXX-XXXX-XXXX",
-      ),
-    },
-  })
-
-  rows.push(helpRow(ctx))
-
-  rows.push({
-    name: form.activating
-      ? t("settings.license.activating", "Activating…")
-      : t("settings.license.activate", "Activate"),
-    desc: form.errorDesc,
-    disabled: () => form.activating,
-    action: () => {
-      void activate(ctx, manager, form, applyLicenseChange)
-    },
-  })
+  rows.push(codeRow(ctx, manager, form, applyLicenseChange))
 
   // The seat limit is the one failure the user can fix right here, and the 409
   // already carried the list, so no second request is needed.
   rows.push({
-    name: t("settings.license.devicesName", "Devices"),
+    type: "group",
+    heading: t("settings.license.devicesName", "Devices"),
     visible: () => form.deviceLimitFailure !== null,
-    render: (_setting, group) => {
-      const failure = form.deviceLimitFailure
-      if (!failure) return undefined
-      const view = new DeviceListView(group.listEl, manager, {
-        initialDevices: failure.devices,
-        onChanged: () => {
-          form.clearError()
-          ctx.refreshDomState()
+    items: [
+      {
+        // Nameless, like the seats section of an active license: the heading
+        // names it and the list takes the whole row.
+        name: "",
+        render: (setting) => {
+          const failure = form.deviceLimitFailure
+          if (!failure) return undefined
+          const view = new DeviceListView(deviceListHost(setting), manager, {
+            initialDevices: failure.devices,
+            onChanged: () => {
+              form.clearError()
+              ctx.refreshDomState()
+            },
+          })
+          return () => {
+            view.dispose()
+          }
         },
-      })
-      return () => {
-        view.dispose()
-      }
-    },
+      },
+    ],
   })
 
   rows.push(purchaseRow())
@@ -181,23 +220,44 @@ function activeLicenseRows(
   applyLicenseChange: () => Promise<void>,
 ): SettingDefinitionItem[] {
   const summary = manager.getLicenseSummary()
-  // No status or expiry rows: the page header already says "Active", and the
-  // seats below are the only part of an active license anyone acts on.
+  // Two sections rather than a single card: the licence is a fact to read once,
+  // the seats are a list to act on, and a heading over each says which is which.
+  // No status or expiry rows — the page header already says "Active".
   const rows: SettingDefinitionItem[] = []
 
-  if (summary) {
+  // The code the user actually typed, not the id derived from it: that is what
+  // they hold, what support asks for, and what they would re-enter elsewhere.
+  // The id is the fallback for a licence activated before the code was stored.
+  const stored = ctx.plugin.settings.licenseCode
+  const identity =
+    stored !== undefined && stored.length > 0
+      ? { name: t("settings.license.codeName", "License code"), value: stored }
+      : summary
+        ? {
+            name: t("settings.license.licenseIdName", "License ID"),
+            value: formatLicenseId(summary.license_id),
+          }
+        : undefined
+
+  if (identity) {
     rows.push({
-      name: t("settings.license.licenseIdName", "License ID"),
-      desc: formatLicenseId(summary.license_id),
+      type: "group",
+      heading: t("settings.license.heading", "License"),
+      cls: "taskchute-license-identity",
+      items: [{ name: identity.name, desc: identity.value }],
     })
   }
 
   rows.push({
-    name: t("settings.license.devicesName", "Devices"),
-    // Releasing this very device is done from the list like any other seat, so
-    // there is no separate sign-out control.
-    render: (_setting, group) => {
-      const view = new DeviceListView(group.listEl, manager, {
+    type: "group",
+    heading: t("settings.license.devicesName", "Devices"),
+    items: [{
+    // No name: the heading above already names the section, so the list takes
+    // the whole row. Releasing this very device is done from the list like any
+    // other seat, so there is no separate sign-out control.
+    name: "",
+    render: (setting) => {
+      const view = new DeviceListView(deviceListHost(setting), manager, {
         onChanged: () => {
           // Seat counts come from the server, so a release has to re-read the
           // summary; rebuilding is the cheapest way to stay consistent, and it
@@ -217,6 +277,7 @@ function activeLicenseRows(
         view.dispose()
       }
     },
+    }],
   })
 
   return rows

--- a/styles.css
+++ b/styles.css
@@ -8453,7 +8453,60 @@ textarea.form-textarea {
   stroke-width: 1.8;
 }
 
+/* ── License activation form (Pro settings) ─────────────────────────────── */
+
+/* The code and the button that spends it are one action, so they share a line
+   under the label rather than being squeezed into the row's control column. */
+.setting-item.taskchute-license-code-item {
+  display: block;
+}
+
+.setting-item.taskchute-license-code-item .setting-item-name {
+  align-items: center;
+  display: flex;
+  gap: var(--size-2-2);
+}
+
+.setting-item.taskchute-license-code-item .setting-item-control {
+  margin-top: var(--size-4-2);
+  width: 100%;
+}
+
+/* Codes run to a couple of hundred characters, so the field takes whatever the
+   button leaves. */
+.setting-item.taskchute-license-code-item .setting-item-control input {
+  flex: 1;
+  min-width: 0;
+}
+
+/* An activation code runs to a couple of hundred characters, so it wraps
+   anywhere rather than pushing the card sideways, and stays selectable for
+   someone copying it back out. */
+.taskchute-license-identity .setting-item-description {
+  overflow-wrap: anywhere;
+  user-select: text;
+}
+
 /* ── License device seats (rendered inline in the Pro settings section) ─── */
+
+/* The list mounts into the row's control element, which normally sits beside
+   the name and sizes itself to its content. The row carries no name — the
+   group heading above it does — so it becomes a plain full-width container. */
+.setting-item.taskchute-license-devices-item {
+  display: block;
+}
+
+.setting-item.taskchute-license-devices-item .setting-item-info {
+  display: none;
+}
+
+.setting-item.taskchute-license-devices-item .setting-item-control {
+  width: 100%;
+  justify-content: flex-start;
+  /* A control area is right-aligned by default, which is wrong for a block of
+     prose sitting where the row's own description would be. */
+  text-align: left;
+}
 
 .taskchute-license-devices {
   margin-bottom: var(--size-4-4);
@@ -8467,7 +8520,7 @@ textarea.form-textarea {
 .taskchute-license-devices__status {
   color: var(--text-muted);
   font-size: var(--font-ui-smaller);
-  margin: var(--size-4-1) 0 var(--size-4-2);
+  margin-top: var(--size-4-2);
   min-height: 1.2em;
 }
 
@@ -8475,6 +8528,7 @@ textarea.form-textarea {
   display: flex;
   flex-direction: column;
   gap: var(--size-4-2);
+  margin-top: var(--size-4-2);
 }
 
 .taskchute-license-devices__row {

--- a/tests/features/ai-task/ai-task-settings-section.test.ts
+++ b/tests/features/ai-task/ai-task-settings-section.test.ts
@@ -5,13 +5,17 @@
  * completion can land after a newer toggle or after a hot reload has replaced
  * the plugin instance. Those races are the bulk of what is tested here.
  */
-import type { SettingDefinitionAction, SettingDefinitionItem } from 'obsidian'
-import { Notice, mockApp } from 'obsidian'
+import type { SettingDefinitionItem, SettingDefinitionRender } from 'obsidian'
+import { Notice, Setting, mockApp } from 'obsidian'
 import { DEFAULT_SETTINGS } from '../../../src/settings'
 import { TaskChuteSettingTab } from '../../../src/settings/SettingsTab'
 import { createAiTaskManager } from '../../../src/features/ai-task'
 import { createFakeLicenseManager } from '../license/fakeLicenseManager'
-import { findByKey, flatten } from '../../settings/definitionHelpers'
+import {
+  findByKey,
+  findByName,
+  flatten,
+} from '../../settings/definitionHelpers'
 
 jest.mock('../../../src/features/ai-task', () => ({
   createAiTaskManager: jest.fn(),
@@ -82,22 +86,60 @@ function createTab(): { tab: TaskChuteSettingTab; plugin: FakePlugin } {
   return { tab, plugin }
 }
 
-function browseRow(
+interface FakeTextComponent {
+  getValue(): string
+  setValue(value: string): FakeTextComponent
+  __triggerEvent(type: string): Promise<void>
+}
+
+interface FakeExtraButton {
+  icon: string | null
+  tooltip: string | null
+  __click(): Promise<void>
+}
+
+/**
+ * The CLI path rows are imperative (`render:`) because the text field and its
+ * picker share one row, so the test has to run the callback against a Setting
+ * and reach for the components it created.
+ */
+function pathRow(
   tab: TaskChuteSettingTab,
   pathName: string,
-): SettingDefinitionAction {
+): { text: FakeTextComponent; browse: FakeExtraButton } {
   const row = flatten(tab.getSettingDefinitions()).find(
-    (item: SettingDefinitionItem): item is SettingDefinitionAction =>
-      'action' in item &&
-      item.action !== undefined &&
-      item.name === 'Browse' &&
-      item.desc === pathName,
+    (item: SettingDefinitionItem): item is SettingDefinitionRender =>
+      'render' in item && item.render !== undefined && item.name === pathName,
   )
-  if (!row) throw new Error(`browse row for "${pathName}" not found`)
-  return row
+  if (!row) throw new Error(`path row for "${pathName}" not found`)
+
+  const setting = new Setting(document.createElement('div')) as unknown as {
+    __textComponents?: FakeTextComponent[]
+    __extraButtons?: FakeExtraButton[]
+  }
+  row.render(setting as never, undefined as never)
+
+  const text = setting.__textComponents?.[0]
+  const browse = setting.__extraButtons?.[0]
+  if (!text || !browse) {
+    throw new Error(`path row for "${pathName}" rendered no field or picker`)
+  }
+  return { text, browse }
+}
+
+/** Types into the field and commits the way the row does: on blur. */
+async function typePath(
+  tab: TaskChuteSettingTab,
+  pathName: string,
+  value: string,
+): Promise<void> {
+  const { text } = pathRow(tab, pathName)
+  text.setValue(value)
+  await text.__triggerEvent('blur')
 }
 
 const CLAUDE_PATH_NAME = 'Claude CLI path (advanced fallback)'
+const CODEX_PATH_NAME = 'Codex CLI path (advanced fallback)'
 
 describe('TaskChute AI task settings section', () => {
   const createAiTaskManagerMock = createAiTaskManager as jest.Mock
@@ -350,16 +392,25 @@ describe('TaskChute AI task settings section', () => {
   })
 
   describe('CLI paths', () => {
+    test('carry their picker on the same row as the field', () => {
+      const { tab } = createTab()
+
+      // A stray "Browse" row of its own would mean the picker drifted back out
+      // of the field's row.
+      expect(findByName(tab.getSettingDefinitions(), 'Browse')).toBeUndefined()
+
+      const { browse } = pathRow(tab, CLAUDE_PATH_NAME)
+      expect(browse.icon).toBe('folder')
+      expect(browse.tooltip).toBe('Browse')
+    })
+
     test('trim on the way in and invalidate the locator cache', async () => {
       const manager = createFakeManager()
       const { tab, plugin } = createTab()
       plugin.aiTaskManager = manager
 
-      await tab.setControlValue(
-        'aiTaskClaudePath',
-        '  /opt/homebrew/bin/claude  ',
-      )
-      await tab.setControlValue('aiTaskCodexPath', '')
+      await typePath(tab, CLAUDE_PATH_NAME, '  /opt/homebrew/bin/claude  ')
+      await typePath(tab, CODEX_PATH_NAME, ' ')
 
       expect(plugin.settings.aiTaskClaudePath).toBe('/opt/homebrew/bin/claude')
       expect(plugin.settings.aiTaskCodexPath).toBe('')
@@ -367,23 +418,39 @@ describe('TaskChute AI task settings section', () => {
       expect(manager.invalidateBinaryCache).toHaveBeenCalledTimes(2)
     })
 
+    test('leave the stored path alone when a blur changed nothing', async () => {
+      const manager = createFakeManager()
+      const { tab, plugin } = createTab()
+      plugin.aiTaskManager = manager
+      plugin.settings.aiTaskClaudePath = '/opt/homebrew/bin/claude'
+
+      const { text } = pathRow(tab, CLAUDE_PATH_NAME)
+      await text.__triggerEvent('blur')
+
+      expect(plugin.saveSettings).not.toHaveBeenCalled()
+      expect(manager.invalidateBinaryCache).not.toHaveBeenCalled()
+    })
+
     test('reject Windows command shims with a visible notice', async () => {
       const manager = createFakeManager()
       const { tab, plugin } = createTab()
       plugin.aiTaskManager = manager
 
-      await tab.setControlValue(
-        'aiTaskClaudePath',
+      await typePath(
+        tab,
+        CLAUDE_PATH_NAME,
         'C:\\Users\\tester\\AppData\\Roaming\\npm\\claude.cmd',
       )
-      await tab.setControlValue(
-        'aiTaskCodexPath',
+      await typePath(
+        tab,
+        CODEX_PATH_NAME,
         'C:\\Users\\tester\\AppData\\Roaming\\npm\\codex.ps1',
       )
 
       expect(plugin.settings.aiTaskClaudePath).toBe('')
       expect(plugin.settings.aiTaskCodexPath).toBe('')
-      expect(tab.getControlValue('aiTaskClaudePath')).toBe('')
+      // The rejection rebuilds the tab, so the re-rendered field is empty too.
+      expect(pathRow(tab, CLAUDE_PATH_NAME).text.getValue()).toBe('')
       expect(Notice).toHaveBeenCalledTimes(2)
       expect(manager.invalidateBinaryCache).toHaveBeenCalledTimes(2)
     })
@@ -394,9 +461,7 @@ describe('TaskChute AI task settings section', () => {
       plugin.aiTaskManager = manager
       selectFileMock.mockResolvedValue('/opt/homebrew/bin/claude')
 
-      browseRow(tab, CLAUDE_PATH_NAME).action({} as HTMLElement, 0)
-      await Promise.resolve()
-      await Promise.resolve()
+      await pathRow(tab, CLAUDE_PATH_NAME).browse.__click()
 
       expect(plugin.settings.aiTaskClaudePath).toBe('/opt/homebrew/bin/claude')
       expect(manager.invalidateBinaryCache).toHaveBeenCalledTimes(1)
@@ -407,9 +472,7 @@ describe('TaskChute AI task settings section', () => {
       plugin.settings.aiTaskClaudePath = '/existing/claude'
       selectFileMock.mockResolvedValue(null)
 
-      browseRow(tab, CLAUDE_PATH_NAME).action({} as HTMLElement, 0)
-      await Promise.resolve()
-      await Promise.resolve()
+      await pathRow(tab, CLAUDE_PATH_NAME).browse.__click()
 
       expect(plugin.settings.aiTaskClaudePath).toBe('/existing/claude')
       expect(plugin.saveSettings).not.toHaveBeenCalled()

--- a/tests/features/license/device-list-view.test.ts
+++ b/tests/features/license/device-list-view.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The seat list is mounted into a container the settings framework owns and
+ * reuses across renders, so tearing it down has to leave that container as it
+ * was found. A view that only stops writing would pile one dead list per pass.
+ */
+import { DeviceListView } from '../../../src/features/license/ui/DeviceListView'
+import type { LicenseManager } from '../../../src/features/license/services/LicenseManager'
+
+function fakeManager(): LicenseManager {
+  return {
+    getDeviceId: () => 'DEVICE-0001',
+    listDevices: jest.fn().mockResolvedValue({ ok: true, devices: [], maxDevices: 3 }),
+    deactivateDevice: jest.fn(),
+  } as unknown as LicenseManager
+}
+
+describe('DeviceListView', () => {
+  test('removes its own tree on dispose', () => {
+    const host = document.createElement('div')
+    const view = new DeviceListView(host, fakeManager(), { initialDevices: [] })
+
+    expect(host.querySelector('.taskchute-license-devices')).not.toBeNull()
+
+    view.dispose()
+
+    expect(host.querySelector('.taskchute-license-devices')).toBeNull()
+    expect(host.childElementCount).toBe(0)
+  })
+
+  test('mounting again after a dispose leaves a single list', () => {
+    const host = document.createElement('div')
+
+    const first = new DeviceListView(host, fakeManager(), { initialDevices: [] })
+    first.dispose()
+    new DeviceListView(host, fakeManager(), { initialDevices: [] })
+
+    expect(host.querySelectorAll('.taskchute-license-devices')).toHaveLength(1)
+  })
+})

--- a/tests/features/license/pro-settings-section.test.ts
+++ b/tests/features/license/pro-settings-section.test.ts
@@ -5,6 +5,7 @@
  * gate will refuse to start.
  */
 import type {
+  SettingDefinitionAction,
   SettingDefinitionItem,
   SettingDefinitionRender,
 } from 'obsidian'
@@ -62,7 +63,10 @@ function activeManager(): LicenseManager {
   })
 }
 
-function createTab(manager: LicenseManager | undefined): TaskChuteSettingTab {
+function createTab(
+  manager: LicenseManager | undefined,
+  licenseCode?: string,
+): TaskChuteSettingTab {
   const app = { ...mockApp, plugins: { plugins: {} } }
   const plugin = {
     app,
@@ -72,6 +76,7 @@ function createTab(manager: LicenseManager | undefined): TaskChuteSettingTab {
       aiTaskEnabled: false,
       aiTaskRunMode: 'terminal',
       aiTaskLogRetentionDays: 30,
+      licenseCode,
     },
     pathManager: { validatePath: () => ({ valid: true }) },
     saveSettings: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
@@ -82,9 +87,12 @@ function createTab(manager: LicenseManager | undefined): TaskChuteSettingTab {
 }
 
 /** The rows on the Pro page, with the page's own visibility ignored. */
-function proItems(manager: LicenseManager | undefined): SettingDefinitionItem[] {
+function proItems(
+  manager: LicenseManager | undefined,
+  licenseCode?: string,
+): SettingDefinitionItem[] {
   const page = pageNamed(
-    createTab(manager).getSettingDefinitions(),
+    createTab(manager, licenseCode).getSettingDefinitions(),
     t('settings.pro.heading', 'Pro settings'),
   )
   if (!page) throw new Error('Pro page not found')
@@ -98,6 +106,13 @@ function names(items: SettingDefinitionItem[]): string[] {
     .filter((name): name is string => Boolean(name))
 }
 
+function headings(items: SettingDefinitionItem[]): string[] {
+  return items
+    .filter((item) => isVisible(item as { visible?: boolean | (() => boolean) }))
+    .map((item) => ('heading' in item ? item.heading : undefined))
+    .filter((heading): heading is string => Boolean(heading))
+}
+
 function descs(items: SettingDefinitionItem[]): string[] {
   return items
     .map((item) => ('desc' in item ? item.desc : undefined))
@@ -107,18 +122,82 @@ function descs(items: SettingDefinitionItem[]): string[] {
     .filter(Boolean)
 }
 
-/** Runs a row's render callback against a throwaway group. */
-function invokeRender(item: SettingDefinitionItem): (() => void) | void {
+/** The row that carries the whole activation form. */
+function codeItem(manager: LicenseManager): SettingDefinitionItem {
+  const item = proItems(manager).find(
+    (candidate) => 'name' in candidate && candidate.name === 'License code',
+  )
+  if (!item) throw new Error('License code row not found')
+  return item
+}
+
+/**
+ * The row that mounts the seat list. Nameless by design — the group heading
+ * above it says "Devices" — so it is found by shape.
+ */
+function deviceItem(manager: LicenseManager): SettingDefinitionItem {
+  const item = proItems(manager).find(
+    (candidate) =>
+      'render' in candidate &&
+      candidate.render !== undefined &&
+      'name' in candidate &&
+      candidate.name === '',
+  )
+  if (!item) throw new Error('Device list row not found')
+  return item
+}
+
+/** Clicks the purchase row and reports where it tried to send the user. */
+function openPurchasePage(manager: LicenseManager): string | URL | undefined {
+  // Found by shape rather than by name: the name is localized, and the
+  // purchase row is the only one on this page that acts on a click.
+  const item = proItems(manager).find(
+    (candidate): candidate is SettingDefinitionAction =>
+      'action' in candidate && candidate.action !== undefined,
+  )
+  const action = item?.action
+  const open = jest.spyOn(window, 'open').mockReturnValue(null)
+
+  try {
+    action?.(document.createElement('div'), 0)
+    return open.mock.calls[0]?.[0]
+  } finally {
+    open.mockRestore()
+  }
+}
+
+type MockTextComponent = { __triggerChange: (value: string) => Promise<void> }
+type MockButtonComponent = { __click: () => Promise<void>; text: string }
+
+type MockSetting = {
+  settingEl: HTMLElement
+  nameEl: HTMLElement
+  controlEl: HTMLElement
+  __textComponents: MockTextComponent[]
+  __buttons: MockButtonComponent[]
+}
+
+type RenderedRow = {
+  cleanup: (() => void) | void
+  setting: MockSetting
+  group: { listEl: HTMLElement }
+}
+
+/** Runs a row's render callback against a throwaway row and group. */
+function invokeRender(item: SettingDefinitionItem): RenderedRow {
   const render = (item as SettingDefinitionRender).render
   const group = new (SettingGroup as unknown as new (
     el: HTMLElement,
   ) => { listEl: HTMLElement })(document.createElement('div'))
-  return render(
-    new (Setting as unknown as new (el: HTMLElement) => never)(
-      document.createElement('div'),
-    ),
-    group as never,
-  )
+  const setting = new (Setting as unknown as new (
+    el: HTMLElement,
+  ) => MockSetting)(document.createElement('div'))
+
+  return {
+    cleanup: render(setting as never, group as never),
+    setting,
+    group,
+  }
 }
 
 describe('Pro settings section', () => {
@@ -147,43 +226,52 @@ describe('Pro settings section', () => {
       expect(names(proItems(fakeManager()))).toContain('License code')
     })
 
-    test('links to the purchase page for someone without a code', () => {
-      const purchase = proItems(fakeManager()).find(
-        (item) => 'desc' in item && typeof item.desc === 'object',
+    test('opens the purchase page from the row itself', () => {
+      // The whole row is the target: an inline link inside a description is
+      // both smaller and easy to miss on the screen someone lands on with no
+      // code in hand.
+      expect(openPurchasePage(fakeManager())).toBe(
+        'https://obsidian.levers.co.jp/',
       )
-      const desc = (purchase as { desc: DocumentFragment }).desc
-      const link = desc.querySelector('a')
-
-      expect(link?.getAttribute('href')).toBe('https://obsidian.levers.co.jp/')
-      expect(link?.textContent).toBe('here')
-      // The link belongs inside the sentence, with text on both sides of it.
-      expect(desc.textContent).toBe('You can buy an activation code here.')
     })
 
-    test('explains where the code comes from on its own row', () => {
+    test('explains where the code comes from behind the label', () => {
       const items = proItems(fakeManager())
 
-      expect(names(items)).toContain('About the license code')
-      // The explanation must not also occupy the form as a standing paragraph.
+      // A row of its own would separate the note from the field it explains.
+      expect(names(items)).not.toContain('About the license code')
+      // Nor may it occupy the form as a standing paragraph.
       expect(descs(items).some((desc) => desc.includes('purchase email'))).toBe(
         false,
       )
+
+      const { setting } = invokeRender(codeItem(fakeManager()))
+      const help = setting.nameEl.querySelector('.taskchute-license-code__help')
+
+      expect(help?.getAttribute('aria-label')).toBe('About the license code')
     })
 
     test('sends Japanese users to the Japanese purchase page', () => {
       setLocaleOverride('ja')
       try {
-        const purchase = proItems(fakeManager()).find(
-          (item) => 'desc' in item && typeof item.desc === 'object',
-        )
-        const desc = (purchase as { desc: DocumentFragment }).desc
-
-        expect(desc.querySelector('a')?.getAttribute('href')).toBe(
+        expect(openPurchasePage(fakeManager())).toBe(
           'https://obsidian.levers.co.jp/ja/',
         )
       } finally {
         setLocaleOverride('en')
       }
+    })
+
+    test('activates with the code typed into the row', async () => {
+      const manager = fakeManager({
+        activate: jest.fn().mockResolvedValue({ ok: true }),
+      })
+      const { setting } = invokeRender(codeItem(manager))
+
+      await setting.__textComponents[0].__triggerChange('TCP-AAAA-BBBB-CCCC')
+      await setting.__buttons[0].__click()
+
+      expect(manager.activate).toHaveBeenCalledWith('TCP-AAAA-BBBB-CCCC')
     })
 
     test('does not show the device list or the AI settings', () => {
@@ -214,13 +302,26 @@ describe('Pro settings section', () => {
     test('shows the license details', () => {
       const items = proItems(activeManager())
 
-      expect(names(items)).toEqual(
-        expect.arrayContaining(['License ID', 'Devices']),
+      // Two sections: the licence to read, the seats to act on.
+      expect(headings(items)).toEqual(
+        expect.arrayContaining(['License', 'Devices']),
       )
+      expect(names(items)).toContain('License ID')
+
       const licenseId = items.find(
         (item) => 'name' in item && item.name === 'License ID',
       )
       expect((licenseId as { desc: string }).desc).toBe('8F3K-2M9Q-X7RD-4WPZ')
+    })
+
+    test('shows the code that was entered, not the id derived from it', () => {
+      // What the user holds and would re-enter elsewhere is the code; the id
+      // means nothing to them.
+      const items = proItems(activeManager(), 'TCP-AAAA-BBBB-CCCC-DDDD')
+
+      expect(names(items)).toContain('License code')
+      expect(names(items)).not.toContain('License ID')
+      expect(descs(items)).toContain('TCP-AAAA-BBBB-CCCC-DDDD')
     })
 
     test('drops the status and expiry rows', () => {
@@ -233,11 +334,7 @@ describe('Pro settings section', () => {
     })
 
     test('mounts the device list and disposes it on teardown', () => {
-      const devices = proItems(activeManager()).find(
-        (item) => 'name' in item && item.name === 'Devices',
-      )
-
-      const cleanup = invokeRender(devices as SettingDefinitionItem)
+      const { cleanup } = invokeRender(deviceItem(activeManager()))
       expect(DeviceListView).toHaveBeenCalledTimes(1)
 
       // The framework tears the row down before replacing it, which is what
@@ -246,6 +343,23 @@ describe('Pro settings section', () => {
       expect(view.dispose).not.toHaveBeenCalled()
       cleanup?.()
       expect(view.dispose).toHaveBeenCalledTimes(1)
+    })
+
+    /**
+     * Obsidian finishes a group by setting its list to exactly the rows'
+     * elements, so a list mounted into the group is removed in the same render
+     * pass — the row ends up showing its name and nothing else. Mounting into
+     * the row's own control element is what keeps the seats on screen.
+     */
+    test('mounts the device list into the row, not the group', () => {
+      const { setting, group } = invokeRender(deviceItem(activeManager()))
+
+      const container = DeviceListView.mock.calls[0][0] as HTMLElement
+      expect(container).toBe(setting.controlEl)
+      expect(container).not.toBe(group.listEl)
+      expect(setting.settingEl.className).toContain(
+        'taskchute-license-devices-item',
+      )
     })
 
     test('shows the AI task settings', () => {

--- a/tests/setup/obsidian-dom-globals.ts
+++ b/tests/setup/obsidian-dom-globals.ts
@@ -175,6 +175,20 @@ Object.defineProperties(Node.prototype, {
       }
     },
   },
+  setText: {
+    configurable: true,
+    writable: true,
+    value(this: Node, text: string | DocumentFragment) {
+      if (typeof text === 'string') {
+        this.textContent = text
+        return
+      }
+      while (this.firstChild) {
+        this.removeChild(this.firstChild)
+      }
+      this.appendChild(text)
+    },
+  },
 })
 
 HTMLElement.prototype.setAttr = function setAttr(name: string, value: string | number | boolean): HTMLElement {


### PR DESCRIPTION
## Why

The Pro settings page was unusable and shipped with the wrong signing key.

- The bundled `LICENSE_PUBLIC_KEY` was the one from the API repo's local `.dev.vars`, so every token the deployed Worker signs would have been rejected as `invalid-signature` on release.
- The page rendered nothing but a "The license service returned an unexpected error" row: the settings tab was registered before the license manager existed, and Obsidian reads a tab's definitions as soon as it is registered to build the search index.
- With that fixed, the device seats still did not appear. The list mounted into the `SettingGroup` the `render:` callback is handed, and Obsidian finishes a group with `listEl.setChildrenInPlace([...rows])` — anything in that list which is not a row's element is removed in the same render pass.

## What changed

- Point the plugin at the production public key.
- Create the license manager before `addSettingTab`, so the first read of the definitions sees it. It is also the gate `createAiTaskManager` checks, so it belongs earlier either way.
- Mount inline UI into the row's own control element rather than the group's list. `Setting.clear()` empties that element before a re-render, so the list survives one and never doubles up; `DeviceListView.dispose()` now detaches its tree as well.
- Reshape the panel around what someone does there:
  - the license and the seats each get a section of their own;
  - the code the user entered is shown instead of the id derived from it;
  - the activation form is one row carrying the field, the button that spends it, and the note about where the code comes from;
  - the purchase row opens the page from the row itself rather than from a link buried in a description;
  - the seat count moves below the list it summarises.
- Put the CLI path picker back beside the field it fills, committing on blur so the command-shim rejection cannot blank the field mid-word.

## Testing

- `npm test` — 227 suites, 3218 tests.
- `npm run lint`, `npx tsc -p tsconfig.test.json --noEmit`, `npm run build`.
- New regression tests: the seat list mounts into the row and not the group, `dispose()` leaves no tree behind, the entered code is what the license section shows, and the purchase row opens the localized page.
- Checked by hand in Obsidian 1.13.7: seats list, release a seat, re-open the settings and toggle AI tasks to force re-renders.

## Note

The stored token no longer verifies under the new public key, so an activated vault falls back to the activation form. Confirm the key is the pair of the deployed Worker's `LICENSE_PRIVATE_KEY` before releasing.