### PR TITLE
Keep the task row inside the phone's width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3068,13 +3068,17 @@ body.is-phone {
   /* Row controls (play/stop, routine, settings) are square boxes of this size;
      the comment button keeps the same height but is twice as wide so it is
      easier to hit. Grid tracks below match these widths exactly, so the visual
-     spacing between the trailing buttons is just `gap`. */
+     spacing between the trailing buttons is just `gap`. The drag grip is
+     narrower than the rest -- it is a grip, not a glyph -- so it carries its
+     own pair of dimensions. */
   --tc-row-control-size: 32px;
   --tc-row-comment-width: calc(var(--tc-row-control-size) * 2);
+  --tc-row-grip-width: 24px;
+  --tc-row-grip-height: 24px;
 
   display: grid;
   grid-template-columns:
-    24px var(--tc-row-control-size) 1fr 220px 110px 50px
+    var(--tc-row-grip-width) var(--tc-row-control-size) 1fr 220px 110px 50px
     var(--tc-row-comment-width) var(--tc-row-control-size) var(--tc-row-control-size);
   gap: 8px;
   align-items: center;
@@ -3087,6 +3091,20 @@ body.is-phone {
 
 .task-item:last-child {
   border-bottom: none;
+}
+
+/* Touch input: a finger needs a bigger target than a mouse pointer does. The
+   32px controls sized for a cursor fall short of the ~44px tap target phones
+   and tablets expect, so grow every row control (and the grip, which is
+   dragged rather than tapped and so gains height rather than width) on any
+   coarse pointer. The grid tracks are written in these variables, so the row
+   re-lays itself out with no second template to keep in sync. */
+@media (pointer: coarse) {
+  .task-item {
+    --tc-row-control-size: 40px;
+    --tc-row-grip-width: 28px;
+    --tc-row-grip-height: 40px;
+  }
 }
 
 .task-item:hover {
@@ -3131,8 +3149,8 @@ body.is-phone {
 
 /* ドラッグハンドルのスタイル */
 .drag-handle {
-  width: 24px;
-  height: 24px;
+  width: var(--tc-row-grip-width, 24px);
+  height: var(--tc-row-grip-height, 24px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -4451,8 +4469,9 @@ textarea.form-textarea {
 @container taskchute-list (max-width: 900px) {
   .task-item {
     grid-template-columns:
-      24px var(--tc-row-control-size) minmax(0, 1fr) minmax(140px, auto) minmax(70px, auto)
-      var(--tc-row-comment-width) var(--tc-row-control-size) var(--tc-row-control-size);
+      var(--tc-row-grip-width) var(--tc-row-control-size) minmax(0, 1fr)
+      minmax(140px, auto) minmax(70px, auto) var(--tc-row-comment-width)
+      var(--tc-row-control-size) var(--tc-row-control-size);
     gap: 8px;
     padding-right: 12px;
   }
@@ -4467,7 +4486,7 @@ textarea.form-textarea {
   /* 640px以下: ドラッグ、再生、タスク名、時間範囲、コメント、ルーチン、設定 (経過時間なし) */
   .task-item {
     grid-template-columns:
-      24px var(--tc-row-control-size) minmax(0, 1fr) 100px
+      var(--tc-row-grip-width) var(--tc-row-control-size) minmax(0, 1fr) 100px
       var(--tc-row-comment-width) var(--tc-row-control-size) var(--tc-row-control-size);
     gap: 6px;
     padding-left: 4px;
@@ -4492,7 +4511,7 @@ textarea.form-textarea {
   /* 520px以下: さらにコンパクト */
   .task-item {
     grid-template-columns:
-      24px var(--tc-row-control-size) minmax(0, 1fr) 90px
+      var(--tc-row-grip-width) var(--tc-row-control-size) minmax(0, 1fr) 90px
       var(--tc-row-comment-width) var(--tc-row-control-size) var(--tc-row-control-size);
     gap: 4px;
     padding-left: 4px;
@@ -4506,6 +4525,72 @@ textarea.form-textarea {
     padding-left: 4px;
   }
 }
+
+/* Phone width: everything above still tries to keep the row on one line, and
+   below ~440px there is no line left to keep -- the name track collapses to a
+   few characters while the clock and the four controls hold their widths. So
+   stop competing for one line: the controls span a two-row row, the name takes
+   the top line and the start/stop clock drops underneath it. Row height is set
+   by the controls, which span both rows, so the row grows by the leading
+   between the two text lines rather than by a second control-sized band. */
+@container taskchute-list (max-width: 440px) {
+  .task-item {
+    /* Its own column now, so it no longer needs the double width it had when
+       it shared the trailing run of buttons. */
+    --tc-row-comment-width: var(--tc-row-control-size);
+
+    grid-template-columns:
+      var(--tc-row-grip-width) var(--tc-row-control-size) minmax(0, 1fr)
+      var(--tc-row-comment-width) var(--tc-row-control-size)
+      var(--tc-row-control-size);
+    grid-template-areas:
+      "grip play name comment routine settings"
+      "grip play time comment routine settings";
+    gap: 4px;
+    padding: 4px 8px 4px 2px;
+  }
+
+  /* Placement only below: every control keeps the paint it was given above,
+     and each spans both rows, so `align-self` is what stops a fixed-height
+     box from sitting against the top of the pair. */
+  .task-item .drag-handle {
+    grid-area: grip;
+    align-self: center;
+  }
+
+  .task-item .play-stop-button {
+    grid-area: play;
+    align-self: center;
+  }
+
+  .task-item .task-name-container {
+    grid-area: name;
+  }
+
+  /* The clock is the second line rather than a column of its own, so it reads
+     as a caption under the name: same left edge, no padding pushing it in. */
+  .task-item .task-time-range {
+    grid-area: time;
+    align-self: start;
+    padding-left: 0;
+  }
+
+  .task-item .comment-button {
+    grid-area: comment;
+    align-self: center;
+  }
+
+  .task-item .routine-button {
+    grid-area: routine;
+    align-self: center;
+  }
+
+  .task-item .settings-task-button {
+    grid-area: settings;
+    align-self: center;
+  }
+}
+
 
 /* Routine edit modal */
 .routine-edit-modal {

--- a/tests/styles/style-regressions.test.ts
+++ b/tests/styles/style-regressions.test.ts
@@ -50,6 +50,25 @@ const codeToken = (css: string, token: string): string => {
   return (match as RegExpExecArray)[1].trim()
 }
 
+/**
+ * Index of the last rule for `selectorStart` that paints -- one declaring
+ * `background`, `color` or `cursor`. Placement-only rules (grid-area and
+ * friends) cannot override the disabled styling the callers guard, so they are
+ * skipped rather than counted as the last word on the selector.
+ */
+const lastPaintingRuleIndex = (css: string, selectorStart: string): number => {
+  let found = -1
+  for (let i = css.indexOf(selectorStart); i >= 0; i = css.indexOf(selectorStart, i + 1)) {
+    const end = css.indexOf('}', i)
+    if (end < 0) break
+    if (/(?:^|\s)(?:background|color|cursor):/.test(css.slice(i, end))) {
+      found = i
+    }
+  }
+
+  return found
+}
+
 describe('style regressions', () => {
   test('AI runs participates in vertical layout so the task list remains scrollable', () => {
     const css = styles()
@@ -362,7 +381,9 @@ describe('style regressions', () => {
 
   test('future task play button keeps disabled styling over generic play-stop styles', () => {
     const css = styles()
-    const lastGenericPlayStopIndex = css.lastIndexOf('.play-stop-button {')
+    // Only a rule that repaints the button can undo the disabled look, so the
+    // narrow-container rules that merely place it in the grid do not count.
+    const lastGenericPlayStopIndex = lastPaintingRuleIndex(css, '.play-stop-button {')
     expect(lastGenericPlayStopIndex).toBeGreaterThanOrEqual(0)
 
     const futurePlayStopRule = readRuleAtOrAfter(


### PR DESCRIPTION
## Problem

The task row's container queries stopped at 520px, and the fixed tracks below that step add up to more than a phone has:

```
24 (grip) + 32 (play) + 90 (clock) + 64 (comment) + 32 (routine) + 32 (settings)
+ 24 (gaps) + 16 (padding) = 314px
```

The task name is the only elastic track, so it absorbs the whole shortfall and then the row spills sideways. Measured in headless Chrome against the real row markup:

| `.task-list` width | overflow | task name |
|---:|---:|---:|
| 280px | **+22px** | 4px |
| 320px | 0 | **10px** |
| 360px | 0 | **50px** |
| 390px | 0 | 80px |

An iPhone (~390px) just barely fits, with 80px of name. A smaller phone, a landscape split, or a narrow desktop pane does not.

Separately, every row control was 32px regardless of input device — short of the tap target a finger needs.

## Change

Below 440px the row takes two lines. The name goes on the first, the start/stop clock on the second, and every control spans both:

```
"grip play name comment routine settings"
"grip play time comment routine settings"
```

That retires the clock's own column and lets the comment button drop from a double to a single width, bringing the guaranteed minimum from 314px down to **218px**.

The freed width pays for the second fix: `@media (pointer: coarse)` grows the controls from 32px to 40px, and the grip to 28x40 (it is dragged rather than tapped, so it gains height rather than width). Every grid track — including the three existing container queries — is now written in those variables, so there is no second template to keep in sync.

| `.task-list` width | overflow | task name |
|---:|---:|---:|
| 280px | **0** | 66px |
| 320px | **0** | 106px |
| 360px | **0** | 146px |
| 390px | **0** | 176px |

(measured with the coarse-pointer variables applied; headless Chrome always reports a fine pointer)

Row height goes from 40px to 51px below 440px, which is the cost of the second line.

## Test change

`style regressions › future task play button keeps disabled styling over generic play-stop styles` searched for the last `.play-stop-button {` rule by substring. The new placement-only rule sits later in the file and trips that search without repainting anything, so the search now takes the last rule that actually declares `background`, `color` or `cursor` — which is what could undo the disabled styling the test guards.

## Verification

- `npx jest` — 228 suites, 3256 tests, all passing
- `npm run lint` — clean
- `npx eslint --config eslint.review.css.config.mjs styles.css` — clean
- `npm run review:obsidian` — 0 errors, 0 warnings (run against the same stylesheet before the branch was split out)

Not yet verified on a physical device; the numbers above are layout measurements, not a visual check on iOS.
