### PR TITLE
Reproduce the Obsidian review locally, and bump the toolchain that makes it see what the dashboard sees

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,16 +63,27 @@ jobs:
 
       # The Obsidian plugin review gate. Obsidian auto-reviews every published
       # version and blocks the ones that fail, so run the part of that review we
-      # can run ourselves (eslint-plugin-obsidianmd, which Obsidian publishes for
-      # exactly this) before anything irreversible happens. Everything below this
-      # point pushes a bump commit and a tag to the default branch; a failure
-      # here leaves the branch untouched.
+      # can run ourselves before anything irreversible happens. Everything below
+      # this point pushes a bump commit and a tag to the default branch; a
+      # failure here leaves the branch untouched.
+      #
+      # Three layers: eslint-plugin-obsidianmd applied verbatim (Obsidian's own
+      # published config), a reconstruction of the dashboard's CSS findings, and
+      # the capability disclosures read out of the built bundle. The last one is
+      # why the build runs here rather than only after the tag -- the disclosure
+      # describes what ships, so it is read from what ships. The later "Build
+      # plugin" step stays: it builds the tagged commit, which is what the
+      # release assets are cut from.
       #
       # Errors fail the release, warnings are reported only -- that is how
       # Obsidian itself judges a submission. The dashboard additionally runs
-      # malware and dependency scans that have no public API, so a pass here is
-      # not a guarantee that publication is allowed; a failure is a guarantee
-      # that it is not.
+      # malware and dependency scans that have no public API, and the CSS and
+      # capability layers are our reconstructions of an implementation Obsidian
+      # does not publish, so a pass here is not a guarantee that publication is
+      # allowed; a failure is a guarantee that it is not.
+      - name: Build plugin for review
+        run: npm run build
+
       - name: Obsidian plugin review
         run: npm run review:obsidian
 

--- a/eslint.review.config.mjs
+++ b/eslint.review.config.mjs
@@ -1,10 +1,27 @@
 // The Obsidian plugin review gate.
 //
-// Obsidian auto-reviews every published version of a community plugin. The
-// part of that review we can run ourselves is eslint-plugin-obsidianmd, which
-// Obsidian publishes as the local equivalent of its guidelines. This config
-// exists to run that plugin's recommended config *verbatim* — the day it is
-// hand-copied here, it stops being a review and starts being a second opinion.
+// Obsidian auto-reviews every published version of a community plugin. That
+// review has two halves, and this config keeps them visibly apart:
+//
+//   1. The published half. eslint-plugin-obsidianmd is what Obsidian ships as
+//      the local equivalent of its guidelines, and its recommended config is
+//      applied here *verbatim* — the day it is hand-copied, it stops being a
+//      review and starts being a second opinion. Which findings it produces
+//      depends on the installed toolchain as much as on this file: the
+//      dashboard's 36 no-unnecessary-type-assertion findings for 2.2.2 need
+//      typescript-eslint 8.68 to appear at all (8.44 reports none of them), so
+//      keeping the toolchain current is part of keeping the gate honest.
+//   2. The reconstructed half. The dashboard's CSS analyser, capability
+//      disclosures and malware/dependency scans have no public implementation.
+//      What can be approximated lives in eslint.review.css.config.mjs and
+//      scripts/obsidian-review-capabilities.mjs, quoting the dashboard's own
+//      wording, and is marked as an approximation wherever it is reported.
+//      It is kept in a separate config on purpose: the recommended config
+//      above applies js.configs.recommended to every file it is asked about,
+//      and those rules crash on a CSS syntax tree.
+//
+// So a clean run here is not permission to publish; a failing one is a
+// guarantee that publishing is refused.
 // eslint.config.mjs is the day-to-day lint; this one is the release gate.
 import obsidianmd from "eslint-plugin-obsidianmd";
 import tseslint from "typescript-eslint";

--- a/eslint.review.css.config.mjs
+++ b/eslint.review.css.config.mjs
@@ -1,0 +1,33 @@
+// The reconstructed CSS half of the Obsidian plugin review.
+//
+// Separate from eslint.review.config.mjs for two reasons. The honest one: the
+// rules here are ours, rebuilt from the findings the dashboard returned, and
+// nothing about them should be mistaken for the config Obsidian publishes. The
+// mechanical one: eslint-plugin-obsidianmd's recommended config layers
+// js.configs.recommended over every file, and those rules throw on a CSS tree
+// (`sourceCode.getAllComments is not a function`), so the two cannot share a
+// config array.
+//
+// scripts/obsidian-review.mjs runs both and merges the reports.
+import css from "@eslint/css";
+import obsidianReviewApprox from "./scripts/obsidian-review-css.mjs";
+
+export default [
+  {
+    ignores: ["node_modules/**", "dist/**", "build/**", "coverage/**", "tmp/**"],
+  },
+  {
+    files: ["**/*.css"],
+    plugins: { css, "obsidian-review-approx": obsidianReviewApprox },
+    language: "css/css",
+    rules: {
+      // @eslint/css's own rule. Its wording differs from the dashboard's
+      // ("Unexpected !important flag found." vs "Avoid !important — override
+      // styles by increasing selector specificity or using CSS variables
+      // instead."), and it stays as published rather than being reworded.
+      "css/no-important": "error",
+      "obsidian-review-approx/no-has": "error",
+      "obsidian-review-approx/partially-supported-feature": "error",
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@codemirror/state": "6.5.0",
         "@codemirror/view": "6.38.6",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
+        "@eslint/css": "^1.4.0",
         "@eslint/js": "^9.36.0",
         "@lezer/highlight": "^1.2.3",
         "@noble/curves": "^1.9.7",
@@ -1427,6 +1428,62 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-1.4.0.tgz",
+      "integrity": "sha512-OnRNKgnbX+tufPuZc2kOJS+v1iIARvfJHRNEAVwN77DBpojl+rGjEP8NKTL6pEZ7BR+HtwIuSSdrymEFlANGxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "@eslint/css-tree": "^4.0.4",
+        "@eslint/plugin-kit": "^0.7.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/css-tree": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.5.tgz",
+      "integrity": "sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.29.0",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/css/node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/css/node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -7536,6 +7593,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.29.0.tgz",
+      "integrity": "sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8694,6 +8758,16 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "esbuild": "^0.25.9",
         "eslint": "^9.36.0",
         "eslint-plugin-no-unsanitized": "^4.1.5",
-        "eslint-plugin-obsidianmd": "^0.4.1",
+        "eslint-plugin-obsidianmd": "^0.4.2",
         "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
@@ -34,7 +34,7 @@
         "ts-jest": "^29.4.4",
         "tslib": "^2.8.1",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.44.1",
+        "typescript-eslint": "^8.68.0",
         "yaml": "^2.9.0"
       },
       "engines": {
@@ -1357,10 +1357,11 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -1387,10 +1388,11 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -2273,41 +2275,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2599,20 +2566,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
-      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
+      "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/type-utils": "8.44.1",
-        "@typescript-eslint/utils": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/type-utils": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2622,31 +2589,33 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.44.1",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.68.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.7.tgz",
+      "integrity": "sha512-dML0wP6oak21rsNYCJpJB6O1BJIEwNpGrTw0URPfAk4hm0e3pRfCtzkfB6olBcXcVlU2rouCyz7lCyRB0OMVCA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
-      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
+      "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2656,19 +2625,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
-      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
+      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.44.1",
-        "@typescript-eslint/types": "^8.44.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.68.0",
+        "@typescript-eslint/types": "^8.68.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2678,17 +2648,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
-      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
+      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1"
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2699,10 +2670,11 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
-      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
+      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2711,20 +2683,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
-      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
+      "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1",
-        "@typescript-eslint/utils": "8.44.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2734,15 +2707,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
-      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2752,21 +2726,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
-      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
+      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.44.1",
-        "@typescript-eslint/tsconfig-utils": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.68.0",
+        "@typescript-eslint/tsconfig-utils": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2776,40 +2750,54 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2818,15 +2806,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
-      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
+      "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2836,18 +2825,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
-      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
+      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.68.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2855,6 +2845,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -3561,19 +3564,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.25.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
@@ -4007,9 +3997,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4832,9 +4822,9 @@
       }
     },
     "node_modules/eslint-plugin-obsidianmd": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz",
-      "integrity": "sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.2.tgz",
+      "integrity": "sha512-NFp6wsRSvN0TU6EPi03uF2UQ3GuYyVtzjKDl25KyP8Bnz8gM0unX7R/e+VQ2JtMW2/3DC/VwIXjHnzAhB9JQwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5242,34 +5232,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -5300,15 +5262,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5329,19 +5282,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -5702,12 +5642,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -6236,16 +6170,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -7607,29 +7531,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -8270,26 +8171,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -8445,45 +8326,12 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -9191,6 +9039,54 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -9217,19 +9113,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/toml-eslint-parser": {
       "version": "0.9.3",
@@ -9285,10 +9168,11 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.12"
       },
@@ -9548,15 +9432,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.1.tgz",
-      "integrity": "sha512-0ws8uWGrUVTjEeN2OM4K1pLKHK/4NiNP/vz6ns+LjT/6sqpaYzIVFajZb1fj/IDwpsrrHb3Jy0Qm5u9CPcKaeg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
+      "integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.44.1",
-        "@typescript-eslint/parser": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1",
-        "@typescript-eslint/utils": "8.44.1"
+        "@typescript-eslint/eslint-plugin": "8.68.0",
+        "@typescript-eslint/parser": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9566,8 +9451,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@codemirror/state": "6.5.0",
     "@codemirror/view": "6.38.6",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
+    "@eslint/css": "^1.4.0",
     "@eslint/js": "^9.36.0",
     "@lezer/highlight": "^1.2.3",
     "@noble/curves": "^1.9.7",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "esbuild": "^0.25.9",
     "eslint": "^9.36.0",
     "eslint-plugin-no-unsanitized": "^4.1.5",
-    "eslint-plugin-obsidianmd": "^0.4.1",
+    "eslint-plugin-obsidianmd": "^0.4.2",
     "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
@@ -47,7 +47,7 @@
     "ts-jest": "^29.4.4",
     "tslib": "^2.8.1",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.44.1",
+    "typescript-eslint": "^8.68.0",
     "yaml": "^2.9.0"
   }
 }

