### PR TITLE
Clear the Obsidian review's css and dependency warnings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,4 @@ export PATH
 # Commit-time gate is lint only, and only over the staged files. Typecheck and
 # the test suites moved to CI (.github/workflows/test.yml) so committing stays
 # fast; run them yourself with npm run typecheck / npm run test:unit.
-npx lint-staged
+npm run lint:staged

--- a/eslint.review.config.mjs
+++ b/eslint.review.config.mjs
@@ -76,11 +76,11 @@ export default [
     },
   },
 
-  // depend/ban-dependencies does not distinguish dev from prod. Neither of
-  // these reaches the published plugin: moment is a type-only dependency the
-  // obsidian typings require (esbuild marks obsidian external), and
-  // lint-staged only runs in the pre-commit hook. Anything added here needs
-  // the same kind of reason written next to it.
+  // depend/ban-dependencies does not distinguish dev from prod, and moment does
+  // not reach the published plugin: it is a type-only dependency the obsidian
+  // typings require (esbuild marks obsidian external). Anything added here
+  // needs the same kind of reason written next to it — lint-staged used to be
+  // on this list and was removed instead, in favour of scripts/lint-staged.mjs.
   {
     files: ["package.json"],
     rules: {
@@ -88,7 +88,7 @@ export default [
         "error",
         {
           presets: ["native", "microutilities", "preferred"],
-          allowed: ["moment", "lint-staged"],
+          allowed: ["moment"],
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
-        "lint-staged": "^17.3.0",
         "moment": "^2.30.1",
         "obsidian": "^1.13.1",
         "ts-jest": "^29.4.4",
@@ -36,6 +35,9 @@
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.44.1",
         "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=22.22.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7432,43 +7434,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lint-staged": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
-      "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^4.0.5",
-        "string-argv": "^0.3.2",
-        "tinyexec": "^1.2.4"
-      },
-      "bin": {
-        "lint-staged": "bin/lint-staged.js"
-      },
-      "engines": {
-        "node": ">=22.22.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/lint-staged"
-      },
-      "optionalDependencies": {
-        "yaml": "^2.9.0"
-      }
-    },
-    "node_modules/lint-staged/node_modules/picomatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
-      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -8779,16 +8744,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/string-argv": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.19"
-      }
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -9160,16 +9115,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tinyexec": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/tldts": {

--- a/package.json
+++ b/package.json
@@ -14,14 +14,11 @@
     "test:coverage": "jest --coverage",
     "prepare": "husky",
     "lint": "eslint --config eslint.config.mjs \"src/**/*.{ts,tsx,js}\" \"tests/**/*.{ts,tsx,js}\"",
+    "lint:staged": "node scripts/lint-staged.mjs",
     "review:obsidian": "node scripts/obsidian-review.mjs"
   },
   "engines": {
     "node": ">=22.22.1"
-  },
-  "lint-staged": {
-    "src/**/*.{ts,tsx,js}": "eslint --config eslint.config.mjs --no-warn-ignored",
-    "tests/**/*.{ts,tsx,js}": "eslint --config eslint.config.mjs --no-warn-ignored"
   },
   "devDependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
@@ -44,7 +41,6 @@
     "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
-    "lint-staged": "^17.3.0",
     "moment": "^2.30.1",
     "obsidian": "^1.13.1",
     "ts-jest": "^29.4.4",

--- a/scripts/lint-staged.mjs
+++ b/scripts/lint-staged.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// The pre-commit lint gate: eslint over the staged source and test files.
+//
+// This replaces lint-staged, which Obsidian's plugin review flags through
+// depend/ban-dependencies. The review does not distinguish dev from prod
+// dependencies, so the only way to clear the finding is to not depend on the
+// package at all — and the hook only ever needed "lint what is staged".
+//
+// Deleted and renamed-away paths are dropped (the file is gone from the work
+// tree), and partially staged files are still linted whole, exactly as the
+// lint-staged configuration this replaces did.
+import { spawnSync } from "node:child_process";
+
+const PATTERNS = [/^src\/.*\.(ts|tsx|js)$/, /^tests\/.*\.(ts|tsx|js)$/];
+
+function git(...args) {
+  const result = spawnSync("git", args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr ?? "");
+    process.exit(result.status ?? 1);
+  }
+  return result.stdout;
+}
+
+const staged = git("diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z")
+  .split("\0")
+  .filter((file) => file.length > 0 && PATTERNS.some((pattern) => pattern.test(file)));
+
+if (staged.length === 0) {
+  process.exit(0);
+}
+
+const eslint = spawnSync(
+  process.execPath,
+  ["node_modules/eslint/bin/eslint.js", "--config", "eslint.config.mjs", "--no-warn-ignored", ...staged],
+  { stdio: "inherit" },
+);
+
+process.exit(eslint.status ?? 1);

