### PR TITLE
Pin the clock in the day state rename test suite

### DIFF
--- a/tests/services/day-state-persistence-service.test.ts
+++ b/tests/services/day-state-persistence-service.test.ts
@@ -61,6 +61,18 @@ describe('DayStatePersistenceService.renameTaskPath', () => {
     return { plugin, store, pathManager, vault }
   }
 
+  // The fixtures below live in 2025-09, and collectStateFiles' fallback only
+  // probes the twelve months before today (the vault mock has no folder listing,
+  // so that fallback is the path taken). Pin the clock inside the fixture month
+  // instead of letting the suite age out of the window.
+  beforeEach(() => {
+    jest.useFakeTimers({ now: new Date('2025-09-14T00:00:00.000Z') })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   it('updates stored state files and cache entries', async () => {
     const { plugin, store, vault } = createPlugin()
     const service = new DayStatePersistenceService(plugin)


### PR DESCRIPTION
`tests/services/day-state-persistence-service.test.ts` started failing on every branch — `main` included — on 2026-09-01, with four `renameTaskPath` tests reporting `vault.modify` was never called.

## Cause

The fixtures are written into `LOGS/2025-09-state.json`. `renameTaskPath` finds state files through `collectStateFiles()`, whose folder listing returns nothing against the test's vault mock (it has no folder API), so the fallback runs — and that fallback only probes the twelve months before *today*:

```ts
for (let i = 0; i < 12; i += 1) {
  const date = new Date(now.getFullYear(), now.getMonth() - i, 1)
  ...
}
```

On 2026-08-31 the window still reached 2025-09; on 2026-09-01 it stops at 2025-10. No file is collected, nothing is written, and the assertions fail. Nothing about the code under test changed.

## Fix

The suite now pins the clock to `2025-09-14` with fake timers, so the fixture month stays inside the window regardless of when the tests run. The fixtures and assertions are untouched.

The twelve-month cap in `collectStateFiles()` is left as is — it is only the fallback for vaults where the folder listing comes back empty, and narrowing or widening it is a separate call.

## Testing

- `npx jest` — 3277 passed, 0 failed (was 4 failed)
- `npm run lint` — clean