--- a/scripts/obsidian-review-capabilities.mjs
+++ b/scripts/obsidian-review-capabilities.mjs
@@ -1,0 +1,120 @@
+// The capability disclosures the Obsidian dashboard prints for this plugin.
+//
+// Those lines are not lint findings and have no public implementation: the
+// dashboard derives them from the release artifact, which is why they name
+// capabilities (`fs`, `child_process`) that src/ reaches only through
+// `require`. This module reconstructs them from the built bundle for the same
+// reason -- what ships is what gets reviewed -- and points at the src/ lines
+// responsible so the disclosure is actionable rather than merely alarming.
+//
+// A disclosure is not a finding. Obsidian does not refuse a plugin for having
+// these capabilities; it tells users about them. So this never fails the gate.
+// What it is for: noticing the day a capability appears that nobody meant to
+// ship.
+import fs from "node:fs";
+import path from "node:path";
+
+// Wording copied from the dashboard's own report for taskchute-plus 2.2.2.
+// Anything not in this table is still reported, just without their phrasing --
+// inventing an official-sounding sentence for it would be worse than saying
+// plainly that we do not know how they word it.
+const KNOWN_CAPABILITIES = new Map([
+  [
+    "fs",
+    {
+      title: "Direct Filesystem Access",
+      detail:
+        "Uses the Node.js fs module to access the filesystem outside of the Obsidian vault API. Can read and write any file on the system.",
+    },
+  ],
+  [
+    "child_process",
+    {
+      title: "Shell Execution",
+      detail:
+        "Executes shell commands via child_process. Gives the plugin full control over the system.",
+    },
+  ],
+]);
+
+// `require("fs")`, `require('node:fs')`, `from "child_process"`, and the
+// import-expression form. esbuild leaves all of them as literals, so a regex
+// over the bundle is enough; a parse would buy nothing on 3 MB of output.
+const MODULE_REFERENCE =
+  /(?:require|import)\s*\(\s*["']([^"']+)["']\s*\)|from\s+["']([^"']+)["']/g;
+
+function normalize(specifier) {
+  return specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+}
+
+function collectModules(source) {
+  const found = new Map();
+  for (const match of source.matchAll(MODULE_REFERENCE)) {
+    const specifier = match[1] ?? match[2];
+    if (!specifier) continue;
+    const name = normalize(specifier);
+    found.set(name, (found.get(name) ?? 0) + 1);
+  }
+  return found;
+}
+
+function listSourceFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...listSourceFiles(full));
+    else if (entry.name.endsWith(".ts")) files.push(full);
+  }
+  return files;
+}
+
+// Which src/ lines put the capability in the bundle. Comments mentioning a
+// module are not evidence, so only lines that actually reference it as a
+// module specifier count.
+function findEvidence(srcDir, moduleName) {
+  if (!fs.existsSync(srcDir)) return [];
+  const evidence = [];
+  for (const file of listSourceFiles(srcDir)) {
+    const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+    lines.forEach((line, index) => {
+      for (const match of line.matchAll(MODULE_REFERENCE)) {
+        const specifier = match[1] ?? match[2];
+        if (specifier && normalize(specifier) === moduleName) {
+          evidence.push({ file, line: index + 1 });
+        }
+      }
+    });
+  }
+  return evidence;
+}
+
+/**
+ * Reads the built bundle and returns the capabilities it discloses.
+ *
+ * @param {{ bundlePath: string, srcDir: string, builtins: Set<string> }} options
+ * @returns {{ module: string, title: string|null, detail: string|null, occurrences: number, evidence: { file: string, line: number }[] }[]}
+ */
+export function scanCapabilities({ bundlePath, srcDir, builtins }) {
+  const bundle = fs.readFileSync(bundlePath, "utf8");
+  const disclosures = [];
+
+  for (const [name, occurrences] of collectModules(bundle)) {
+    if (!builtins.has(name)) continue;
+    const known = KNOWN_CAPABILITIES.get(name);
+    disclosures.push({
+      module: name,
+      title: known?.title ?? null,
+      detail: known?.detail ?? null,
+      occurrences,
+      evidence: findEvidence(srcDir, name),
+    });
+  }
+
+  // Named capabilities first -- those are the ones the dashboard puts in front
+  // of a user deciding whether to install.
+  return disclosures.sort((a, b) => {
+    if (Boolean(a.title) !== Boolean(b.title)) return a.title ? -1 : 1;
+    return a.module.localeCompare(b.module);
+  });
+}

--- a/scripts/obsidian-review-css.mjs
+++ b/scripts/obsidian-review-css.mjs
@@ -1,0 +1,108 @@
+// The CSS half of the Obsidian plugin review — an *approximation*.
+//
+// Obsidian's dashboard reports CSS findings that no published package
+// implements: `eslint-plugin-obsidianmd` (0.4.2) carries no CSS rules at all
+// and does not depend on `@eslint/css`. The bot's own CSS analyser is not open
+// source, so everything below is reconstructed from the findings it returned
+// for this plugin, quoting its wording verbatim so a local report reads like
+// the dashboard's. Treat a clean run here as "no known regression", never as
+// "the dashboard will pass".
+//
+// What the dashboard reported for taskchute-plus 2.2.x, and where it lives now:
+//
+//   Avoid !important ...                        -> css/no-important (official
+//                                                  @eslint/css rule, kept as-is
+//                                                  even though its wording
+//                                                  differs from the bot's)
+//   Avoid :has ...                              -> no-has, below
+//   Unexpected browser feature "text-decoration" -> partially-supported-feature,
+//     is only partially supported by Obsidian      below
+//
+// Deliberately NOT enabled: `css/use-baseline`. It looks like the right rule
+// for the "browser feature" finding, but it answers a different question --
+// Baseline is "supported across Chrome, Edge, Firefox and Safari", while
+// Obsidian ships a single Chromium. Run against this stylesheet it reports 31
+// findings (user-select, resize, overscroll-behavior, ...) that the dashboard
+// does not, because Obsidian's Chromium supports them. A gate that cries wolf
+// 31 times is a gate people learn to ignore.
+
+// The bot names a fixed Obsidian version in its message rather than the
+// plugin's own minAppVersion (this plugin declares 1.13.0 and was told about
+// 1.11.4). It is a constant on their side, so it is a constant here too, and it
+// goes stale the same way theirs does.
+const OBSIDIAN_BASELINE = "1.11.4";
+
+// Shorthands the dashboard rejects unless they carry a single keyword. This is
+// the whole of what it flagged; it is a list of observations, not a model of
+// their analyser, so only add a property here after the dashboard names it.
+const SINGLE_KEYWORD_SHORTHANDS = new Set(["text-decoration"]);
+
+function valueChildren(value) {
+  if (!value) return [];
+  // css-tree hands back a List; @eslint/css exposes it untouched.
+  if (Array.isArray(value.children)) return value.children;
+  if (typeof value.children?.toArray === "function") return value.children.toArray();
+  return [];
+}
+
+const noHas = {
+  meta: {
+    type: "problem",
+    docs: { description: "Avoid the :has() selector, as Obsidian's plugin review rejects it." },
+    schema: [],
+    messages: {
+      avoidHas:
+        "Avoid :has — it can cause significant performance issues due to broad selector invalidation.",
+    },
+  },
+  create(context) {
+    const { sourceCode } = context;
+    return {
+      PseudoClassSelector(node) {
+        if (node.name !== "has") return;
+        context.report({ loc: sourceCode.getLoc(node), messageId: "avoidHas" });
+      },
+    };
+  },
+};
+
+const partiallySupportedFeature = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Avoid shorthand forms Obsidian's bundled Chromium only partially supports.",
+    },
+    schema: [],
+    messages: {
+      partiallySupported:
+        'Unexpected browser feature "{{feature}}" is only partially supported by Obsidian {{version}}',
+    },
+  },
+  create(context) {
+    const { sourceCode } = context;
+    return {
+      Declaration(node) {
+        if (!SINGLE_KEYWORD_SHORTHANDS.has(node.property)) return;
+        // One keyword is accepted (`text-decoration: none`); the multi-value
+        // form is what gets flagged, and the longhands are the way out.
+        if (valueChildren(node.value).length < 2) return;
+        context.report({
+          loc: sourceCode.getLoc(node),
+          messageId: "partiallySupported",
+          data: { feature: node.property, version: OBSIDIAN_BASELINE },
+        });
+      },
+    };
+  },
+};
+
+export default {
+  meta: { name: "obsidian-review-approx" },
+  rules: {
+    "no-has": noHas,
+    "partially-supported-feature": partiallySupportedFeature,
+  },
+};
+
+export { OBSIDIAN_BASELINE };

--- a/scripts/obsidian-review.mjs
+++ b/scripts/obsidian-review.mjs
@@ -1,14 +1,37 @@
 #!/usr/bin/env node
-// Runs the Obsidian plugin review gate (eslint.review.config.mjs) and reports
-// it three ways: stylish text on stdout, GitHub annotations, and a job summary.
-// Errors fail the run; warnings are reported and tolerated, which is how
-// Obsidian's own review treats them.
+// Runs the Obsidian plugin review gate and reports it three ways: stylish text
+// on stdout, GitHub annotations, and a job summary. Errors fail the run;
+// warnings are reported and tolerated, which is how Obsidian's own review
+// treats them.
+//
+// Three layers, in descending order of how much they can be trusted:
+//
+//   eslint.review.config.mjs      eslint-plugin-obsidianmd, applied verbatim.
+//                                 This is Obsidian's own published config.
+//   eslint.review.css.config.mjs  our reconstruction of the dashboard's CSS
+//                                 findings. Validated against 2.2.2, where it
+//                                 reproduces the dashboard's counts exactly.
+//   obsidian-review-capabilities  the disclosures the dashboard prints for the
+//                                 release artifact. Never fails the run.
+//
+// The dashboard additionally runs malware and dependency scans with no public
+// implementation, so a clean run here is not permission to publish. Obsidian's
+// own preview scan (developer dashboard, any branch/tag/commit) remains the
+// only way to see the whole review.
 import fs from "node:fs";
 import path from "node:path";
+import { builtinModules } from "node:module";
 import { ESLint } from "eslint";
+import { scanCapabilities } from "./obsidian-review-capabilities.mjs";
 
 const REVIEW_CONFIG = "eslint.review.config.mjs";
 const REVIEW_TARGETS = ["src", "manifest.json", "LICENSE", "package.json"];
+const CSS_CONFIG = "eslint.review.css.config.mjs";
+const CSS_TARGETS = ["styles.css"];
+// The capability scan reads what actually ships, so it needs a build. The
+// release workflow builds before this step for exactly this reason.
+const BUNDLE_PATH = "main.js";
+const SRC_DIR = "src";
 const REPORT_PATH = "obsidian-review.json";
 const GUIDELINES_URL =
   "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines";
@@ -63,7 +86,24 @@ function table(rows) {
   return lines.join("\n");
 }
 