--- a/src/features/reminder/ui/ReminderIconRenderer.ts
+++ b/src/features/reminder/ui/ReminderIconRenderer.ts
@@ -78,15 +78,12 @@ export class ReminderIconRenderer {
     tag: string,
     options?: { cls?: string; text?: string; attr?: Record<string, string> }
   ): HTMLElement {
-    const maybeCreateEl = (
-      parent as HTMLElement & {
-        createEl?: (tagName: string, options?: Record<string, unknown>) => HTMLElement;
-      }
-    ).createEl;
+    const host = parent as HTMLElement & {
+      createEl?: (tagName: string, options?: Record<string, unknown>) => HTMLElement;
+    };
 
-    if (typeof maybeCreateEl === 'function') {
-      const result: HTMLElement = maybeCreateEl.call(parent, tag, options as Record<string, unknown> | undefined) as HTMLElement;
-      return result;
+    if (typeof host.createEl === 'function') {
+      return host.createEl(tag, options);
     }
 
     // Fallback for non-Obsidian environments
@@ -117,15 +114,12 @@ export class ReminderIconRenderer {
     tag: string,
     options?: { cls?: string; attr?: Record<string, string> }
   ): SVGElement {
-    const maybeCreateSvg = (
-      parent as (HTMLElement | SVGElement) & {
-        createSvg?: (tagName: string, options?: Record<string, unknown>) => SVGElement;
-      }
-    ).createSvg;
+    const host = parent as (HTMLElement | SVGElement) & {
+      createSvg?: (tagName: string, options?: Record<string, unknown>) => SVGElement;
+    };
 
-    if (typeof maybeCreateSvg === 'function') {
-      const result: SVGElement = maybeCreateSvg.call(parent, tag, options as Record<string, unknown> | undefined) as SVGElement;
-      return result;
+    if (typeof host.createSvg === 'function') {
+      return host.createSvg(tag, options);
     }
 
     // Fallback for non-Obsidian environments

--- a/src/features/review/services/ReviewService.ts
+++ b/src/features/review/services/ReviewService.ts
@@ -44,10 +44,9 @@ export class ReviewService {
     try {
       const { workspace } = this.plugin.app;
       const workspaceWithSplit = workspace as { splitActiveLeaf?: (direction: 'vertical' | 'horizontal') => WorkspaceLeaf | null };
-      const splitFunction = workspaceWithSplit.splitActiveLeaf;
       const rightLeaf: WorkspaceLeaf | null =
-        typeof splitFunction === 'function'
-          ? (splitFunction.call(workspace, 'vertical') as WorkspaceLeaf | null)
+        typeof workspaceWithSplit.splitActiveLeaf === 'function'
+          ? workspaceWithSplit.splitActiveLeaf('vertical')
           : workspace.getLeaf('split');
 
       if (!rightLeaf) {

--- a/src/ui/header/TaskHeaderController.ts
+++ b/src/ui/header/TaskHeaderController.ts
@@ -271,6 +271,7 @@ export default class TaskHeaderController {
       !this.host.setAiTaskBoardView
     ) {
       this.boardViewSwitchEl?.remove()
+      this.markBoardViewSwitchPresence(actionSection, false)
       return
     }
 
@@ -287,7 +288,25 @@ export default class TaskHeaderController {
     ) {
       actionSection.insertBefore(group, addTaskButton)
     }
+    this.markBoardViewSwitchPresence(actionSection, true)
     this.refreshBoardViewActiveState()
+  }
+
+  /**
+   * The narrow-width header layout has to know whether the switch is on screen.
+   * A `:has()` selector would say so declaratively, but Obsidian's plugin
+   * review rejects it, so the state is published as a class on both elements
+   * the layout rules select.
+   */
+  private markBoardViewSwitchPresence(
+    actionSection: HTMLElement,
+    present: boolean,
+  ): void {
+    actionSection.classList.toggle('has-board-view-switch', present)
+    actionSection.parentElement?.classList.toggle(
+      'has-board-view-switch',
+      present,
+    )
   }
 
   /** Build the segmented control and register its handlers exactly once */

--- a/src/ui/project/ProjectBoardView.ts
+++ b/src/ui/project/ProjectBoardView.ts
@@ -326,10 +326,9 @@ export class ProjectBoardView extends ItemView {
 
       const workspace = this.app.workspace
       const workspaceWithSplit = workspace as { splitActiveLeaf?: (direction: 'vertical' | 'horizontal') => WorkspaceLeaf | null }
-      const splitFunction = workspaceWithSplit.splitActiveLeaf
       const rightLeaf: WorkspaceLeaf | null =
-        typeof splitFunction === 'function'
-          ? (splitFunction.call(workspace, 'vertical') as WorkspaceLeaf | null)
+        typeof workspaceWithSplit.splitActiveLeaf === 'function'
+          ? workspaceWithSplit.splitActiveLeaf('vertical')
           : workspace.getLeaf('split')
 
       if (!rightLeaf) {

--- a/styles.css
+++ b/styles.css
@@ -2844,9 +2844,12 @@ body.is-phone {
 /* Obsidian leaf splits do not change the viewport width, so use the view
    container instead of a media query. At narrow widths the right-side switch
    and add action stay together on a second row while the drawer returns to
-   its original top-left position. */
+   its original top-left position. The `has-board-view-switch` marker class is
+   toggled by TaskHeaderController: `:has()` would express the same thing, but
+   Obsidian's plugin review flags it for the invalidation cost it puts on every
+   ancestor of the switch. */
 @container taskchute-view (max-width: 680px) {
-  .top-bar-container:has(> .header-action-section > .ai-board-view-switch) {
+  .top-bar-container.has-board-view-switch {
     grid-template-rows: repeat(2, 30px);
     height: 66px;
     row-gap: 6px;
@@ -2862,7 +2865,7 @@ body.is-phone {
     justify-self: start;
   }
 
-  .top-bar-container > .header-action-section:has(> .ai-board-view-switch) {
+  .top-bar-container > .header-action-section.has-board-view-switch {
     grid-column: 1 / -1;
     grid-row: 2;
     justify-self: end;
@@ -2872,7 +2875,7 @@ body.is-phone {
   }
 
   .top-bar-container
-    > .header-action-section:has(> .ai-board-view-switch)::-webkit-scrollbar {
+    > .header-action-section.has-board-view-switch::-webkit-scrollbar {
     display: none;
   }
 }
@@ -8175,30 +8178,41 @@ textarea.form-textarea {
     overflow: hidden;
 }
 
-.xterm-dim {
+/* xterm.js customization: upstream carries `!important` here and on the
+   scrollbar arrow below. Obsidian's plugin review rejects `!important`, so both
+   rules win on specificity instead — the selectors are scoped to the terminal's
+   own subtree, which no theme rule reaches. */
+.xterm .xterm-rows .xterm-dim {
     /* Dim should not apply to background, so the opacity of the foreground color is applied
      * explicitly in the generated class and reset to 1 here */
-    opacity: 1 !important;
+    opacity: 1;
 }
 
-.xterm-underline-1 { text-decoration: underline; }
-.xterm-underline-2 { text-decoration: double underline; }
-.xterm-underline-3 { text-decoration: wavy underline; }
-.xterm-underline-4 { text-decoration: dotted underline; }
-.xterm-underline-5 { text-decoration: dashed underline; }
+/* xterm.js customization: upstream writes these as the `text-decoration`
+   shorthand ("overline wavy underline"). Obsidian's plugin review only accepts
+   the single-keyword form of the shorthand, so the line and the style are set
+   through their longhands instead — same rendering, same cascade. */
+.xterm-underline-1 { text-decoration-line: underline; }
+.xterm-underline-2 { text-decoration-line: underline; text-decoration-style: double; }
+.xterm-underline-3 { text-decoration-line: underline; text-decoration-style: wavy; }
+.xterm-underline-4 { text-decoration-line: underline; text-decoration-style: dotted; }
+.xterm-underline-5 { text-decoration-line: underline; text-decoration-style: dashed; }
 
 .xterm-overline {
-    text-decoration: overline;
+    text-decoration-line: overline;
 }
 
-.xterm-overline.xterm-underline-1 { text-decoration: overline underline; }
-.xterm-overline.xterm-underline-2 { text-decoration: overline double underline; }
-.xterm-overline.xterm-underline-3 { text-decoration: overline wavy underline; }
-.xterm-overline.xterm-underline-4 { text-decoration: overline dotted underline; }
-.xterm-overline.xterm-underline-5 { text-decoration: overline dashed underline; }
+.xterm-overline.xterm-underline-1 { text-decoration-line: overline underline; }
+.xterm-overline.xterm-underline-2 { text-decoration-line: overline underline; text-decoration-style: double; }
+.xterm-overline.xterm-underline-3 { text-decoration-line: overline underline; text-decoration-style: wavy; }
+.xterm-overline.xterm-underline-4 { text-decoration-line: overline underline; text-decoration-style: dotted; }
+.xterm-overline.xterm-underline-5 { text-decoration-line: overline underline; text-decoration-style: dashed; }
 
 .xterm-strikethrough {
-    text-decoration: line-through;
+    text-decoration-line: line-through;
+    /* The shorthand this replaces also reset the style; keep that reset so a
+       strikethrough over a wavy/dotted underline still draws solid. */
+    text-decoration-style: solid;
 }
 
 .xterm-screen .xterm-decoration-container .xterm-decoration {
@@ -8233,9 +8247,9 @@ textarea.form-textarea {
 }
 
 /* Arrows */
-.xterm .xterm-scrollable-element > .scrollbar > .scra {
+.xterm .xterm-scrollable-element > .scrollbar > .scra.scra {
 	cursor: pointer;
-	font-size: 11px !important;
+	font-size: 11px;
 }
 
 .xterm .xterm-scrollable-element > .visible {

--- a/tests/features/ai-task/terminal-view-adapter.test.ts
+++ b/tests/features/ai-task/terminal-view-adapter.test.ts
@@ -15,12 +15,102 @@ import { createTerminalViewAdapter } from '../../../src/features/ai-task/ui/Term
 
 const repoRoot = join(__dirname, '..', '..', '..')
 
+/**
+ * Obsidian's plugin review rejects three things upstream xterm.css uses: the
+ * multi-keyword `text-decoration` shorthand, and `!important`. The vendored
+ * block therefore is not byte-identical to the installed package — it is the
+ * package plus exactly these substitutions, which this table pins so an
+ * @xterm/xterm upgrade still fails the sync check above.
+ */
+const OBSIDIAN_REVIEW_PATCHES: ReadonlyArray<readonly [string, string]> = [
+  [
+    `.xterm-dim {
+    /* Dim should not apply to background, so the opacity of the foreground color is applied
+     * explicitly in the generated class and reset to 1 here */
+    opacity: 1 !important;
+}`,
+    `/* xterm.js customization: upstream carries \`!important\` here and on the
+   scrollbar arrow below. Obsidian's plugin review rejects \`!important\`, so both
+   rules win on specificity instead — the selectors are scoped to the terminal's
+   own subtree, which no theme rule reaches. */
+.xterm .xterm-rows .xterm-dim {
+    /* Dim should not apply to background, so the opacity of the foreground color is applied
+     * explicitly in the generated class and reset to 1 here */
+    opacity: 1;
+}`,
+  ],
+  [
+    `.xterm-underline-1 { text-decoration: underline; }
+.xterm-underline-2 { text-decoration: double underline; }
+.xterm-underline-3 { text-decoration: wavy underline; }
+.xterm-underline-4 { text-decoration: dotted underline; }
+.xterm-underline-5 { text-decoration: dashed underline; }
+
+.xterm-overline {
+    text-decoration: overline;
+}
+
+.xterm-overline.xterm-underline-1 { text-decoration: overline underline; }
+.xterm-overline.xterm-underline-2 { text-decoration: overline double underline; }
+.xterm-overline.xterm-underline-3 { text-decoration: overline wavy underline; }
+.xterm-overline.xterm-underline-4 { text-decoration: overline dotted underline; }
+.xterm-overline.xterm-underline-5 { text-decoration: overline dashed underline; }`,
+    `/* xterm.js customization: upstream writes these as the \`text-decoration\`
+   shorthand ("overline wavy underline"). Obsidian's plugin review only accepts
+   the single-keyword form of the shorthand, so the line and the style are set
+   through their longhands instead — same rendering, same cascade. */
+.xterm-underline-1 { text-decoration-line: underline; }
+.xterm-underline-2 { text-decoration-line: underline; text-decoration-style: double; }
+.xterm-underline-3 { text-decoration-line: underline; text-decoration-style: wavy; }
+.xterm-underline-4 { text-decoration-line: underline; text-decoration-style: dotted; }
+.xterm-underline-5 { text-decoration-line: underline; text-decoration-style: dashed; }
+
+.xterm-overline {
+    text-decoration-line: overline;
+}
+
+.xterm-overline.xterm-underline-1 { text-decoration-line: overline underline; }
+.xterm-overline.xterm-underline-2 { text-decoration-line: overline underline; text-decoration-style: double; }
+.xterm-overline.xterm-underline-3 { text-decoration-line: overline underline; text-decoration-style: wavy; }
+.xterm-overline.xterm-underline-4 { text-decoration-line: overline underline; text-decoration-style: dotted; }
+.xterm-overline.xterm-underline-5 { text-decoration-line: overline underline; text-decoration-style: dashed; }`,
+  ],
+  [
+    `.xterm-strikethrough {
+    text-decoration: line-through;
+}`,
+    `.xterm-strikethrough {
+    text-decoration-line: line-through;
+    /* The shorthand this replaces also reset the style; keep that reset so a
+       strikethrough over a wavy/dotted underline still draws solid. */
+    text-decoration-style: solid;
+}`,
+  ],
+  [
+    `.xterm .xterm-scrollable-element > .scrollbar > .scra {
+	cursor: pointer;
+	font-size: 11px !important;
+}`,
+    `.xterm .xterm-scrollable-element > .scrollbar > .scra.scra {
+	cursor: pointer;
+	font-size: 11px;
+}`,
+  ],
+]
+
+function applyObsidianReviewPatches(css: string): string {
+  return OBSIDIAN_REVIEW_PATCHES.reduce((patched, [upstream, replacement]) => {
+    expect(patched).toContain(upstream)
+    return patched.replace(upstream, replacement)
+  }, css)
+}
+
 describe('TerminalViewAdapter module', () => {
   beforeEach(() => {
     document.body.replaceChildren()
   })
 
-  test('styles.css carries the installed xterm css verbatim', () => {
+  test('styles.css carries the installed xterm css, review patches aside', () => {
     const vendored = readFileSync(
       join(repoRoot, 'node_modules', '@xterm', 'xterm', 'css', 'xterm.css'),
       'utf8',
@@ -28,8 +118,9 @@ describe('TerminalViewAdapter module', () => {
     const styles = readFileSync(join(repoRoot, 'styles.css'), 'utf8')
 
     // Fails after an @xterm/xterm upgrade until the new css is pasted back
-    // into the vendored block at the end of styles.css.
-    expect(styles).toContain(vendored)
+    // into the vendored block at the end of styles.css and the patches below
+    // are re-applied to it.
+    expect(styles).toContain(applyObsidianReviewPatches(vendored))
   })
 
   test('factory returns an adapter whose pre-open calls are safe no-ops', () => {

--- a/tests/guardrails/obsidian-review-config.test.ts
+++ b/tests/guardrails/obsidian-review-config.test.ts
@@ -8,7 +8,7 @@ const REVIEW_CONFIG = 'eslint.review.config.mjs'
 // depend/ban-dependencies は dev と prod を区別しないので、配布物に入らない
 // dev 専用パッケージだけをここで許している。増やすときは必ずこのテストと
 // eslint.review.config.mjs のコメントの両方を通すこと。
-const ALLOWED_BANNED_DEPENDENCIES = ['moment', 'lint-staged']
+const ALLOWED_BANNED_DEPENDENCIES = ['moment']
 
 type RuleEntry = unknown
 type RuleMap = Record<string, RuleEntry>

--- a/tests/ui/header/task-header-board-view-switch.test.ts
+++ b/tests/ui/header/task-header-board-view-switch.test.ts
@@ -206,6 +206,28 @@ describe('TaskHeaderController board view switch', () => {
     expect(withDisabledFeature.innerHTML).toBe(withoutMembers.innerHTML)
   })
 
+  // The narrow-width header rules key off this class instead of `:has()`,
+  // which Obsidian's plugin review rejects. If it stops tracking the control,
+  // the switch silently overlaps the add action on a split pane.
+  test('the presence marker class follows the control on both the section and the top bar', () => {
+    const { host, state } = createHost({ enabled: false })
+    const { controller, container } = renderHeader(host)
+    const actions = container.querySelector('.header-action-section')
+
+    expect(actions?.classList.contains('has-board-view-switch')).toBe(false)
+    expect(container.classList.contains('has-board-view-switch')).toBe(false)
+
+    state.enabled = true
+    controller.refreshAiTaskBoardSwitch()
+    expect(actions?.classList.contains('has-board-view-switch')).toBe(true)
+    expect(container.classList.contains('has-board-view-switch')).toBe(true)
+
+    state.enabled = false
+    controller.refreshAiTaskBoardSwitch()
+    expect(actions?.classList.contains('has-board-view-switch')).toBe(false)
+    expect(container.classList.contains('has-board-view-switch')).toBe(false)
+  })
+
   test('refreshAiTaskBoardSwitch adds and removes the control as the feature toggles', () => {
     const { host, state } = createHost({ enabled: false })
     const { controller, container } = renderHeader(host)

--- a/tests/ui/header/task-header-layout.test.ts
+++ b/tests/ui/header/task-header-layout.test.ts
@@ -49,14 +49,14 @@ describe('TaskChute header layout', () => {
 
     const query = css.slice(queryStart, css.indexOf('/* Navigation Overlay */', queryStart))
     expect(query).toMatch(
-      /\.top-bar-container:has\([\s\S]*\.ai-board-view-switch[\s\S]*grid-template-rows:\s*repeat\(2,\s*30px\);/,
+      /\.top-bar-container\.has-board-view-switch\s*\{[\s\S]*grid-template-rows:\s*repeat\(2,\s*30px\);/,
     )
     expect(query).toMatch(/\.date-nav-container\.compact\s*\{[\s\S]*grid-row:\s*1;/)
     expect(query).toMatch(
       /\.top-bar-container\s*>\s*\.drawer-toggle\s*\{[\s\S]*grid-column:\s*1;[\s\S]*grid-row:\s*1;/,
     )
     expect(query).toMatch(
-      /\.header-action-section:has\(>\s*\.ai-board-view-switch\)\s*\{[\s\S]*grid-column:\s*1\s*\/\s*-1;[\s\S]*grid-row:\s*2;[\s\S]*justify-self:\s*end;/,
+      /\.header-action-section\.has-board-view-switch\s*\{[\s\S]*grid-column:\s*1\s*\/\s*-1;[\s\S]*grid-row:\s*2;[\s\S]*justify-self:\s*end;/,
     )
   })
 


### PR DESCRIPTION
Obsidian's plugin review reports a batch of warnings against the published plugin. This clears every one that is actually a property of our code.

## What changed

**`:has()` (3 findings)** — the narrow-width header rules asked "is the AI board view switch present?" with `:has()`, which the review rejects for the invalidation cost it puts on every ancestor of the switch. `TaskHeaderController` now publishes that state as a `has-board-view-switch` class on the action section and on the top bar, and the container query selects the class. A new test pins the class to the control so the two cannot drift.

**`text-decoration` (9 findings) and `!important` (2 findings)** — all in the vendored `@xterm/xterm` css at the end of `styles.css`. The multi-keyword shorthand (`overline wavy underline`) becomes `text-decoration-line` / `text-decoration-style` longhands, and the two `!important` rules win on specificity instead; both selectors are scoped to the terminal's own subtree, which no theme rule reaches. `.xterm-strikethrough` keeps an explicit `text-decoration-style: solid` because the shorthand it replaces used to reset it.

The block was previously required to be byte-identical to the installed package, and `terminal-view-adapter.test.ts` enforced that so an upgrade could not slip through unnoticed. That guardrail now compares `styles.css` against the installed package *plus a pinned table of these substitutions*, so it keeps failing after an `@xterm/xterm` upgrade until the new css is pasted back and the patches re-applied.

**`lint-staged` (1 finding)** — `depend/ban-dependencies` does not distinguish dev from prod, so the only way to clear it is to not depend on the package. The pre-commit hook now runs `scripts/lint-staged.mjs`, ~30 lines that lint the staged `src/` and `tests/` files with the same eslint invocation. `lint-staged` is removed from `devDependencies` and from the review config's allowlist.

**Unnecessary type assertions** — four sites where an `as T` sat on a `Function.prototype.call` result. Called as a method on the object instead, they type correctly with no assertion. See the note below on the reported counts.

## Not addressed

*Direct Filesystem Access* and *Shell Execution* are inherent to the AI task feature: it spawns the agent CLIs through `child_process` and reads their transcripts through `fs`. These are review notes that need a justification in the submission, not code that can change.

## Note on the assertion counts

The review reports 19 `unnecessaryAssertion` and 17 `contextuallyUnnecessary` findings. Running `@typescript-eslint/no-unnecessary-type-assertion` locally over `src/` and `tests/` finds 4 and 0 — the four fixed here, which only surface under `strict: true` (they depend on `strictBindCallApply`; the repo's `tsconfig.json` enables `strictNullChecks` only). I could not reproduce the remaining 32 under any tsconfig I tried, so if you have the review output with file/line locations I will take a second pass. Turning on full `strict` in `tsconfig.json` is the obvious way to keep them caught, but it currently produces 71 type errors, so that belongs in its own PR.

## Verification

`npm run lint`, `npm run typecheck`, `npm test` (3256 passing), `npm run build`, and `npm run review:obsidian` (0 errors, 0 warnings) all pass.