### PR TITLE
Hide the desktop-only terminal button and the Pro page on mobile

### DIFF
--- a/src/settings/proUnlockState.ts
+++ b/src/settings/proUnlockState.ts
@@ -1,5 +1,20 @@
+import { Platform } from "obsidian"
 import { isAiTaskLicensed } from "../features/ai-task/availability"
 import type { SectionContext } from "./types"
+
+/**
+ * Whether this platform has anything a Pro license could unlock.
+ *
+ * AI tasks are the only thing it buys — `isProLicenseActive` is literally the
+ * AI entitlement — and they spawn a local CLI, which
+ * `evaluateAiTaskAvailability` refuses on mobile as `not-desktop`. Activating
+ * from an iPad would therefore unlock nothing, so the section stays off there:
+ * both the license form and the AI settings behind it. A seat activated from a
+ * desktop is still released from the device list on a desktop.
+ */
+export function isProSectionSupported(): boolean {
+  return Platform.isDesktop
+}
 
 /**
  * AI tasks are still in preparation, so the Pro section — the license form and

--- a/src/settings/sections/advanced/externalTools.ts
+++ b/src/settings/sections/advanced/externalTools.ts
@@ -1,29 +1,39 @@
+import { Platform } from "obsidian"
 import { t } from "../../../i18n"
 import { TERMINAL_NAME } from "../../../constants"
 import { toggle } from "../../controlHandlers"
 import type { SectionModule } from "../../types"
 
 export const externalToolsSection: SectionModule = {
-  items: () => [
-    {
-      type: "group",
-      heading: t("settings.features.heading", "External tools"),
-      items: [
-        {
-          name: t("settings.features.robotButton", "Show terminal button"),
-          desc: t(
-            "settings.features.robotButtonDesc",
-            `Enable AI integration via ${TERMINAL_NAME} (requires ${TERMINAL_NAME} plugin).`,
-          ),
-          control: {
-            type: "toggle",
-            key: "aiRobotButtonEnabled",
-            defaultValue: false,
+  /**
+   * Desktop only, group heading included: the toggle governs a button that
+   * runs a Terminal plugin command, and that plugin is desktop-only, so on
+   * mobile the row could only ever turn on a button that reports the plugin
+   * as missing. The single row is the whole group, hence the empty list.
+   */
+  items: () =>
+    Platform.isDesktop
+      ? [
+          {
+            type: "group",
+            heading: t("settings.features.heading", "External tools"),
+            items: [
+              {
+                name: t("settings.features.robotButton", "Show terminal button"),
+                desc: t(
+                  "settings.features.robotButtonDesc",
+                  `Enable AI integration via ${TERMINAL_NAME} (requires ${TERMINAL_NAME} plugin).`,
+                ),
+                control: {
+                  type: "toggle",
+                  key: "aiRobotButtonEnabled",
+                  defaultValue: false,
+                },
+              },
+            ],
           },
-        },
-      ],
-    },
-  ],
+        ]
+      : [],
 
   handlers: {
     aiRobotButtonEnabled: toggle({

--- a/src/settings/sections/pro/aiTask.ts
+++ b/src/settings/sections/pro/aiTask.ts
@@ -1,4 +1,4 @@
-import { Notice, Platform } from "obsidian"
+import { Notice } from "obsidian"
 import type { Setting, SettingDefinitionRender } from "obsidian"
 import { t } from "../../../i18n"
 import { ElectronDirectoryPicker } from "../../../features/ai-task/services/ElectronDirectoryPicker"
@@ -154,17 +154,12 @@ function cliPathRow(
 /**
  * Everything a Pro license unlocks. Only reached from the Pro page, which has
  * already checked entitlement.
- *
- * Rendered on desktop only. Every row here configures a local CLI the plugin
- * spawns -- which `evaluateAiTaskAvailability` already refuses on mobile as
- * `not-desktop` -- so a licensed iPad would otherwise be offered a feature it
- * can never run. The license rows stay: those matter on every platform.
  */
 export function aiTaskSection(guard: AiTaskToggleGuard): SectionModule {
   const paths = cliPaths()
 
   return {
-    items: (ctx) => (!Platform.isDesktop ? [] : [
+    items: (ctx) => [
       {
         type: "group",
         heading: t("settings.aiTask.heading", "AI task"),
@@ -221,7 +216,7 @@ export function aiTaskSection(guard: AiTaskToggleGuard): SectionModule {
           },
         ],
       },
-    ]),
+    ],
 
     handlers: {
       aiTaskEnabled: {

--- a/src/settings/sections/pro/aiTask.ts
+++ b/src/settings/sections/pro/aiTask.ts
@@ -1,4 +1,4 @@
-import { Notice } from "obsidian"
+import { Notice, Platform } from "obsidian"
 import type { Setting, SettingDefinitionRender } from "obsidian"
 import { t } from "../../../i18n"
 import { ElectronDirectoryPicker } from "../../../features/ai-task/services/ElectronDirectoryPicker"
@@ -154,12 +154,17 @@ function cliPathRow(
 /**
  * Everything a Pro license unlocks. Only reached from the Pro page, which has
  * already checked entitlement.
+ *
+ * Rendered on desktop only. Every row here configures a local CLI the plugin
+ * spawns -- which `evaluateAiTaskAvailability` already refuses on mobile as
+ * `not-desktop` -- so a licensed iPad would otherwise be offered a feature it
+ * can never run. The license rows stay: those matter on every platform.
  */
 export function aiTaskSection(guard: AiTaskToggleGuard): SectionModule {
   const paths = cliPaths()
 
   return {
-    items: (ctx) => [
+    items: (ctx) => (!Platform.isDesktop ? [] : [
       {
         type: "group",
         heading: t("settings.aiTask.heading", "AI task"),
@@ -216,7 +221,7 @@ export function aiTaskSection(guard: AiTaskToggleGuard): SectionModule {
           },
         ],
       },
-    ],
+    ]),
 
     handlers: {
       aiTaskEnabled: {

--- a/src/settings/sections/pro/index.ts
+++ b/src/settings/sections/pro/index.ts
@@ -4,6 +4,7 @@ import { syncAiTaskManagerToLicense } from "../../../features/ai-task/licenseGat
 import {
   ProUnlockState,
   isProLicenseActive,
+  isProSectionSupported,
   isProSectionVisible,
 } from "../../proUnlockState"
 import type { AiTaskToggleGuard } from "../../services/aiTaskLifecycle"
@@ -44,6 +45,11 @@ export function proSection(
 
   return {
     items: (ctx) => {
+      // Not merely hidden behind the page's `visible` predicate: a page's
+      // contents still reach the settings search, and there is nothing here
+      // for a platform that cannot run what the license unlocks.
+      if (!isProSectionSupported()) return []
+
       const manager = ctx.plugin.licenseManager
       let items: SettingDefinitionItem[]
 

--- a/src/settings/sections/version.ts
+++ b/src/settings/sections/version.ts
@@ -2,6 +2,7 @@ import { Notice } from "obsidian"
 import { t } from "../../i18n"
 import {
   ProUnlockState,
+  isProSectionSupported,
   isProSectionVisible,
 } from "../proUnlockState"
 import type { SectionModule } from "../types"
@@ -21,6 +22,9 @@ export function versionSection(unlock: ProUnlockState): SectionModule {
             name: t("settings.version.name", "Version"),
             desc: ctx.plugin.manifest.version,
             action: () => {
+              // Counting taps where the section can never be drawn would end in
+              // a notice announcing settings that are not there.
+              if (!isProSectionSupported()) return
               if (isProSectionVisible(ctx, unlock)) return
               if (!unlock.registerClick()) return
               new Notice(

--- a/src/ui/header/TaskHeaderController.ts
+++ b/src/ui/header/TaskHeaderController.ts
@@ -1,4 +1,4 @@
-import { Notice, App, setIcon } from 'obsidian'
+import { Notice, App, Platform, setIcon } from 'obsidian'
 import { applyIcon, createIconSpan } from '../icons'
 import TaskMoveCalendar, {
   TaskMoveCalendarFactory,
@@ -195,7 +195,10 @@ export default class TaskHeaderController {
     })
     this.actionSectionEl = actionSection
 
-    if (this.host.plugin.settings.aiRobotButtonEnabled === true) {
+    // The platform check is not redundant with the settings row hiding itself
+    // on mobile: settings sync, so a vault turned on from a desktop carries
+    // `aiRobotButtonEnabled: true` to an iPad that can never run the command.
+    if (Platform.isDesktop && this.host.plugin.settings.aiRobotButtonEnabled === true) {
       const robotButton = actionSection.createEl('button', {
         cls: 'robot-terminal-button',
         text: '🤖',

--- a/tests/features/ai-task/ai-task-settings-section.test.ts
+++ b/tests/features/ai-task/ai-task-settings-section.test.ts
@@ -168,23 +168,25 @@ describe('TaskChute AI task settings section', () => {
   })
 
   /**
-   * Every row here configures a local CLI the plugin spawns, which
-   * evaluateAiTaskAvailability already refuses on mobile as `not-desktop`. The
-   * license rows stay: activating and seeing device seats matters on an iPad.
+   * The license unlocks AI tasks and nothing else, and those spawn a local CLI
+   * that evaluateAiTaskAvailability refuses on mobile as `not-desktop`, so the
+   * page has nothing to offer there -- activation form included.
    */
-  test('declares no AI settings on mobile, license rows aside', () => {
+  test('declares no Pro page at all on mobile, license rows included', () => {
     Platform.isDesktop = false
     Platform.isMobile = true
     try {
       const { tab } = createTab()
 
       const items = tab.getSettingDefinitions()
+      expect(pageNamed(items, 'Pro settings')).toBeUndefined()
       expect(findByKey(items, 'aiTaskEnabled')).toBeUndefined()
       expect(findByKey(items, 'aiTaskRunMode')).toBeUndefined()
       expect(findByKey(items, 'aiTaskLogRetentionDays')).toBeUndefined()
       expect(findByName(items, CLAUDE_PATH_NAME)).toBeUndefined()
       expect(headings(items)).not.toContain('AI task')
-      expect(pageNamed(items, 'Pro settings')).toBeDefined()
+      // The rest of the tab is unaffected.
+      expect(findByName(items, 'Version')).toBeDefined()
     } finally {
       Platform.isDesktop = true
       Platform.isMobile = false

--- a/tests/features/ai-task/ai-task-settings-section.test.ts
+++ b/tests/features/ai-task/ai-task-settings-section.test.ts
@@ -6,7 +6,7 @@
  * the plugin instance. Those races are the bulk of what is tested here.
  */
 import type { SettingDefinitionItem, SettingDefinitionRender } from 'obsidian'
-import { Notice, Setting, mockApp } from 'obsidian'
+import { Notice, Platform, Setting, mockApp } from 'obsidian'
 import { DEFAULT_SETTINGS } from '../../../src/settings'
 import { TaskChuteSettingTab } from '../../../src/settings/SettingsTab'
 import { createAiTaskManager } from '../../../src/features/ai-task'
@@ -15,6 +15,8 @@ import {
   findByKey,
   findByName,
   flatten,
+  headings,
+  pageNamed,
 } from '../../settings/definitionHelpers'
 
 jest.mock('../../../src/features/ai-task', () => ({
@@ -163,6 +165,30 @@ describe('TaskChute AI task settings section', () => {
     expect(findByKey(items, 'aiTaskLogRetentionDays')?.control.type).toBe(
       'number',
     )
+  })
+
+  /**
+   * Every row here configures a local CLI the plugin spawns, which
+   * evaluateAiTaskAvailability already refuses on mobile as `not-desktop`. The
+   * license rows stay: activating and seeing device seats matters on an iPad.
+   */
+  test('declares no AI settings on mobile, license rows aside', () => {
+    Platform.isDesktop = false
+    Platform.isMobile = true
+    try {
+      const { tab } = createTab()
+
+      const items = tab.getSettingDefinitions()
+      expect(findByKey(items, 'aiTaskEnabled')).toBeUndefined()
+      expect(findByKey(items, 'aiTaskRunMode')).toBeUndefined()
+      expect(findByKey(items, 'aiTaskLogRetentionDays')).toBeUndefined()
+      expect(findByName(items, CLAUDE_PATH_NAME)).toBeUndefined()
+      expect(headings(items)).not.toContain('AI task')
+      expect(pageNamed(items, 'Pro settings')).toBeDefined()
+    } finally {
+      Platform.isDesktop = true
+      Platform.isMobile = false
+    }
   })
 
   describe('the runtime toggle', () => {

--- a/tests/settings/settings-task-creation-advanced.test.ts
+++ b/tests/settings/settings-task-creation-advanced.test.ts
@@ -1,4 +1,4 @@
-import { mockApp } from 'obsidian'
+import { Platform, mockApp } from 'obsidian'
 import { DEFAULT_SETTINGS } from '../../src/settings'
 import { TaskChuteSettingTab } from '../../src/settings/SettingsTab'
 import { findByKey, headings, pageNamed } from './definitionHelpers'
@@ -85,5 +85,27 @@ describe('TaskChute task creation advanced setting', () => {
       'Section',
       'External tools',
     ])
+  })
+
+  /**
+   * The one row under "External tools" turns on a button that runs a command
+   * from the desktop-only Terminal plugin, so on mobile it could only ever
+   * enable a button that reports the plugin as missing.
+   */
+  test('drops the external tools group on mobile', () => {
+    Platform.isDesktop = false
+    Platform.isMobile = true
+    try {
+      const { tab } = createTab()
+      const items = tab.getSettingDefinitions()
+
+      expect(headings(items)).not.toContain('External tools')
+      expect(findByKey(items, 'aiRobotButtonEnabled')).toBeUndefined()
+      // The rest of the page is unaffected.
+      expect(findByKey(items, 'showTaskCreationAdvancedSettings')).toBeDefined()
+    } finally {
+      Platform.isDesktop = true
+      Platform.isMobile = false
+    }
   })
 })

--- a/tests/settings/settings-version.test.ts
+++ b/tests/settings/settings-version.test.ts
@@ -1,5 +1,5 @@
 import type { SettingDefinitionAction } from 'obsidian'
-import { Notice, mockApp } from 'obsidian'
+import { Notice, Platform, mockApp } from 'obsidian'
 import { TaskChuteSettingTab } from '../../src/settings/SettingsTab'
 import { ProUnlockState, isProSectionVisible } from '../../src/settings/proUnlockState'
 import { versionSection } from '../../src/settings/sections/version'
@@ -78,6 +78,33 @@ describe('TaskChute settings version display', () => {
     // Further clicks are inert once the section is already visible.
     click()
     expect(ctx.refreshDomState).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The section it would reveal is not declared on mobile, so counting the taps
+   * would end in a notice announcing settings that are not there.
+   */
+  test('does not unlock the Pro section on mobile', () => {
+    Platform.isDesktop = false
+    Platform.isMobile = true
+    try {
+      const ctx = createContext('1.7.13')
+      const unlock = new ProUnlockState()
+      const row = findByName(
+        versionSection(unlock).items(ctx),
+        'Version',
+      ) as SettingDefinitionAction
+
+      for (let i = 0; i < 12; i += 1) row.action({} as HTMLElement, 0)
+
+      expect(unlock.isUnlocked).toBe(false)
+      expect(isProSectionVisible(ctx, unlock)).toBe(false)
+      expect(Notice).not.toHaveBeenCalled()
+      expect(ctx.refreshDomState).not.toHaveBeenCalled()
+    } finally {
+      Platform.isDesktop = true
+      Platform.isMobile = false
+    }
   })
 
   test('the tab exposes the version row through its definitions', () => {

--- a/tests/ui/header/task-header-controller.test.ts
+++ b/tests/ui/header/task-header-controller.test.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'obsidian'
 import TaskHeaderController, {
   TaskHeaderControllerHost,
   TaskHeaderControllerDependencies,
@@ -118,6 +119,32 @@ describe('TaskHeaderController', () => {
     const robotButton = container.querySelector('.robot-terminal-button') as HTMLButtonElement
     robotButton.dispatchEvent(new Event('click', { bubbles: true }))
     expect(executeCommand).toHaveBeenCalledWith('terminal:open-terminal.integrated.root')
+  })
+
+  /**
+   * The setting is synced, so a vault switched on from a desktop reaches an
+   * iPad with the flag set — where the Terminal plugin cannot be installed and
+   * the button could only ever report it as missing.
+   */
+  test('omits the robot button on mobile even with the setting on', () => {
+    Platform.isDesktop = false
+    Platform.isMobile = true
+    try {
+      const host = createHost({
+        plugin: { settings: { aiRobotButtonEnabled: true } } as TaskHeaderControllerHost['plugin'],
+      })
+      const controller = new TaskHeaderController(host)
+      const container = document.createElement('div')
+      attachCreateEl(container)
+
+      controller.render(container)
+
+      expect(container.querySelector('.robot-terminal-button')).toBeNull()
+      expect(container.querySelector('.add-task-button')).toBeTruthy()
+    } finally {
+      Platform.isDesktop = true
+      Platform.isMobile = false
+    }
   })
 
   test('calendar selection updates current date and triggers reload', async () => {


### PR DESCRIPTION
## Why

On an iPad, the plugin exposes settings and a button that can never do anything there.

**The terminal button.** The 🤖 header button runs `terminal:open-terminal.integrated.root`, a command from the community **Terminal** plugin, which is Node/Electron-based and desktop-only. On iOS that plugin cannot be installed, so pressing the button always ends in the "Terminal plugin not found" notice. Its toggle — *Show terminal button*, under Advanced settings → External tools — was still offered on mobile, and settings sync: a vault switched on from a desktop carried `aiRobotButtonEnabled: true` to the iPad and drew the button regardless of the toggle's own visibility.

**The Pro page.** A Pro license unlocks AI tasks and nothing else — `isProLicenseActive` is literally `isAiTaskLicensed` — and AI tasks spawn a local CLI, which `evaluateAiTaskAvailability` already refuses on mobile as `not-desktop`. Yet the settings UI never consulted that rule: the whole AI task group rendered on an iPad, and so did the activation form above it, offering to unlock a feature that platform cannot run.

Neither surface is new: the header button dates to the first commit (2025-08-01) and the toggle to 2025-10-08.

`manifest.json` still declares `isDesktopOnly: false` and is untouched — the plugin itself stays fully usable on mobile. This only removes the affordances that are not.

## What changed

- **`proUnlockState.ts`** — new `isProSectionSupported()`, stating "Pro needs a desktop" beside the entitlement it qualifies.
- **`pro/index.ts`** — `proSection` returns no items on mobile, rather than leaning on the page's `visible` predicate. A page's contents still reach the settings search, so a hidden page would keep answering searches for a license form that cannot help. The AI task group disappears with the page, activation form included.
- **`version.ts`** — the version row stops counting its hidden unlock taps on mobile, or ten taps would end in a notice announcing settings that are not there.
- **`externalTools.ts`** — the "External tools" group is returned only on desktop. Its single row is the whole group, so the heading goes with it.
- **`TaskHeaderController.ts`** — the 🤖 button repeats the platform check instead of trusting the synced flag.

No stored value changes, so a desktop vault behaves exactly as before. A seat activated from a desktop is still released from the desktop device list.

## Tests

Four cases added, each flipping the mocked `Platform` to mobile and restoring it afterwards:

- No Pro page at all in the definition tree — no `aiTaskEnabled` / `aiTaskRunMode` / `aiTaskLogRetentionDays`, no CLI path rows, no "AI task" heading — while the rest of the tab is untouched.
- Twelve taps on the version row unlock nothing and raise no notice.
- Advanced settings declares neither the "External tools" heading nor `aiRobotButtonEnabled`.
- The header renders no `.robot-terminal-button` even with the setting on.

`npm test` (228 suites, 3260 tests), `npm run typecheck` and `npm run lint` all pass.

## Manual check

With the terminal button enabled and Pro activated on a Mac, then synced to an iPad: Advanced settings has no External tools group, there is no Pro page, and the header has no 🤖 — while the Mac keeps all three.