### PR TITLE
Clear the Obsidian review's text-decoration and assertion warnings

### DIFF
--- a/src/ui/tasklist/TaskListRenderer.ts
+++ b/src/ui/tasklist/TaskListRenderer.ts
@@ -66,13 +66,13 @@ export default class TaskListRenderer {
 
   constructor(private readonly host: TaskListRendererHost) {
     const showProjectModalBound: ((inst: TaskInstance) => Promise<void> | void) | undefined = this.host.showProjectModal
-      ? (this.host.showProjectModal.bind(this.host) as (inst: TaskInstance) => Promise<void> | void)
+      ? (inst) => this.host.showProjectModal?.(inst)
       : undefined
     const showUnifiedProjectModalBound: ((inst: TaskInstance) => Promise<void> | void) | undefined = this.host.showUnifiedProjectModal
-      ? (this.host.showUnifiedProjectModal.bind(this.host) as (inst: TaskInstance) => Promise<void> | void)
+      ? (inst) => this.host.showUnifiedProjectModal?.(inst)
       : undefined
     const openProjectInSplitBound: ((projectPath: string) => Promise<void> | void) | undefined = this.host.openProjectInSplit
-      ? (this.host.openProjectInSplit.bind(this.host) as (projectPath: string) => Promise<void> | void)
+      ? (projectPath) => this.host.openProjectInSplit?.(projectPath)
       : undefined
 
     this.actions = new TaskItemActionController({

--- a/styles.css
+++ b/styles.css
@@ -8307,31 +8307,27 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
     opacity: 1;
 }
 
-/* xterm.js customization: upstream writes these as the `text-decoration`
-   shorthand ("overline wavy underline"). Obsidian's plugin review only accepts
-   the single-keyword form of the shorthand, so the line and the style are set
-   through their longhands instead — same rendering, same cascade. */
-.xterm-underline-1 { text-decoration-line: underline; }
-.xterm-underline-2 { text-decoration-line: underline; text-decoration-style: double; }
-.xterm-underline-3 { text-decoration-line: underline; text-decoration-style: wavy; }
-.xterm-underline-4 { text-decoration-line: underline; text-decoration-style: dotted; }
-.xterm-underline-5 { text-decoration-line: underline; text-decoration-style: dashed; }
-
-.xterm-overline {
-    text-decoration-line: overline;
+/* xterm.js customization: upstream draws these with the `text-decoration`
+   shorthand and its `-line` / `-style` longhands. Obsidian's plugin review
+   accepts `text-decoration` only with a single keyword and rejects the
+   longhands outright, so the underline styles collapse to a plain underline and
+   the overline is drawn as a top border instead — a border on an inline box
+   adds no height, so the rows keep their geometry, and overline now composes
+   with underline without needing the five combined rules upstream carries. */
+.xterm-underline-1,
+.xterm-underline-2,
+.xterm-underline-3,
+.xterm-underline-4,
+.xterm-underline-5 {
+    text-decoration: underline;
 }
 
-.xterm-overline.xterm-underline-1 { text-decoration-line: overline underline; }
-.xterm-overline.xterm-underline-2 { text-decoration-line: overline underline; text-decoration-style: double; }
-.xterm-overline.xterm-underline-3 { text-decoration-line: overline underline; text-decoration-style: wavy; }
-.xterm-overline.xterm-underline-4 { text-decoration-line: overline underline; text-decoration-style: dotted; }
-.xterm-overline.xterm-underline-5 { text-decoration-line: overline underline; text-decoration-style: dashed; }
+.xterm-overline {
+    border-top: 1px solid currentColor;
+}
 
 .xterm-strikethrough {
-    text-decoration-line: line-through;
-    /* The shorthand this replaces also reset the style; keep that reset so a
-       strikethrough over a wavy/dotted underline still draws solid. */
-    text-decoration-style: solid;
+    text-decoration: line-through;
 }
 
 .xterm-screen .xterm-decoration-container .xterm-decoration {

--- a/tests/features/ai-task/terminal-view-adapter.test.ts
+++ b/tests/features/ai-task/terminal-view-adapter.test.ts
@@ -55,35 +55,23 @@ const OBSIDIAN_REVIEW_PATCHES: ReadonlyArray<readonly [string, string]> = [
 .xterm-overline.xterm-underline-3 { text-decoration: overline wavy underline; }
 .xterm-overline.xterm-underline-4 { text-decoration: overline dotted underline; }
 .xterm-overline.xterm-underline-5 { text-decoration: overline dashed underline; }`,
-    `/* xterm.js customization: upstream writes these as the \`text-decoration\`
-   shorthand ("overline wavy underline"). Obsidian's plugin review only accepts
-   the single-keyword form of the shorthand, so the line and the style are set
-   through their longhands instead — same rendering, same cascade. */
-.xterm-underline-1 { text-decoration-line: underline; }
-.xterm-underline-2 { text-decoration-line: underline; text-decoration-style: double; }
-.xterm-underline-3 { text-decoration-line: underline; text-decoration-style: wavy; }
-.xterm-underline-4 { text-decoration-line: underline; text-decoration-style: dotted; }
-.xterm-underline-5 { text-decoration-line: underline; text-decoration-style: dashed; }
-
-.xterm-overline {
-    text-decoration-line: overline;
+    `/* xterm.js customization: upstream draws these with the \`text-decoration\`
+   shorthand and its \`-line\` / \`-style\` longhands. Obsidian's plugin review
+   accepts \`text-decoration\` only with a single keyword and rejects the
+   longhands outright, so the underline styles collapse to a plain underline and
+   the overline is drawn as a top border instead — a border on an inline box
+   adds no height, so the rows keep their geometry, and overline now composes
+   with underline without needing the five combined rules upstream carries. */
+.xterm-underline-1,
+.xterm-underline-2,
+.xterm-underline-3,
+.xterm-underline-4,
+.xterm-underline-5 {
+    text-decoration: underline;
 }
 
-.xterm-overline.xterm-underline-1 { text-decoration-line: overline underline; }
-.xterm-overline.xterm-underline-2 { text-decoration-line: overline underline; text-decoration-style: double; }
-.xterm-overline.xterm-underline-3 { text-decoration-line: overline underline; text-decoration-style: wavy; }
-.xterm-overline.xterm-underline-4 { text-decoration-line: overline underline; text-decoration-style: dotted; }
-.xterm-overline.xterm-underline-5 { text-decoration-line: overline underline; text-decoration-style: dashed; }`,
-  ],
-  [
-    `.xterm-strikethrough {
-    text-decoration: line-through;
-}`,
-    `.xterm-strikethrough {
-    text-decoration-line: line-through;
-    /* The shorthand this replaces also reset the style; keep that reset so a
-       strikethrough over a wavy/dotted underline still draws solid. */
-    text-decoration-style: solid;
+.xterm-overline {
+    border-top: 1px solid currentColor;
 }`,
   ],
   [


### PR DESCRIPTION
The Obsidian plugin review reported 24 findings on 2.2.3: 21 `Unexpected browser feature "text-decoration" is only partially supported` in `styles.css`, and 3 `This assertion is unnecessary` in `TaskListRenderer.ts`. `npm run review:obsidian` is back to 0 errors / 0 warnings.

## CSS

The previous pass replaced the `text-decoration` shorthand with the `text-decoration-line` / `-style` longhands, but the review flags the longhands under the same feature — only the single-keyword shorthand is accepted. The xterm decorations are now written without any longhand:

- `.xterm-underline-1`–`5` share one `text-decoration: underline`
- `.xterm-overline` draws a `border-top` instead. A border on an inline box adds no height, so the rows keep their geometry, and it composes with underline on its own — the five `.xterm-overline.xterm-underline-*` rules upstream carries are gone
- `.xterm-strikethrough` is back to upstream's `text-decoration: line-through`

Trade-off: the underline style variants (SGR `4:2`–`4:5` — double, wavy, dotted, dashed) all render as a plain underline. There is no way to keep them without `text-decoration-style`.

The vendored-CSS check in `terminal-view-adapter.test.ts` follows the new patch table.

## TypeScript

The three bound host callbacks used `bind` with a type assertion. Removing the assertion alone turns the values into `any` (the tsconfig sets `strictNullChecks` but not `strict`, so `strictBindCallApply` is off and `bind` returns `any`), trading one review finding for `no-unsafe-assignment`. They are arrow wrappers now, which keep the `this` binding and infer from the existing annotation.

## Testing

- `npm run review:obsidian` — 0 errors, 0 warnings
- `npm run lint`, `npm run typecheck` — clean
- `npx jest` — `tests/services/day-state-persistence-service.test.ts` fails with 4 pre-existing failures, present on `main` before this branch and untouched here. Everything else passes.