### PR TITLE
Show the error code alongside every license API failure

### DIFF
--- a/src/features/license/ui/DeviceListView.ts
+++ b/src/features/license/ui/DeviceListView.ts
@@ -90,7 +90,7 @@ export class DeviceListView {
     if (this.disposed) return
 
     if (!result.ok) {
-      this.setStatus(describeApiFailure(result.failure))
+      this.setError(describeApiFailure(result.failure))
       return
     }
 
@@ -101,6 +101,13 @@ export class DeviceListView {
 
   private setStatus(message: string): void {
     this.statusEl.setText(message)
+    this.statusEl.classList.remove('taskchute-license-devices__status--error')
+  }
+
+  /** A failed request is not a seat count, and must not read like one. */
+  private setError(message: string): void {
+    this.statusEl.setText(message)
+    this.statusEl.classList.add('taskchute-license-devices__status--error')
   }
 
   private render(): void {
@@ -187,7 +194,7 @@ export class DeviceListView {
     if (!result.ok) {
       // render() rewrites the status line, so the error goes on after it.
       this.render()
-      this.setStatus(describeApiFailure(result.failure))
+      this.setError(describeApiFailure(result.failure))
       return
     }
 

--- a/src/features/license/ui/licenseMessages.ts
+++ b/src/features/license/ui/licenseMessages.ts
@@ -4,6 +4,10 @@
  * Localized from the API's stable `error` code, never from its `message`: that
  * field is Japanese prose and would leak into an English UI. The server text is
  * kept only as a last resort for a code this build does not recognize.
+ *
+ * Every message carries its code. The prose is what the user acts on, but the
+ * code is what support asks for and what a bug report has to contain, and a
+ * failure that reaches the screen without one leaves both sides guessing.
  */
 import { t } from '../../../i18n'
 import type { ActivationFailure } from '../services/LicenseManager'
@@ -27,6 +31,13 @@ const FALLBACKS: Record<string, string> = {
   malformed: 'The license request was rejected. Please report this as a bug.',
 }
 
+/** Codes for the failures the client itself decides, which have no server code. */
+const CLIENT_CODES = {
+  network: 'network_unreachable',
+  malformed: 'bad_request',
+  untrustedToken: 'untrusted_token',
+} as const
+
 function formatRetryAt(retryAfterAt: number | undefined): string {
   if (retryAfterAt === undefined) return ''
 
@@ -37,7 +48,45 @@ function messageForCode(code: string, vars?: Record<string, string>): string {
   return t(`license.errors.${code}`, FALLBACKS[code] ?? FALLBACKS['internal'], vars)
 }
 
+/**
+ * The message the user reads, with the code that identifies the failure.
+ *
+ * The code goes last and in parentheses so it never gets in the way of the
+ * instruction, which is the part most users need.
+ */
+function withCode(message: string, code: string): string {
+  return t('license.errors.withCode', '{message} (code: {code})', { message, code })
+}
+
+/**
+ * The stable identifier for a failure: the server's own code where there is
+ * one, and a client-side code where the request never produced an answer.
+ */
+export function apiFailureCode(failure: LicenseApiFailure): string {
+  if (failure.kind === 'network') return CLIENT_CODES.network
+  if (failure.kind === 'malformed') return `${CLIENT_CODES.malformed}_${failure.status}`
+
+  return failure.code
+}
+
+export function activationFailureCode(failure: ActivationFailure): string {
+  switch (failure.kind) {
+    case 'invalid-input':
+      return 'malformed_code'
+    case 'device-limit':
+      return 'device_limit_reached'
+    case 'untrusted-token':
+      return CLIENT_CODES.untrustedToken
+    default:
+      return apiFailureCode(failure)
+  }
+}
+
 export function describeApiFailure(failure: LicenseApiFailure): string {
+  return withCode(apiFailureMessage(failure), apiFailureCode(failure))
+}
+
+function apiFailureMessage(failure: LicenseApiFailure): string {
   if (failure.kind === 'network') return messageForCode('network')
   if (failure.kind === 'malformed') return messageForCode('malformed')
 
@@ -54,6 +103,10 @@ export function describeApiFailure(failure: LicenseApiFailure): string {
 }
 
 export function describeActivationFailure(failure: ActivationFailure): string {
+  return withCode(activationFailureMessage(failure), activationFailureCode(failure))
+}
+
+function activationFailureMessage(failure: ActivationFailure): string {
   switch (failure.kind) {
     case 'invalid-input':
       return messageForCode('malformed_code')
@@ -65,6 +118,6 @@ export function describeActivationFailure(failure: ActivationFailure): string {
         'The license service returned a token this version cannot verify. Please update the plugin.',
       )
     default:
-      return describeApiFailure(failure)
+      return apiFailureMessage(failure)
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1064,6 +1064,7 @@ export const en = {
       malformed: "The license request was rejected. Please report this as a bug.",
       untrustedToken:
         "The license service returned a token this version cannot verify. Please update the plugin.",
+      withCode: "{message} (code: {code})",
     },
     devices: {
       description:

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -1062,6 +1062,7 @@ export const ja = {
       malformed: "ライセンスのリクエストが拒否されました。不具合として報告してください。",
       untrustedToken:
         "このバージョンでは検証できないトークンが返されました。プラグインを更新してください。",
+      withCode: "{message}（エラーコード: {code}）",
     },
     devices: {
       description:

--- a/src/settings/sections/pro/license.ts
+++ b/src/settings/sections/pro/license.ts
@@ -81,6 +81,12 @@ function codeRow(
     desc: form.errorDesc,
     render: (setting) => {
       setting.settingEl.addClass("taskchute-license-code-item")
+      // A failure is not a description: it reads as one unless it is coloured
+      // like the error it is.
+      setting.settingEl.classList.toggle(
+        "taskchute-license-code-item--error",
+        form.errorDesc.length > 0,
+      )
       helpButton(ctx, setting)
 
       setting.addText((text) => {

--- a/styles.css
+++ b/styles.css
@@ -8010,6 +8010,13 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
   min-width: 0;
 }
 
+/* A failed activation is written into the row's description slot, which is
+   muted prose by default — the one place on the screen the user must not read
+   past. */
+.setting-item.taskchute-license-code-item--error .setting-item-description {
+  color: var(--text-error);
+}
+
 /* An activation code runs to a couple of hundred characters, so it wraps
    anywhere rather than pushing the card sideways, and stays selectable for
    someone copying it back out. */
@@ -8053,6 +8060,10 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
   font-size: var(--font-ui-smaller);
   margin-top: var(--size-4-2);
   min-height: 1.2em;
+}
+
+.taskchute-license-devices__status--error {
+  color: var(--text-error);
 }
 
 .taskchute-license-devices__list {

--- a/tests/features/license/device-list-view.test.ts
+++ b/tests/features/license/device-list-view.test.ts
@@ -27,6 +27,27 @@ describe('DeviceListView', () => {
     expect(host.childElementCount).toBe(0)
   })
 
+  test('shows a failed load as an error, with its code', async () => {
+    // The status line otherwise reads as a seat count in muted grey, which is
+    // the wrong thing for a request that never returned a list.
+    const manager = {
+      getDeviceId: () => 'DEVICE-0001',
+      listDevices: jest
+        .fn()
+        .mockResolvedValue({ ok: false, failure: { ok: false, kind: 'network' } }),
+      deactivateDevice: jest.fn(),
+    } as unknown as LicenseManager
+    const host = document.createElement('div')
+
+    new DeviceListView(host, manager)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const status = host.querySelector('.taskchute-license-devices__status')
+    expect(status?.classList.contains('taskchute-license-devices__status--error')).toBe(true)
+    expect(status?.textContent).toContain('network_unreachable')
+  })
+
   test('mounting again after a dispose leaves a single list', () => {
     const host = document.createElement('div')
 

--- a/tests/features/license/pro-settings-section.test.ts
+++ b/tests/features/license/pro-settings-section.test.ts
@@ -274,6 +274,46 @@ describe('Pro settings section', () => {
       expect(manager.activate).toHaveBeenCalledWith('TCP-AAAA-BBBB-CCCC')
     })
 
+    test('reports a failed activation with its message and error code', async () => {
+      // Support is asked for the code, so the row has to carry both halves:
+      // what the user should do, and what identifies the failure.
+      const manager = fakeManager({
+        activate: jest.fn().mockResolvedValue({
+          ok: false,
+          failure: { ok: false, kind: 'api', code: 'invalid_code', status: 404 },
+        }),
+      })
+      const tab = createTab(manager)
+      const items = () => {
+        const page = pageNamed(
+          tab.getSettingDefinitions(),
+          t('settings.pro.heading', 'Pro settings'),
+        )
+        if (!page) throw new Error('Pro page not found')
+        return flatten(page.items ?? [])
+      }
+      const codeRow = () => {
+        const item = items().find(
+          (candidate) => 'name' in candidate && candidate.name === 'License code',
+        )
+        if (!item) throw new Error('License code row not found')
+        return item
+      }
+      const { setting } = invokeRender(codeRow())
+
+      await setting.__textComponents[0].__triggerChange('TCP-AAAA-BBBB-CCCC')
+      await setting.__buttons[0].__click()
+
+      const desc = descs([codeRow()])[0] ?? ''
+      expect(desc).toContain('was not found')
+      expect(desc).toContain('invalid_code')
+      // And it is marked as an error, not left reading as help text.
+      const { setting: failed } = invokeRender(codeRow())
+      expect(
+        failed.settingEl.classList.contains('taskchute-license-code-item--error'),
+      ).toBe(true)
+    })
+
     test('does not show the device list or the AI settings', () => {
       const items = proItems(fakeManager())
 


### PR DESCRIPTION
## What

A failed activation showed only prose ("That does not look like an activation code."), so neither the user nor support could name the failure. Every license API failure that reaches the screen now carries its stable error code, and looks like an error instead of like help text.

The license API is the only thing this plugin talks to over the network (`requestUrl` appears in `LicenseApiClient` alone), so this covers every request path: activation, the device list, and releasing a seat.

## Changes

- `describeApiFailure` / `describeActivationFailure` return `{message} (code: {code})` — `{message}（エラーコード: {code}）` in Japanese. New i18n key `license.errors.withCode` in both locales.
- Codes are the API's own stable ones (`invalid_code`, `license_expired`, `device_limit_reached`, …). Where the request never produced a server answer, the client supplies one: `network_unreachable`, `bad_request_<status>`, `untrusted_token`.
- `apiFailureCode` / `activationFailureCode` are exported for callers that want the code without the prose.
- The activation row's description turns `var(--text-error)` while it carries a failure; it was the same muted grey as the help text under the field.
- The device list separates its seat count from its failures (`setStatus` / `setError`), so a failed load or release no longer reads as a count.

## Tests

- A failed activation puts the message, the code, and the error class on the license code row.
- A failed device list load shows `network_unreachable` in the error state.
- Full suite, `tsc --noEmit` and eslint pass.