-function writeSummary(errors, warnings) {
+function disclosureLines(disclosures) {
+  return disclosures.map((disclosure) => {
+    const where = disclosure.evidence
+      .slice(0, 3)
+      .map((item) => `${relative(item.file)}:${item.line}`)
+      .join(", ");
+    const rest = disclosure.evidence.length > 3
+      ? ` (+${disclosure.evidence.length - 3} more)`
+      : "";
+    const headline = disclosure.title
+      ? `${disclosure.title}: ${disclosure.detail}`
+      : `Uses the Node.js ${disclosure.module} module. The dashboard's wording `
+        + "for this one has not been seen, so this is our own.";
+    return { headline, where: where ? `${where}${rest}` : "(not reached from src/)" };
+  });
+}
+
+function writeSummary(errors, warnings, disclosures) {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) return;
 
@@ -92,19 +132,53 @@ function writeSummary(errors, warnings) {
       "",
     );
   }
+  if (disclosures.length > 0) {
+    parts.push(
+      "### Capabilities disclosed to users",
+      "",
+      "These are not findings. Obsidian shows them to anyone deciding whether"
+        + " to install, and they are derived from the built bundle.",
+      "",
+      "| Capability | Reached from |",
+      "| --- | --- |",
+      ...disclosureLines(disclosures).map(
+        ({ headline, where }) => `| ${escapeCell(headline)} | ${escapeCell(where)} |`,
+      ),
+      "",
+    );
+  }
   parts.push(
-    "> This gate runs `eslint-plugin-obsidianmd`, the checks Obsidian publishes"
-      + " for local use. The dashboard also runs malware and dependency scans"
-      + " that cannot be reproduced here, so a pass is not a guarantee of"
-      + " publication.",
+    "> Only the error and warning tables come from `eslint-plugin-obsidianmd`,"
+      + " the config Obsidian publishes. The CSS findings and the capability"
+      + " list are reconstructions of a dashboard whose implementation is not"
+      + " public, and the malware and dependency scans cannot be reproduced"
+      + " here at all — so a pass is not a guarantee of publication.",
     "",
   );
 
   fs.appendFileSync(summaryPath, parts.join("\n"), "utf8");
 }
 
+if (!fs.existsSync(BUNDLE_PATH)) {
+  process.stdout.write(
+    `${BUNDLE_PATH} is missing, and the capability disclosures are read from it`
+      + " rather than from src/, because that is what Obsidian reviews. Run"
+      + " `npm run build` first.\n",
+  );
+  process.exit(1);
+}
+
 const eslint = new ESLint({ overrideConfigFile: REVIEW_CONFIG });
-const results = await eslint.lintFiles(REVIEW_TARGETS);
+const cssEslint = new ESLint({ overrideConfigFile: CSS_CONFIG });
+const results = [
+  ...(await eslint.lintFiles(REVIEW_TARGETS)),
+  ...(await cssEslint.lintFiles(CSS_TARGETS)),
+];
+const disclosures = scanCapabilities({
+  bundlePath: BUNDLE_PATH,
+  srcDir: SRC_DIR,
+  builtins: new Set(builtinModules),
+});
 
 const stylish = await eslint.loadFormatter("stylish");
 const rendered = await stylish.format(results);
@@ -112,8 +186,11 @@ if (rendered.trim().length > 0) {
   process.stdout.write(rendered.endsWith("\n") ? rendered : `${rendered}\n`);
 }
 
-const jsonFormatter = await eslint.loadFormatter("json");
-fs.writeFileSync(REPORT_PATH, await jsonFormatter.format(results), "utf8");
+fs.writeFileSync(
+  REPORT_PATH,
+  `${JSON.stringify({ findings: results, disclosures }, null, 2)}\n`,
+  "utf8",
+);
 
 const errors = [];
 const warnings = [];
@@ -128,10 +205,17 @@ if (process.env.GITHUB_ACTIONS === "true") {
   for (const { file, message } of warnings) annotate("warning", file, message);
 }
 
