### PR TITLE
chore(ci): move action-gh-release to its node 24 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,7 @@ jobs:
             ${{ steps.prep.outputs.dir }}/styles.css
 
       - name: Create GitHub Release (published)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.bump.outputs.new_version }}
           name: ${{ steps.bump.outputs.new_version }}


### PR DESCRIPTION
## Summary

The Auto Release workflow logs a deprecation warning on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: softprops/action-gh-release@v2.

`softprops/action-gh-release@v3.0.0` is a runtime-only major: it moves the action's bundle target from Node 20 to Node 24 and changes nothing else. The inputs this workflow passes (`tag_name`, `name`, `generate_release_notes`, `files`) are unchanged, so the bump is a drop-in.

This is the follow-up to #143, which moved the remaining actions to their Node 24 releases; `action-gh-release` had no Node 24 line at the time.

## Changes

- `.github/workflows/release.yml`: `softprops/action-gh-release@v2` -> `@v3`

## Verification

Every other action in the repository already runs on Node 24 (`actions/checkout@v7`, `actions/setup-node@v7`, `actions/upload-artifact@v7`, `actions/attest-build-provenance@v4`), so this removes the last source of the warning. The release workflow is `workflow_dispatch`-only, so it cannot be exercised from this PR -- the next manual release run is the real check.