-writeSummary(errors, warnings);
+// Disclosures are printed on every run, passing or not: their whole value is
+// being read when nothing is wrong, so that a new one gets noticed.
+for (const { headline, where } of disclosureLines(disclosures)) {
+  process.stdout.write(`disclosure: ${headline}\n  reached from ${where}\n`);
+}
+
+writeSummary(errors, warnings, disclosures);
 
 process.stdout.write(
-  `Obsidian plugin review: ${errors.length} error(s), ${warnings.length} warning(s); report written to ${REPORT_PATH}\n`,
+  `Obsidian plugin review: ${errors.length} error(s), ${warnings.length} warning(s), `
+    + `${disclosures.length} capability disclosure(s); report written to ${REPORT_PATH}\n`,
 );
 
 if (errors.length > 0) {

--- a/src/features/ai-task/services/AiTaskRuntimeLease.ts
+++ b/src/features/ai-task/services/AiTaskRuntimeLease.ts
@@ -201,13 +201,13 @@ function terminalRendererLeaseIdentity(
 }
 
 function runtimeWindow(): AiTaskRuntimeWindow {
-  return window as unknown as AiTaskRuntimeWindow
+  return window
 }
 
 function legacyFocusedRuntimeWindow(): AiTaskRuntimeWindow | undefined {
   try {
     if (typeof activeWindow === 'undefined') return undefined
-    return activeWindow as unknown as AiTaskRuntimeWindow
+    return activeWindow
   } catch {
     return undefined
   }

--- a/src/features/ai-task/services/AiTaskWorkingDirectoryCandidates.ts
+++ b/src/features/ai-task/services/AiTaskWorkingDirectoryCandidates.ts
@@ -24,9 +24,7 @@ export function collectAiTaskWorkingDirectoryCandidates(
   for (const file of files) {
     let frontmatter: Record<string, unknown> | undefined
     try {
-      frontmatter = app.metadataCache.getFileCache(file)?.frontmatter as
-        | Record<string, unknown>
-        | undefined
+      frontmatter = app.metadataCache.getFileCache(file)?.frontmatter
     } catch {
       // One stale/broken cache entry must not hide candidates from later files.
       continue

--- a/src/features/ai-task/ui/ObsidianTaskLinkFields.ts
+++ b/src/features/ai-task/ui/ObsidianTaskLinkFields.ts
@@ -252,9 +252,7 @@ function collectHumanTaskTitles(
   const titles = new Set<string>()
   for (const file of files) {
     if (excludePath && file.path === excludePath) continue
-    const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter as
-      | Record<string, unknown>
-      | undefined
+    const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter
     if (frontmatter?.['ai_task'] === true) continue
     const title = resolveTaskDisplayTitle(frontmatter, file.basename)
     if (title) titles.add(title)

--- a/src/features/core/services/TaskLoaderService.ts
+++ b/src/features/core/services/TaskLoaderService.ts
@@ -99,7 +99,7 @@ export interface TaskLoaderHost {
 const DEFAULT_SLOT_KEY = 'none'
 
 function resolveTaskId(metadata?: TaskFrontmatterWithLegacy): string | undefined {
-  return extractTaskIdFromFrontmatter(metadata as Record<string, unknown> | undefined)
+  return extractTaskIdFromFrontmatter(metadata)
 }
 
 function promoteDeletedEntriesToTaskId(
@@ -1184,7 +1184,7 @@ function migrateDayStateSlotKeys(context: TaskLoaderHost, state: DayState): bool
   // Migrate duplicatedInstances – clear invalid slotKey/originalSlotKey for downstream re-calculation
   if (Array.isArray(state.duplicatedInstances)) {
     for (const dup of state.duplicatedInstances) {
-      const dupRecord = dup as DuplicatedRecord
+      const dupRecord = dup
       if (dupRecord.slotKey && !config.isValidSlotKey(dupRecord.slotKey)) {
         dupRecord.slotKey = undefined
         mutated = true

--- a/src/features/core/services/TaskOrderManager.ts
+++ b/src/features/core/services/TaskOrderManager.ts
@@ -247,7 +247,7 @@ export class TaskOrderManager {
     }
 
     const working = [...sameTasks];
-    const needsSeed = working.some((inst) => !Number.isFinite(inst.order as number));
+    const needsSeed = working.some((inst) => !Number.isFinite(inst.order));
     if (needsSeed) {
       this.normalizeOrdersForDrag(working);
     }

--- a/src/features/core/services/TaskReuseService.ts
+++ b/src/features/core/services/TaskReuseService.ts
@@ -103,11 +103,11 @@ export class TaskReuseService {
 
     const timestamp = Date.now()
     const metadata = this.plugin.app.metadataCache.getFileCache(file)
-    const frontmatter = metadata?.frontmatter as Record<string, unknown> | undefined
+    const frontmatter = metadata?.frontmatter
     const scheduledTime = options?.scheduledTime
       ?? getScheduledTime(frontmatter)
     const resolvedSlotKey = this.resolveSlotKey(options?.slotKey, scheduledTime)
-    let taskId = extractTaskIdFromFrontmatter(metadata?.frontmatter as Record<string, unknown> | undefined)
+    let taskId = extractTaskIdFromFrontmatter(metadata?.frontmatter)
     if (!taskId) {
       try {
         const manager = new TaskIdManager(this.plugin)

--- a/src/features/core/views/TaskChuteView.ts
+++ b/src/features/core/views/TaskChuteView.ts
@@ -374,8 +374,8 @@ export class TaskChuteView
       registerManagedDomEvent: (target, event, handler) =>
         this.registerManagedDomEvent(
           target,
-          event as keyof DocumentEventMap | keyof HTMLElementEventMap,
-          handler as EventListener,
+          event,
+          handler,
         ),
       getContainer: () => this.containerEl,
       selectionController: this.taskSelectionController,
@@ -4313,7 +4313,7 @@ export class TaskChuteView
         task.file = file
         task.name = file.basename
         task.displayTitle = displayTitle
-        task.frontmatter = metadata as Record<string, unknown>
+        task.frontmatter = metadata
       })
 
       this.taskInstances.forEach((inst) => {

--- a/src/features/license/index.ts
+++ b/src/features/license/index.ts
@@ -12,7 +12,6 @@ import type { App } from 'obsidian'
 import type { TaskChuteSettings } from '../../types'
 import { LicenseApiClient } from './services/LicenseApiClient'
 import { LicenseManager } from './services/LicenseManager'
-import type { LicenseStorageBridge } from './services/LicenseStore'
 import { LicenseStore } from './services/LicenseStore'
 
 /** Electron's CommonJS require, available in Obsidian desktop only. */
@@ -107,7 +106,7 @@ export function createLicenseManager(plugin: LicensePluginLike): LicenseManager 
 
   // App exposes loadLocalStorage/saveLocalStorage but does not declare them in
   // the public typings; the same cast is used by AiCustomModelStore's callers.
-  const store = new LicenseStore(plugin.app as unknown as LicenseStorageBridge)
+  const store = new LicenseStore(plugin.app)
   const client = new LicenseApiClient({ log })
 
   const platform = describePlatform()

--- a/src/features/license/services/LicenseApiClient.ts
+++ b/src/features/license/services/LicenseApiClient.ts
@@ -237,7 +237,7 @@ function toFailure(status: number, payload: unknown): LicenseApiFailure {
     status,
     ...(typeof message === 'string' ? { message } : {}),
     ...(typeof details === 'object' && details !== null
-      ? { details: details as LicenseErrorDetails }
+      ? { details: details }
       : {}),
   }
 }

--- a/src/features/log/services/BackupRestoreService.ts
+++ b/src/features/log/services/BackupRestoreService.ts
@@ -400,7 +400,7 @@ export class BackupRestoreService {
       ]
       const hasKnownEntryKey = knownEntryKeys.some((key) => key in asRecord)
       if (hasKnownEntryKey) {
-        normalized[dateKey] = [asRecord as TaskLogEntry]
+        normalized[dateKey] = [asRecord]
         continue
       }
 

--- a/src/features/log/services/RecordsRebuilder.ts
+++ b/src/features/log/services/RecordsRebuilder.ts
@@ -270,7 +270,7 @@ export class RecordsRebuilder {
         typeof value === 'boolean' ||
         value === null
       ) {
-        record[key] = value as RecordsEntry[keyof RecordsEntry]
+        record[key] = value
       }
     }
     return record

--- a/src/features/log/services/RecordsWriter.ts
+++ b/src/features/log/services/RecordsWriter.ts
@@ -49,7 +49,7 @@ function compactObject<T extends Record<string, unknown>>(input: T): Partial<T> 
     if (typeof value === 'object') {
       if (Array.isArray(value)) {
         if (value.length === 0) continue
-      } else if (Object.keys(value as Record<string, unknown>).length === 0) {
+      } else if (Object.keys(value).length === 0) {
         continue
       }
     }

--- a/src/features/recipe/services/RecipeDocumentCodec.ts
+++ b/src/features/recipe/services/RecipeDocumentCodec.ts
@@ -554,8 +554,8 @@ export class RecipeDocumentCodec {
       schemaVersion,
       title,
       goal: stripManagedHeading(section('goal')),
-      steps: parseChecklist(section('checklist'), 'step', true) as RecipeStep[],
-      qualityChecks: parseChecklist(section('quality-checklist'), 'quality', true) as RecipeQualityCheck[],
+      steps: parseChecklist(section('checklist'), 'step', true),
+      qualityChecks: parseChecklist(section('quality-checklist'), 'quality', true),
       constraints: parseConstraints(section('constraints')),
     }
   }

--- a/src/features/recipe/services/RecipeService.ts
+++ b/src/features/recipe/services/RecipeService.ts
@@ -136,7 +136,7 @@ export class RecipeService {
 
     const raw = await this.plugin.app.vault.read(file)
     const parsedRecipe = this.documentCodec.parse(raw)
-    const frontmatter = this.plugin.app.metadataCache.getFileCache(file)?.frontmatter as Record<string, unknown> | undefined
+    const frontmatter = this.plugin.app.metadataCache.getFileCache(file)?.frontmatter
     const title = parsedRecipe.title
       ?? (typeof frontmatter?.title === 'string' && frontmatter.title.trim().length > 0
       ? frontmatter.title.trim()
@@ -229,7 +229,7 @@ export class RecipeService {
     const taskFolderPath = this.plugin.pathManager.getTaskFolderPath()
     return listFilesInFolder(this.plugin.app, taskFolderPath, { markdownOnly: true })
       .reduce<Array<{ path: string; title: string }>>((usages, file) => {
-        const frontmatter = this.plugin.app.metadataCache.getFileCache(file)?.frontmatter as Record<string, unknown> | undefined
+        const frontmatter = this.plugin.app.metadataCache.getFileCache(file)?.frontmatter
         const taskRecipePath = normalizeRecipeReference(frontmatter?.recipe)
         if (taskRecipePath !== normalizedRecipePath) return usages
         const title = typeof frontmatter?.title === 'string' && frontmatter.title.trim().length > 0

--- a/src/features/reminder/modals/ReminderNotificationModal.ts
+++ b/src/features/reminder/modals/ReminderNotificationModal.ts
@@ -27,13 +27,13 @@ const createElCompat = <K extends keyof HTMLElementTagNameMap>(
   tag: K,
   options?: CreateElOptions
 ): HTMLElementTagNameMap[K] => {
-  const maybeCreateEl = (
-    parent as HTMLElement & {
-      createEl?: (tagName: string, options?: Record<string, unknown>) => HTMLElement;
-    }
-  ).createEl;
-  if (typeof maybeCreateEl === 'function') {
-    return maybeCreateEl.call(parent, tag, options as Record<string, unknown>) as HTMLElementTagNameMap[K];
+  // Called as a method rather than through `.call`, so `this` is bound by the
+  // call itself: no unbound-method finding, and no assertion on the result.
+  const host = parent as HTMLElement & {
+    createEl?: (tagName: string, options?: Record<string, unknown>) => HTMLElement;
+  };
+  if (typeof host.createEl === 'function') {
+    return host.createEl(tag, options) as HTMLElementTagNameMap[K];
   }
   const element = createEl(tag);
   if (options?.cls) {

--- a/src/features/reminder/ui/ReminderIconRenderer.ts
+++ b/src/features/reminder/ui/ReminderIconRenderer.ts
@@ -114,12 +114,11 @@ export class ReminderIconRenderer {
     tag: string,
     options?: { cls?: string; attr?: Record<string, string> }
   ): SVGElement {
-    const host = parent as (HTMLElement | SVGElement) & {
-      createSvg?: (tagName: string, options?: Record<string, unknown>) => SVGElement;
-    };
-
-    if (typeof host.createSvg === 'function') {
-      return host.createSvg(tag, options);
+    // No cast on `parent`: Obsidian augments both HTMLElement and SVGElement
+    // with createSvg, so one would not change the type. The tag is narrowed
+    // instead, exactly as the fallback below does.
+    if (typeof parent.createSvg === 'function') {
+      return parent.createSvg(tag as keyof SVGElementTagNameMap, options);
     }
 
     // Fallback for non-Obsidian environments

--- a/src/features/routine/controllers/RoutineController.ts
+++ b/src/features/routine/controllers/RoutineController.ts
@@ -1064,7 +1064,7 @@ export default class RoutineController {
           task.monthly_week = 'last'
           task.routine_week = 'last'
         } else if (typeof singleWeek === 'number') {
-          task.monthly_week = (singleWeek - 1) as RoutineWeek
+          task.monthly_week = (singleWeek - 1)
           task.routine_week = singleWeek
         }
       } else {

--- a/src/features/routine/modals/RoutineEditModal.ts
+++ b/src/features/routine/modals/RoutineEditModal.ts
@@ -667,7 +667,7 @@ export default class RoutineEditModal extends Modal {
     return {
       isRoutine: true,
       name: this.file.basename ?? "untitled",
-    } as RoutineFrontmatter
+    }
   }
 
   private normalizeRoutineType(type: unknown): RoutineType {

--- a/src/features/routine/services/RoutineService.ts
+++ b/src/features/routine/services/RoutineService.ts
@@ -1,5 +1,5 @@
 import { RoutineRule } from '../../../types';
-import type { RoutineWeek, RoutineMonthday } from '../../../types/TaskFields';
+import type { RoutineMonthday } from '../../../types/TaskFields';
 
 /**
  * RoutineService
@@ -66,7 +66,7 @@ export class RoutineService {
           if (Number.isFinite(raw)) {
             const zeroBased = Math.floor(raw);
             if (zeroBased >= 0 && zeroBased <= 4) {
-              week = (zeroBased + 1) as RoutineWeek;
+              week = (zeroBased + 1);
             }
           }
         }
@@ -278,7 +278,7 @@ export class RoutineService {
         const key = String(parsed);
         if (!seen.has(key)) {
           seen.add(key);
-          result.push(parsed as RoutineWeek);
+          result.push(parsed);
         }
       }
     }

--- a/src/services/TaskIdManager.ts
+++ b/src/services/TaskIdManager.ts
@@ -71,7 +71,7 @@ export class TaskIdManager {
 
   async ensureTaskIdForFile(file: TFile): Promise<string | null> {
     const cached = this.plugin.app.metadataCache.getFileCache(file)
-    const existing = extractTaskIdFromFrontmatter(cached?.frontmatter as Record<string, unknown> | undefined)
+    const existing = extractTaskIdFromFrontmatter(cached?.frontmatter)
     if (existing) {
       if (cached?.frontmatter && cached.frontmatter[TASK_ID_FRONTMATTER_KEY] !== existing) {
         await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter) => {

--- a/src/ui/modals/ConfirmModal.ts
+++ b/src/ui/modals/ConfirmModal.ts
@@ -23,11 +23,13 @@ const createElCompat = <K extends keyof HTMLElementTagNameMap>(
   tag: K,
   options?: CreateElOptions,
 ): HTMLElementTagNameMap[K] => {
-  const maybeCreateEl = (parent as HTMLElement & {
+  // Called as a method rather than through `.call`, so `this` is bound by the
+  // call itself: no unbound-method finding, and no assertion on the result.
+  const host = parent as HTMLElement & {
     createEl?: (tagName: string, options?: Record<string, unknown>) => HTMLElement
-  }).createEl
-  if (typeof maybeCreateEl === 'function') {
-    return maybeCreateEl.call(parent, tag, options as Record<string, unknown>) as HTMLElementTagNameMap[K]
+  }
+  if (typeof host.createEl === 'function') {
+    return host.createEl(tag, options) as HTMLElementTagNameMap[K]
   }
   const element = createEl(tag)
   if (options?.cls) {

--- a/src/ui/modals/DisambiguateStopTimeDateModal.ts
+++ b/src/ui/modals/DisambiguateStopTimeDateModal.ts
@@ -19,11 +19,13 @@ const createElCompat = <K extends keyof HTMLElementTagNameMap>(
   tag: K,
   options?: CreateElOptions,
 ): HTMLElementTagNameMap[K] => {
-  const maybeCreateEl = (parent as HTMLElement & {
+  // Called as a method rather than through `.call`, so `this` is bound by the
+  // call itself: no unbound-method finding, and no assertion on the result.
+  const host = parent as HTMLElement & {
     createEl?: (tagName: string, options?: Record<string, unknown>) => HTMLElement
-  }).createEl
-  if (typeof maybeCreateEl === 'function') {
-    return maybeCreateEl.call(parent, tag, options as Record<string, unknown>) as HTMLElementTagNameMap[K]
+  }
+  if (typeof host.createEl === 'function') {
+    return host.createEl(tag, options) as HTMLElementTagNameMap[K]
   }
   const element = createEl(tag)
   if (options?.cls) {

--- a/src/ui/task/TaskCompletionController.ts
+++ b/src/ui/task/TaskCompletionController.ts
@@ -287,7 +287,7 @@ export default class TaskCompletionController {
     try {
       const syncManager = new ProjectNoteSyncService(
         this.host.app as unknown as App,
-        this.host.plugin.pathManager as unknown as PathManagerLike,
+        this.host.plugin.pathManager,
       )
       const projectPath = syncManager.getProjectNotePath(inst)
       if (!projectPath) {

--- a/tests/commands/command-manager.test.ts
+++ b/tests/commands/command-manager.test.ts
@@ -29,7 +29,7 @@ describe('CommandRegistrar', () => {
     addCommand,
     app: appMock,
     showSettingsModal,
-  } as CommandHost;
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/execution/log-reconciler.test.ts
+++ b/tests/execution/log-reconciler.test.ts
@@ -2348,12 +2348,12 @@ describe('LogReconciler', () => {
       }
       const originalApply = reconcilerAny.applyRecordsToSnapshot.bind(reconcilerAny)
       let firstReplayBatchSize = -1
-      reconcilerAny.applyRecordsToSnapshot = ((records: unknown, ...rest: unknown[]) => {
+      reconcilerAny.applyRecordsToSnapshot = (records: unknown, ...rest: unknown[]) => {
         if (firstReplayBatchSize < 0 && Array.isArray(records)) {
           firstReplayBatchSize = records.length
         }
         return originalApply(records, ...rest)
-      }) as unknown as (...args: unknown[]) => number
+      }
 
       const stats = await reconciler.reconcilePendingDeltas()
       expect(stats.processedEntries).toBeGreaterThan(0)
@@ -2425,12 +2425,12 @@ describe('LogReconciler', () => {
       }
       const originalApply = reconcilerAny.applyRecordsToSnapshot.bind(reconcilerAny)
       let firstReplayBatchSize = -1
-      reconcilerAny.applyRecordsToSnapshot = ((records: unknown, ...rest: unknown[]) => {
+      reconcilerAny.applyRecordsToSnapshot = (records: unknown, ...rest: unknown[]) => {
         if (firstReplayBatchSize < 0 && Array.isArray(records)) {
           firstReplayBatchSize = records.length
         }
         return originalApply(records, ...rest)
-      }) as unknown as (...args: unknown[]) => number
+      }
 
       const stats = await reconciler.reconcilePendingDeltas()
       expect(stats.processedEntries).toBe(0)

--- a/tests/features/ai-task/ai-model-select-controller.test.ts
+++ b/tests/features/ai-task/ai-model-select-controller.test.ts
@@ -17,7 +17,7 @@ function rect(top: number, bottom: number): DOMRect {
     width: 500,
     height: bottom - top,
     toJSON: () => ({}),
-  } as DOMRect
+  }
 }
 
 const labels: AiModelSelectLabels = {

--- a/tests/features/ai-task/ai-run-pane-resize.test.ts
+++ b/tests/features/ai-task/ai-run-pane-resize.test.ts
@@ -109,7 +109,7 @@ describe('AI run pane drag resize', () => {
       registerManagedDisposer: () => () => undefined,
       saveLocalStorage,
       loadLocalStorage: (key: string) => stored.get(key),
-    } as unknown as AiRunPaneControllerHost
+    }
     controller = new AiRunPaneController(host)
   })
 

--- a/tests/features/ai-task/ai-task-obsidian-link-coordinator.test.ts
+++ b/tests/features/ai-task/ai-task-obsidian-link-coordinator.test.ts
@@ -50,7 +50,7 @@ function createInstance(options: InstanceOptions): TaskInstance {
     state: options.state ?? 'idle',
     slotKey: 'none',
     executedTitle: options.executedTitle,
-  } as TaskInstance
+  }
 }
 
 function createHuman(

--- a/tests/features/ai-task/ai-task-row-renderer-instances.test.ts
+++ b/tests/features/ai-task/ai-task-row-renderer-instances.test.ts
@@ -23,7 +23,7 @@ function createInstance(
     instanceId,
     state,
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 function createHost(

--- a/tests/features/ai-task/ai-task-row-renderer.test.ts
+++ b/tests/features/ai-task/ai-task-row-renderer.test.ts
@@ -17,7 +17,7 @@ function createInstance(
     instanceId: 'instance-1',
     state: 'idle',
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 function createHost(

--- a/tests/features/ai-task/ai-task-runtime-lease.test.ts
+++ b/tests/features/ai-task/ai-task-runtime-lease.test.ts
@@ -104,7 +104,7 @@ class FakeRuntimeWindow {
 }
 
 function runtimeWindow(value: FakeRuntimeWindow): AiTaskRuntimeWindow {
-  return value as unknown as AiTaskRuntimeWindow
+  return value
 }
 
 describe('AiTaskRuntimeLease', () => {

--- a/tests/features/ai-task/ai-task-settings-section.test.ts
+++ b/tests/features/ai-task/ai-task-settings-section.test.ts
@@ -82,7 +82,7 @@ function createTab(): { tab: TaskChuteSettingTab; plugin: FakePlugin } {
     plugins: { plugins: Record<string, unknown> }
   }).plugins.plugins['taskchute-plus'] = plugin
 
-  const tab = new TaskChuteSettingTab(app as never, plugin as never)
+  const tab = new TaskChuteSettingTab(app, plugin as never)
   return { tab, plugin }
 }
 

--- a/tests/features/ai-task/broker-source/owner-sentinel-probe-source.test.ts
+++ b/tests/features/ai-task/broker-source/owner-sentinel-probe-source.test.ts
@@ -226,7 +226,7 @@ describe('sentinelStateFrom', () => {
     ['a platform without a probe', 'unsupported', 'unknown'],
   ])('reads %s as %s', (_name, reading, expected) => {
     expect(
-      probe.sentinelStateFrom(identityOf('/tmp/owner.jsonl'), reading as Reading),
+      probe.sentinelStateFrom(identityOf('/tmp/owner.jsonl'), reading),
     ).toBe(expected)
   })
 

--- a/tests/features/ai-task/task-chute-view-ai-coupling.test.ts
+++ b/tests/features/ai-task/task-chute-view-ai-coupling.test.ts
@@ -312,7 +312,7 @@ function makeInstance(
     instanceId: 'inst-1',
     state: 'idle',
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 function makeHumanInstance(title: string, instanceId = 'human-1'): TaskInstance {
@@ -328,7 +328,7 @@ function makeHumanInstance(title: string, instanceId = 'human-1'): TaskInstance 
     instanceId,
     state: 'idle',
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 function makeLinkedAiInstance(

--- a/tests/features/ai-task/task-chute-view-ai-notices.test.ts
+++ b/tests/features/ai-task/task-chute-view-ai-notices.test.ts
@@ -7,7 +7,6 @@
  */
 import { Notice, TFile, WorkspaceLeaf } from 'obsidian'
 import { TaskChuteView } from '../../../src/features/core/views/TaskChuteView'
-import type { AiTaskManager } from '../../../src/features/ai-task/services/AiTaskManager'
 import {
   AiPromptNotFoundError,
   AiRunAlreadyActiveError,
@@ -159,7 +158,7 @@ function makeInstance(file: TFile | null = makeTaskFile()): TaskInstance {
     instanceId: 'inst-1',
     state: 'idle',
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 function makeRecord(overrides: Partial<AiRunRecord> = {}): AiRunRecord {
@@ -306,7 +305,7 @@ describe('TaskChuteView AI pane lifecycle on settings changes', () => {
     expect(paneContainer.querySelector('.ai-run-pane')).toBeNull()
 
     ;(plugin as { aiTaskManager?: unknown }).aiTaskManager =
-      manager as unknown as AiTaskManager
+      manager
     view.onAiTaskSettingsChanged()
 
     expect(paneContainer.querySelector('.ai-run-pane')).not.toBeNull()

--- a/tests/features/ai-task/task-chute-view-ai-start-options.test.ts
+++ b/tests/features/ai-task/task-chute-view-ai-start-options.test.ts
@@ -140,7 +140,7 @@ function makeInstance(instanceId = 'inst-1'): TaskInstance {
     instanceId,
     state: 'idle',
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 function makeRecord(overrides: Partial<AiRunRecord> = {}): AiRunRecord {

--- a/tests/features/ai-task/task-chute-view-board-view.test.ts
+++ b/tests/features/ai-task/task-chute-view-board-view.test.ts
@@ -143,7 +143,7 @@ function makeInstance(path: string, aiTask: boolean): TaskInstance {
     instanceId: `inst-${path}`,
     state: 'idle',
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 describe('TaskChuteView board view state', () => {

--- a/tests/features/ai-task/task-drag-board-view.test.ts
+++ b/tests/features/ai-task/task-drag-board-view.test.ts
@@ -44,7 +44,7 @@ function makeInstance(
     state: 'idle',
     slotKey: SLOT,
     order: options.order,
-  } as TaskInstance
+  }
 }
 
 function sortByOrder(items: TaskInstance[]): TaskInstance[] {

--- a/tests/features/ai-task/task-list-renderer-ai.test.ts
+++ b/tests/features/ai-task/task-list-renderer-ai.test.ts
@@ -73,7 +73,7 @@ function createAiInstance(): TaskInstance {
     instanceId: 'ai-instance-1',
     state: 'idle',
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 describe('TaskListRenderer AI task integration', () => {
@@ -200,7 +200,7 @@ describe('TaskListRenderer AI task integration', () => {
       instanceId: 'plain-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createBaseHost([plain])
     host.isAiTaskFeatureEnabled = () => true
     host.editAiTask = jest.fn()

--- a/tests/features/ai-task/task-list-renderer-board-view.test.ts
+++ b/tests/features/ai-task/task-list-renderer-board-view.test.ts
@@ -41,7 +41,7 @@ function makeInstance(
     instanceId: `inst-${path}`,
     state: 'idle',
     slotKey: 'none',
-  } as TaskInstance
+  }
 }
 
 function createHost(

--- a/tests/features/ai-task/working-directory-select-controller.test.ts
+++ b/tests/features/ai-task/working-directory-select-controller.test.ts
@@ -29,7 +29,7 @@ function rect(top: number, bottom: number): DOMRect {
     width: 500,
     height: bottom - top,
     toJSON: () => ({}),
-  } as DOMRect
+  }
 }
 
 describe('WorkingDirectorySelectController', () => {

--- a/tests/features/license/license-api-client.test.ts
+++ b/tests/features/license/license-api-client.test.ts
@@ -148,15 +148,20 @@ describe('isTransientFailure', () => {
     status,
   })
 
-  test.each([
-    ['network', { ok: false, kind: 'network' } as LicenseApiFailure, true],
+  // Annotated rather than asserted per row: the assertions this replaces read
+  // as unnecessary to no-unnecessary-type-assertion, but without them the two
+  // object literals widen and stop matching LicenseApiFailure.
+  const cases: Array<[string, LicenseApiFailure, boolean]> = [
+    ['network', { ok: false, kind: 'network' }, true],
     ['rate limited', api(429), true],
     ['server error', api(500), true],
     ['bad gateway', api(502), true],
     ['forbidden', api(403), false],
     ['conflict', api(409), false],
-    ['malformed request', { ok: false, kind: 'malformed', status: 400 } as LicenseApiFailure, false],
-  ])('%s -> %s', (_label, failure, expected) => {
+    ['malformed request', { ok: false, kind: 'malformed', status: 400 }, false],
+  ]
+
+  test.each(cases)('%s -> %s', (_label, failure, expected) => {
     expect(isTransientFailure(failure)).toBe(expected)
   })
 })

--- a/tests/features/task-reuse-service.test.ts
+++ b/tests/features/task-reuse-service.test.ts
@@ -61,7 +61,7 @@ describe('TaskReuseService', () => {
         mergeDayState: jest.fn(),
         clearCache: jest.fn(),
         renameTaskPath: jest.fn(),
-      } as unknown as TaskChutePluginLike['dayStateService'],
+      },
       routineAliasService: {} as TaskChutePluginLike['routineAliasService'],
       pathManager: {} as TaskChutePluginLike['pathManager'],
       settings: { slotKeys: {}, useOrderBasedSort: true },

--- a/tests/navigation/navigate-to-today.test.ts
+++ b/tests/navigation/navigate-to-today.test.ts
@@ -70,7 +70,7 @@ describe('Navigate to today (showTodayTasks)', () => {
           duplicatedInstances: [],
           slotOverrides: {},
           orders: {},
-        } as DayState)),
+        })),
         saveDay: jest.fn(),
       },
       routineAliasService: {
@@ -126,7 +126,7 @@ describe('Navigate to today (showTodayTasks)', () => {
         duplicatedInstances: [],
         slotOverrides: {},
         orders: {},
-      } as DayState;
+      };
 
       // showTodayTasksを呼び出す前の状態を確認
       expect(view['currentDayStateKey']).toBe(futureDateStr);
@@ -167,7 +167,7 @@ describe('Navigate to today (showTodayTasks)', () => {
         duplicatedInstances: [],
         slotOverrides: { 'TASKS/future-task.md': '10:00' },
         orders: {},
-      } as DayState);
+      });
 
       // ensureDayStateForCurrentDateをモック
       view['ensureDayStateForCurrentDate'] = jest.fn(async () => {
@@ -255,7 +255,7 @@ describe('Navigate to today (showTodayTasks)', () => {
         duplicatedInstances: [],
         slotOverrides: { 'TASKS/future-task.md': '15:00' },
         orders: { 'TASKS/future-task.md': 5 },
-      } as DayState;
+      };
 
       // showTodayTasksを実行
       view.showTodayTasks();

--- a/tests/recipe/recipe-ui.test.ts
+++ b/tests/recipe/recipe-ui.test.ts
@@ -996,7 +996,7 @@ describe('recipe UI helpers', () => {
           x: 0,
           y: 0,
           toJSON: () => ({}),
-        } as DOMRect
+        }
       }
       return {
         top: 0,
@@ -1008,7 +1008,7 @@ describe('recipe UI helpers', () => {
         x: 0,
         y: 0,
         toJSON: () => ({}),
-      } as DOMRect
+      }
     })
     const popover = new RecipeRunPopover({
       service: {

--- a/tests/reminder/reminder-icon-renderer.test.ts
+++ b/tests/reminder/reminder-icon-renderer.test.ts
@@ -297,7 +297,7 @@ describe('ReminderIconRenderer', () => {
 
     it('should not render icon for invalid reminder_time "abc"', () => {
       const renderer = new ReminderIconRenderer({ tv: mockTv });
-      const task = createMockTask('abc' as string);
+      const task = createMockTask('abc');
       const container = document.createElement('div');
 
       renderer.render(container, task);
@@ -342,7 +342,7 @@ describe('ReminderIconRenderer', () => {
 
     it('should return false from hasReminder for "abc"', () => {
       const renderer = new ReminderIconRenderer({ tv: mockTv });
-      const task = createMockTask('abc' as string);
+      const task = createMockTask('abc');
 
       expect(renderer.hasReminder(task)).toBe(false);
     });

--- a/tests/reminder/reminder-integration.test.ts
+++ b/tests/reminder/reminder-integration.test.ts
@@ -514,7 +514,7 @@ describe('ReminderSystemManager', () => {
         },
       ];
 
-      manager.buildTodaySchedules(tasks as unknown[]);
+      manager.buildTodaySchedules(tasks);
 
       const reminderService = manager.getReminderService();
       const schedules = reminderService.getSchedules();
@@ -548,7 +548,7 @@ describe('ReminderSystemManager', () => {
         },
       ];
 
-      manager.buildTodaySchedules(tasks as unknown[]);
+      manager.buildTodaySchedules(tasks);
 
       const reminderService = manager.getReminderService();
       const schedule = reminderService.getScheduleByPath('task1.md');
@@ -580,7 +580,7 @@ describe('ReminderSystemManager', () => {
         },
       ];
 
-      manager.buildTodaySchedules(tasks as unknown[]);
+      manager.buildTodaySchedules(tasks);
 
       const schedules = manager.getReminderService().getSchedules();
       expect(schedules.length).toBe(1);

--- a/tests/routine/routine-manager-modal.test.ts
+++ b/tests/routine/routine-manager-modal.test.ts
@@ -217,7 +217,7 @@ describe('RoutineManagerModal', () => {
 
   it('gives the remove confirmation the shared dialog chrome', async () => {
     const file = createFile('TASKS/routine.md')
-    file.stat = { ctime: 1, mtime: 1, size: 0 } as TFile['stat']
+    file.stat = { ctime: 1, mtime: 1, size: 0 }
     const folder = { path: 'TASKS', children: [file] }
 
     const app = {

--- a/tests/services/day-state-store.test.ts
+++ b/tests/services/day-state-store.test.ts
@@ -10,7 +10,7 @@ describe('DayStateStoreService', () => {
       slotOverrides: {},
       orders: {},
       ...overrides,
-    } as DayState;
+    };
   }
 
   function createDeps(initialStates: Record<string, DayState> = {}) {

--- a/tests/services/task-execution-service.test.ts
+++ b/tests/services/task-execution-service.test.ts
@@ -112,7 +112,7 @@ describe('TaskExecutionService', () => {
     jest.useFakeTimers().setSystemTime(new Date('2025-01-02T12:00:00.000Z'))
 
     const host = createHost({
-      getCurrentInstance: jest.fn().mockReturnValue({} as TaskInstance),
+      getCurrentInstance: jest.fn().mockReturnValue({}),
       hasRunningInstances: jest.fn().mockReturnValue(false),
     })
     const service = new TaskExecutionService(host)

--- a/tests/services/task-mutation-service.test.ts
+++ b/tests/services/task-mutation-service.test.ts
@@ -150,7 +150,7 @@ describe('TaskMutationService', () => {
       instanceId: 'instance-1',
       state: 'idle',
       slotKey: '8:00-12:00',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     const service = new TaskMutationService(host)
 
@@ -173,7 +173,7 @@ describe('TaskMutationService', () => {
       instanceId: 'candidate-only',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost()
     const service = new TaskMutationService(host)
 
@@ -194,7 +194,7 @@ describe('TaskMutationService', () => {
       instanceId: 'candidate-only',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost()
     const persistError = new Error('persist failed')
     host.persistDayState = jest.fn(async () => Promise.reject(persistError))
@@ -223,7 +223,7 @@ describe('TaskMutationService', () => {
       state: 'idle',
       slotKey: 'none',
       isDuplicate: true,
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [duplicate], tasks: [task] })
     host.dayState.duplicatedInstances.push({
       instanceId: duplicate.instanceId,
@@ -250,7 +250,7 @@ describe('TaskMutationService', () => {
       instanceId: 'instance-1',
       state: 'idle',
       slotKey: '8:00-12:00',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     const service = new TaskMutationService(host)
 
@@ -280,7 +280,7 @@ describe('TaskMutationService', () => {
       instanceId: 'instance-1',
       state: 'idle',
       slotKey: '16:00-0:00',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     const service = new TaskMutationService(host)
 
@@ -335,7 +335,7 @@ describe('TaskMutationService', () => {
       originalSlotKey: '16:00-0:00',
       isDuplicate: true,
       createdMillis: 1000,
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [sourceDuplicate], tasks: [baseTask] })
     host.dayState.duplicatedInstances.push({
       instanceId: 'dup-source',
@@ -391,7 +391,7 @@ describe('TaskMutationService', () => {
       originalSlotKey: '8:00-12:00',
       isDuplicate: true,
       createdMillis: 1000,
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [sourceDuplicate], tasks: [baseTask] })
     host.dayState.duplicatedInstances.push({
       instanceId: 'dup-source-manual-slot',
@@ -476,13 +476,13 @@ describe('TaskMutationService', () => {
       instanceId: 'base-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const duplicate: TaskInstance = {
       task,
       instanceId: 'dup-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
 
     const host = createHost({ taskInstances: [base, duplicate], tasks: [task] })
     host.dayState.duplicatedInstances.push({
@@ -514,7 +514,7 @@ describe('TaskMutationService', () => {
       instanceId: 'inst-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
 
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     const service = new TaskMutationService(host)
@@ -539,7 +539,7 @@ describe('TaskMutationService', () => {
       instanceId: 'inst-run',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
 
     const removeRunningTaskRecord = jest.fn(async () => {})
     const host = createHost({
@@ -564,7 +564,7 @@ describe('TaskMutationService', () => {
       instanceId: 'dup-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
 
     const host = createHost({ taskInstances: [duplicate], tasks: [task] })
     host.dayState.duplicatedInstances.push({
@@ -587,13 +587,13 @@ describe('TaskMutationService', () => {
       instanceId: 'base-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const duplicate: TaskInstance = {
       task,
       instanceId: 'dup-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
 
     const host = createHost({ taskInstances: [base, duplicate], tasks: [task] })
     // Intentionally do NOT push to duplicatedInstances to simulate missing metadata
@@ -630,13 +630,13 @@ describe('TaskMutationService', () => {
       instanceId: 'base-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const duplicate: TaskInstance = {
       task,
       instanceId: 'dup-new',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
 
     const host = createHost({ taskInstances: [base, duplicate], tasks: [task] })
     host.dayState.duplicatedInstances.push({
@@ -661,13 +661,13 @@ describe('TaskMutationService', () => {
       instanceId: 'dup-first',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const second: TaskInstance = {
       task,
       instanceId: 'dup-second',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [first, second], tasks: [task] })
     host.dayState.duplicatedInstances.push(
       {
@@ -697,7 +697,7 @@ describe('TaskMutationService', () => {
       instanceId: 'instance-failure',
       state: 'idle',
       slotKey: '8:00-12:00',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     host.ensureDayStateForCurrentDate = jest.fn(async () => {
       throw new Error('ensure failed')
@@ -720,7 +720,7 @@ describe('TaskMutationService', () => {
       instanceId: 'instance-del',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     host.app.fileManager.trashFile = jest.fn(async () => {})
     const service = new TaskMutationService(host)
@@ -743,14 +743,14 @@ describe('TaskMutationService', () => {
       instanceId: 'routine-1',
       slotKey: '12:00-16:00',
       state: 'idle',
-    } as TaskInstance
+    }
     const nonRoutineTask = createTask('TASKS/non.md', { taskId: 'tc-task-non' })
     const nonRoutineInstance: TaskInstance = {
       task: nonRoutineTask,
       instanceId: 'non-1',
       slotKey: '16:00-0:00',
       state: 'idle',
-    } as TaskInstance
+    }
     const host = createHost()
     const service = new TaskMutationService(host)
 
@@ -774,13 +774,13 @@ describe('TaskMutationService', () => {
       state: 'idle',
       slotKey: '12:00-16:00',
       order: 100,
-    } as TaskInstance
+    }
     const target: TaskInstance = {
       task,
       instanceId: 'move-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [peer, target] })
     const service = new TaskMutationService(host)
 
@@ -800,7 +800,7 @@ describe('TaskMutationService', () => {
       instanceId: 'dup-sync-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [inst], tasks: [task] })
     host.dayState.duplicatedInstances.push({
       instanceId: 'dup-sync-1',
@@ -826,7 +826,7 @@ describe('TaskMutationService', () => {
       instanceId: 'dup-manual-1',
       state: 'idle',
       slotKey: '16:00-0:00',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [inst], tasks: [task] })
     host.dayState.duplicatedInstances.push({
       instanceId: 'dup-manual-1',
@@ -854,7 +854,7 @@ describe('TaskMutationService', () => {
       state: 'idle',
       slotKey: '8:00-12:00',
       order: 200,
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [inst] })
     host.saveTaskOrders = jest.fn().mockRejectedValueOnce(new Error('persist failed'))
     const service = new TaskMutationService(host)
@@ -900,7 +900,7 @@ describe('TaskMutationService', () => {
       instanceId: 'routine-1',
       state: 'idle',
       slotKey: '8:00-12:00',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [routineTask] })
     const service = new TaskMutationService(host)
 
@@ -922,7 +922,7 @@ describe('TaskMutationService', () => {
       instanceId: 'routine-persist-failure-1',
       state: 'running',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [routineTask] })
     host.persistDayState = jest
       .fn()
@@ -945,7 +945,7 @@ describe('TaskMutationService', () => {
       instanceId: 'error-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     host.app.fileManager.trashFile = jest.fn(async () => {
       throw new Error('trash failed')
@@ -970,7 +970,7 @@ describe('TaskMutationService', () => {
       instanceId: 'fail-1',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     host.ensureDayStateForCurrentDate = jest.fn(async () => {
       throw new Error('load failure')
@@ -991,7 +991,7 @@ describe('TaskMutationService', () => {
       instanceId: 'persist-failure-1',
       state: 'running',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost({ taskInstances: [instance], tasks: [task] })
     const originalDeleted = [...host.dayStateManager.getDeleted('2026-07-13')]
     host.persistDayState = jest.fn(async () => {
@@ -1016,7 +1016,7 @@ describe('TaskMutationService', () => {
       instanceId: 'candidate-original',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost()
     let currentDate = '2025-10-09'
     const originalDayState = host.dayState
@@ -1057,7 +1057,7 @@ describe('TaskMutationService', () => {
       instanceId: 'candidate-reload',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost()
     const service = new TaskMutationService(host)
 
@@ -1100,7 +1100,7 @@ describe('TaskMutationService', () => {
       instanceId: 'candidate-cleanup-reload',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     let releaseCleanup!: () => void
     const cleanupGate = new Promise<void>((resolve) => {
       releaseCleanup = resolve
@@ -1154,7 +1154,7 @@ describe('TaskMutationService', () => {
       instanceId: 'candidate-uncached',
       state: 'idle',
       slotKey: 'none',
-    } as TaskInstance
+    }
     const host = createHost()
     let currentDate = '2025-10-09'
     const originalDayState = host.dayState

--- a/tests/settings/setting-definitions.test.ts
+++ b/tests/settings/setting-definitions.test.ts
@@ -21,7 +21,7 @@ function createTab(): TaskChuteSettingTab {
     pathManager: { validatePath: () => ({ valid: true }) },
     saveSettings: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
   }
-  return new TaskChuteSettingTab(mockApp as never, plugin as never)
+  return new TaskChuteSettingTab(mockApp, plugin as never)
 }
 
 function controls(items: SettingDefinitionItem[]) {

--- a/tests/settings/settings-recipe-feature.test.ts
+++ b/tests/settings/settings-recipe-feature.test.ts
@@ -11,7 +11,7 @@ function createTab() {
     pathManager: { validatePath: () => ({ valid: true }) },
     saveSettings: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
   }
-  const tab = new TaskChuteSettingTab(mockApp as never, plugin as never)
+  const tab = new TaskChuteSettingTab(mockApp, plugin as never)
   return { tab, plugin }
 }
 

--- a/tests/settings/settings-tab-section-customization.test.ts
+++ b/tests/settings/settings-tab-section-customization.test.ts
@@ -12,7 +12,7 @@ function createTab() {
     pathManager: { validatePath: () => ({ valid: true }) },
     saveSettings: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
   };
-  const tab = new TaskChuteSettingTab(mockApp as never, plugin as never);
+  const tab = new TaskChuteSettingTab(mockApp, plugin as never);
   return { tab, plugin };
 }
 

--- a/tests/settings/settings-task-creation-advanced.test.ts
+++ b/tests/settings/settings-task-creation-advanced.test.ts
@@ -11,7 +11,7 @@ function createTab() {
     pathManager: { validatePath: () => ({ valid: true }) },
     saveSettings: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
   }
-  const tab = new TaskChuteSettingTab(mockApp as never, plugin as never)
+  const tab = new TaskChuteSettingTab(mockApp, plugin as never)
   return { tab, plugin }
 }
 

--- a/tests/settings/settings-version.test.ts
+++ b/tests/settings/settings-version.test.ts
@@ -88,7 +88,7 @@ describe('TaskChute settings version display', () => {
       saveSettings: jest.fn(),
     }
     const tab = new TaskChuteSettingTab(
-      mockApp as never,
+      mockApp,
       plugin as never,
     )
 

--- a/tests/setup/obsidian-dom-globals.ts
+++ b/tests/setup/obsidian-dom-globals.ts
@@ -116,7 +116,7 @@ Object.defineProperties(Node.prototype, {
   doc: {
     configurable: true,
     get(this: Node) {
-      return this.ownerDocument ?? (this as unknown as Document)
+      return this.ownerDocument ?? (this)
     },
   },
   createEl: {

--- a/tests/task-display/task-move-calendar.test.ts
+++ b/tests/task-display/task-move-calendar.test.ts
@@ -175,7 +175,7 @@ describe("TaskMoveCalendar", () => {
           x: 0,
           y: 0,
           toJSON: () => ({}),
-        } as DOMRect
+        }
       }
       return {
         top: 0,
@@ -187,7 +187,7 @@ describe("TaskMoveCalendar", () => {
         x: 0,
         y: 0,
         toJSON: () => ({}),
-      } as DOMRect
+      }
     })
     const popoutCalendar = new TaskMoveCalendar({
       anchor: popoutAnchor,

--- a/tests/ui/header/task-header-board-view-switch.test.ts
+++ b/tests/ui/header/task-header-board-view-switch.test.ts
@@ -44,7 +44,7 @@ function createHost(options: AiHostOptions = {}): {
   state: { view: AiTaskBoardView; enabled: boolean }
 } {
   const state = {
-    view: options.initialView ?? ('mixed' as AiTaskBoardView),
+    view: options.initialView ?? ('mixed'),
     enabled: options.enabled ?? true,
   }
   const setAiTaskBoardView = jest.fn((view: AiTaskBoardView) => {

--- a/tests/ui/navigation/navigation-routine-controller.test.ts
+++ b/tests/ui/navigation/navigation-routine-controller.test.ts
@@ -135,7 +135,7 @@ describe('NavigationRoutineController', () => {
         pathManager: {
           getTaskFolderPath: () => 'TASKS',
         },
-      } as NavigationRoutineHost['plugin'],
+      },
       navigationContent,
       reloadTasksAndRestore: jest.fn(),
       showRoutineEditModal: jest.fn(),

--- a/tests/ui/task/task-settings-tooltip-controller.test.ts
+++ b/tests/ui/task/task-settings-tooltip-controller.test.ts
@@ -418,7 +418,7 @@ const createTimeController = () => {
           x: 0,
           y: 0,
           toJSON: () => ({}),
-        } as DOMRect
+        }
       }
       return {
         top: 0,
@@ -430,7 +430,7 @@ const createTimeController = () => {
         x: 0,
         y: 0,
         toJSON: () => ({}),
-      } as DOMRect
+      }
     })
     const host = createHost()
     const controller = new TaskSettingsTooltipController(host)

--- a/tests/ui/tasklist/task-context-menu-controller.test.ts
+++ b/tests/ui/tasklist/task-context-menu-controller.test.ts
@@ -75,7 +75,7 @@ const getMenuInstance = (): FakeMenu => {
   if (!result) {
     throw new Error('Menu instance not created')
   }
-  return result as unknown as FakeMenu
+  return result
 }
 
 const createHost = (

--- a/tests/ui/tasklist/task-item-action-controller.test.ts
+++ b/tests/ui/tasklist/task-item-action-controller.test.ts
@@ -140,7 +140,7 @@ describe('TaskItemActionController', () => {
         name: 'orphan',
         isRoutine: false,
       },
-    } as unknown as TaskInstance)
+    })
 
     controller.renderProject(container, inst)
 

--- a/tests/ui/time/time-edit-popup.test.ts
+++ b/tests/ui/time/time-edit-popup.test.ts
@@ -26,7 +26,7 @@ const createAnchor = (): HTMLElement => {
       x: 0,
       y: 0,
       toJSON: () => '',
-    }) as DOMRect
+    })
   return anchor
 }
 

--- a/tests/utils/taskViewTestUtils.ts
+++ b/tests/utils/taskViewTestUtils.ts
@@ -91,7 +91,7 @@ function createDayState(overrides?: Partial<DayState>): DayState {
     slotOverrides: {},
     orders: {},
     ...overrides,
-  } as DayState;
+  };
 }
 
 function createDayStateStoreServiceStub(dayState: DayState, date: string) {

--- a/tests/views/routine-modal-helpers.test.ts
+++ b/tests/views/routine-modal-helpers.test.ts
@@ -11,7 +11,7 @@ describe('routine modal helpers', () => {
     frontmatter: {},
     path: 'Task/Example.md',
     name: 'Example',
-  } as TaskData);
+  });
 
   test('deriveRoutineModalTitle prefers displayTitle', () => {
     const task = {

--- a/tests/views/taskchute-view/day-state-lifecycle.test.ts
+++ b/tests/views/taskchute-view/day-state-lifecycle.test.ts
@@ -1,6 +1,5 @@
 import { TaskChuteView } from '../../../src/features/core/views/TaskChuteView';
 import {
-  AutocompleteInstance,
   DayState,
   HiddenRoutine,
   TaskChutePluginLike,
@@ -94,7 +93,7 @@ function createDayState(overrides: Partial<DayState> = {}): DayState {
     slotOverrides: {},
     orders: {},
     ...overrides,
-  } as DayState;
+  };
 }
 
 function createPluginStub() {
@@ -201,7 +200,7 @@ function createTaskData(overrides: Partial<TaskData> = {}): TaskData {
     isRoutine: false,
     taskId: defaultTaskId,
     ...overrides,
-  } as TaskData;
+  };
 }
 
 function createTaskInstance(task: TaskData, overrides: Partial<TaskInstance> = {}): TaskInstance {
@@ -211,7 +210,7 @@ function createTaskInstance(task: TaskData, overrides: Partial<TaskInstance> = {
     state: 'idle',
     slotKey: '8:00-12:00',
     ...overrides,
-  } as TaskInstance;
+  };
 }
 
 type CreateElCapableElement = HTMLElement & {
@@ -238,12 +237,10 @@ function attachRecursiveCreateEl(target: HTMLElement): void {
     this.appendChild(el);
     return el;
   }) as unknown as CreateElCapableElement['createEl'];
-  typed.createSpan = (function (this: CreateElCapableElement, options: Record<string, unknown> = {}) {
+  typed.createSpan = function (this: CreateElCapableElement, options: Record<string, unknown> = {}) {
     return this.createEl?.('span', options) ?? document.createElement('span');
-  }) as unknown as CreateElCapableElement['createSpan'];
-  (typed as HTMLElement & {
-    createSvg?: (tag: string, options?: { attr?: Record<string, string>; cls?: string }) => SVGElement;
-  }).createSvg = (function (this: HTMLElement, tag: string, options: { attr?: Record<string, string>; cls?: string } = {}) {
+  };
+  (typed).createSvg = (function (this: HTMLElement, tag: string, options: { attr?: Record<string, string>; cls?: string } = {}) {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', tag);
     if (options.cls) {
       svg.setAttribute('class', options.cls);
@@ -255,7 +252,7 @@ function attachRecursiveCreateEl(target: HTMLElement): void {
     }
     attachRecursiveCreateEl(svg as unknown as HTMLElement);
     this.appendChild(svg as unknown as HTMLElement);
-    return svg as unknown as SVGElement;
+    return svg;
   }) as unknown as HTMLElement['createSvg'];
   if (typeof (typed as { empty?: () => void }).empty !== 'function') {
     (typed as { empty: () => void }).empty = function () {
@@ -2388,7 +2385,7 @@ describe('TaskChuteView running task restore', () => {
           originalSlotKey: '8:00-12:00',
           startTime: new Date('2025-01-01T06:00:00.000Z'),
           stopTime: undefined,
-        } as TaskInstance)
+        })
         return instances.slice(-1)
       })
 
@@ -2484,7 +2481,7 @@ describe('TaskChuteView navigation overlay', () => {
     const contentContainer = document.createElement('div');
     attachRecursiveCreateEl(contentContainer);
 
-    view.navigationController.createNavigationUI(contentContainer as CreateElCapableElement);
+    view.navigationController.createNavigationUI(contentContainer);
     view.navigationState.isOpen = true;
     view.navigationController.openNavigation();
 
@@ -3467,13 +3464,13 @@ describe('TaskChuteView onClose cleanup', () => {
     };
     scheduleAccessor.activeMoveCalendar = {
       close: closeMock,
-    } as MoveCalendarStub;
+    };
 
     const autocompleteCleanup = jest.fn();
     const secondaryCleanup = jest.fn();
     (view as Mutable<TaskChuteView>).autocompleteInstances = [
-      { cleanup: autocompleteCleanup } as AutocompleteInstance,
-      { cleanup: secondaryCleanup } as AutocompleteInstance,
+      { cleanup: autocompleteCleanup },
+      { cleanup: secondaryCleanup },
     ];
 
     const disposeMock = jest.fn();

--- a/tests/views/tasklist/task-list-renderer.test.ts
+++ b/tests/views/tasklist/task-list-renderer.test.ts
@@ -44,7 +44,7 @@ describe('TaskListRenderer', () => {
       }
       attachCreateEl(svg as unknown as HTMLElement);
       this.appendChild(svg as unknown as HTMLElement);
-      return svg as unknown as SVGElement;
+      return svg;
     }) as unknown as HTMLElement['createSvg'];
     (typed as HTMLElement & { empty?: () => void }).empty = function () {
       while (this.firstChild) {

--- a/tests/views/tasklist/task-row-controller.test.ts
+++ b/tests/views/tasklist/task-row-controller.test.ts
@@ -30,7 +30,7 @@ const addCreateEl = (element: HTMLElement): HTMLElement => {
     addCreateEl(child)
     return child
   }
-  element.createEl = createEl as unknown as HTMLElement['createEl']
+  element.createEl = createEl
   return element
 }
 


### PR DESCRIPTION
Obsidian auto-reviews every published version of a community plugin, and #153 cleared the findings it reported against 2.2.2. This branch is the follow-up: make `npm run review:obsidian` actually reproduce that review, and fix what falls out once it does.

Two commits, and they touch disjoint sets of files (only `package.json` / `package-lock.json` overlap).

---

## 1. `ef68cc6` — reproduce the review's css and capability layers

The review has a published half and a non-published half. Only the first was runnable locally:

| Layer | Public? |
|---|---|
| JS/TS, manifest, LICENSE, package.json rules | **Yes** — `eslint-plugin-obsidianmd`, already applied verbatim |
| Submission PR checks | **Yes** — obsidian-releases `validate-plugin-entry.yml` (submission only) |
| CSS analysis, capability disclosure, malware/dependency scan | **No** — no public implementation |

`eslint-plugin-obsidianmd@0.4.2` carries no CSS rules and does not depend on `@eslint/css`, so the css findings the dashboard reports could not be reproduced by any published package. `npm run review:obsidian` is now three layers:

1. **`eslint.review.config.mjs`** — Obsidian's published config, applied verbatim. Changes here are **comments only**; the rules are untouched, and the header now spells out why the two halves are kept apart (`js.configs.recommended` crashes on a CSS syntax tree, so they cannot share a config array).
2. **`eslint.review.css.config.mjs` + `scripts/obsidian-review-css.mjs`** — our own approximation, quoting the dashboard's wording. Validated by running it against the *unfixed* 2.2.2 `styles.css`: it reports `:has` 3 / `!important` 2 / `text-decoration` 9, **matching the dashboard's counts exactly**. `css/use-baseline` is deliberately not enabled — Baseline asks "supported across Chrome, Edge, Firefox and Safari" while Obsidian ships a single Chromium, so it flags 31 features the dashboard does not.
3. **`scripts/obsidian-review-capabilities.mjs`** — scans the built `main.js` and reports capability disclosures in the dashboard's own words, with the `src/` lines that reach them. It does not fail the gate. `release.yml` now builds before the review, since the scan needs `main.js`.

A clean run here is **not** permission to publish — the malware and dependency scans have no public API. A failing one is a guarantee that publishing is refused.

## 2. `84c8d32` — bump the toolchain, and clear what the newer rules find

#153 could not reproduce the 36 type-assertion findings the dashboard reported (19 *"does not change the type"* + 17 *"receiver accepts the original type"*) under any tsconfig. The answer was not the tsconfig:

**`typescript-eslint` 8.68 reports them; 8.44 reports none.** The review bot simply runs a newer typescript-eslint than our lockfile pinned. Against this tree 8.68 finds 140, split across those same two messages.

So the bump has to bring the fixes with it, or `lint` fails. 137 were autofixable. The rest:

- The `createEl` compat helpers in `ConfirmModal`, `DisambiguateStopTimeDateModal` and `ReminderNotificationModal` read the method off the element and call it through `.call`, which 8.68 also reports as `unbound-method`. Calling it as a method binds `this` at the call site and drops the assertion on the result — the same shape #153 applied to `ReminderIconRenderer`.
- Four type-only imports were left unused once the assertions went.

**Two autofixes had to be reworked because they broke the build.** These are the only non-mechanical hunks and the ones worth reviewing:

- `ReminderIconRenderer.createSvg` cast `parent`, and Obsidian augments **both** `HTMLElement` and `SVGElement` with `createSvg` — so the cast genuinely did not change the type and the rule was right. But removing it exposes `createSvg`'s real signature, which does not accept a bare `string`. The tag is narrowed instead, exactly as the fallback path already did.
- The `isTransientFailure` table in `license-api-client.test.ts` asserted each row `as LicenseApiFailure`. Without them the object literals widen (`ok: boolean` rather than `ok: false`) and stop matching, so the table carries a type annotation instead.

`eslint-plugin-obsidianmd` 0.4.1 → 0.4.2 rides along and changes nothing in our report.

---

## Reading this diff

77 files, but the review surface is small:

- **9 files** are hand-written (the five above plus four unused-import removals) — roughly 60 lines
- **60 files** are `eslint --fix` output: one to four `as X` deletions each, nothing to read
- **8 files** are the gate itself, none of them product code

## Verification

`npm run lint`, `npm run typecheck`, `npm test` (3256 passing), `npm run build`, and `npm run review:obsidian` (0 errors, 0 warnings, 8 capability disclosures) all pass.

## Follow-up, not in this PR

Run the developer dashboard's **Preview Scan** against this commit and diff it against the local report — that is the only way to find what the reconstruction still misses.