### PR TITLE
Keep the calendar glyph and the date's fixed box on a phone

### DIFF
--- a/src/ui/header/TaskHeaderController.ts
+++ b/src/ui/header/TaskHeaderController.ts
@@ -155,8 +155,8 @@ export default class TaskHeaderController {
     })
     // The label opens the same calendar the glyph beside it does. It is the
     // largest thing in the header and reads as the current date, so it is what
-    // a finger goes for; on a phone it is also the only one of the two left,
-    // since the narrow layout drops the glyph to fit the row.
+    // a finger goes for, on a phone as much as on a desktop -- the header is
+    // one row at every width, so both controls survive the narrow layout.
     const dateLabel = navContainer.createSpan({
       cls: 'date-nav-label',
       attr: {

--- a/styles.css
+++ b/styles.css
@@ -2897,75 +2897,6 @@ body.is-phone .taskchute-modal .modal-button-container {
   }
 }
 
-/* Phone-width leaf. The five controls need ~340px to sit on one line, so below
-   that they stop trying: the two that frame the header keep the top row at its
-   corners and the date navigator takes a full-width row of its own, arrows
-   pinned to the edges and the date centred between them.
-
-       [三]                    [+]
-       [<]        Today        [>]
-
-   The calendar glyph is what gives way -- the date label opens the same
-   picker, and it is the bigger target of the two. */
-@container taskchute-view (max-width: 380px) {
-  .top-bar-container {
-    grid-template-rows: repeat(2, 30px);
-    height: 66px;
-    row-gap: 6px;
-  }
-
-  /* The drawer is already pinned to the top-left corner by the 680px layout
-     above, which this width is inside of. */
-  .top-bar-container > .header-action-section {
-    grid-column: 3;
-    grid-row: 1;
-    justify-self: end;
-  }
-
-  /* Qualified by the bar: `.date-nav-container.compact` declares its own
-     column and centring further down the sheet, and would otherwise win this
-     on source order alone. */
-  .top-bar-container > .date-nav-container.compact {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    justify-self: stretch;
-    justify-content: space-between;
-  }
-
-  .top-bar-container > .date-nav-container.compact .calendar-btn {
-    display: none;
-  }
-
-  /* The label is a fixed 150px box everywhere else, so the arrows never move
-     as the date changes. There is no width to spare here, though, and holding
-     that box pushes the next-day arrow off the edge of the leaf. So it gives
-     up the fixed width and truncates instead -- the leading "Today (8/31" is
-     the part that carries the meaning. `display: block` is what lets it: an
-     ellipsis has no effect on the flex box it used to be. */
-  .top-bar-container > .date-nav-container.compact .date-nav-label {
-    display: block;
-    width: auto;
-    min-width: 0;
-    flex: 0 1 auto;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    line-height: 28px;
-  }
-
-  /* The board switch cannot share the top row with anything, so it keeps the
-     row of its own that the 680px layout gave it -- pushed below the date
-     navigator rather than above it. */
-  .top-bar-container.has-board-view-switch {
-    grid-template-rows: repeat(3, 30px);
-    height: 102px;
-  }
-
-  .top-bar-container > .header-action-section.has-board-view-switch {
-    grid-row: 3;
-  }
-}
-
 /* Navigation Overlay */
 .navigation-overlay {
   position: fixed;
@@ -4016,21 +3947,31 @@ body.is-phone .taskchute-modal .modal-button-container {
 /* The label reserves a fixed box wide enough for the longest string it ever
    shows ("Today (12/31 Wed)"), so the arrows and the calendar button keep
    their positions as the date changes instead of sliding in and out. Because
-   the box no longer shrinks, the `is-not-today` margin nudges that used to
-   re-centre it -- and pulled the text under the calendar glyph -- are gone. */
+   the box no longer shrinks with the text, the `is-not-today` margin nudges
+   that used to re-centre it -- and pulled the text under the calendar glyph --
+   are gone.
+
+   The whole row needs 338px to hold that box (30 + 10 + [30 + 6 + 30 + 6 +
+   150 + 6 + 30] + 10 + 30). Below that the label is the one thing allowed to
+   give: `min-width: 0` lets it shrink and truncate to "Today (9/2..." rather
+   than push the next-day arrow off the edge of the leaf. `display: block` is
+   what lets an ellipsis work at all -- it has no effect on the flex container
+   this used to be. */
 .date-nav-label {
   font-size: 15px;
   font-weight: bold;
   color: #1976d2;
+  flex: 0 1 150px;
   width: 150px;
-  min-width: 150px;
-  flex-shrink: 0;
+  min-width: 0;
+  display: block;
   text-align: center;
   letter-spacing: 0.5px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   height: 28px;
+  line-height: 28px;
 
   /* It opens the calendar. Nothing else about it changes -- no underline, no
      hover colour -- because the header reads as a date first and a control
@@ -4042,6 +3983,7 @@ body.is-phone .taskchute-modal .modal-button-container {
   font-size: 15px;
   letter-spacing: 0.5px;
   height: 24px;
+  line-height: 24px;
 }
 .calendar-btn {
   background: none;

--- a/tests/styles/style-regressions.test.ts
+++ b/tests/styles/style-regressions.test.ts
@@ -802,44 +802,35 @@ describe('style regressions', () => {
     expect(stacked).toMatch(/flex-direction:\s*column;/)
   })
 
-  test('the header drops to two rows only on a phone-width leaf', () => {
+  test('the date label keeps a fixed box so the nav controls never move', () => {
     const css = styles()
-    const query = '@container taskchute-view (max-width: 380px)'
-    expect(css).toContain(query)
 
-    // Drawer and add stay at the corners of the top row; the date navigator
-    // takes the full width of the second one, arrows at its edges.
-    const bar = readRuleAfter(css, '.top-bar-container {', query)
-    expect(bar).toMatch(/grid-template-rows:\s*repeat\(2, 30px\);/)
+    // The label holds a box wide enough for the longest date string it ever
+    // shows, so neither arrow nor the calendar glyph slides as the date
+    // changes -- "Today (9/2 Wed)" and "9/3 Thu" occupy the same width.
+    const label = readRule(css, '.date-nav-label {')
+    expect(label).toMatch(/flex:\s*0 1 150px;/)
+    expect(label).toMatch(/width:\s*150px;/)
+    expect(label).toMatch(/text-align:\s*center;/)
 
-    const nav = readRuleAfter(
-      css,
-      '.top-bar-container > .date-nav-container.compact {',
-      query,
-    )
-    expect(nav).toMatch(/grid-row:\s*2;/)
-    expect(nav).toMatch(/grid-column:\s*1 \/ -1;/)
-    expect(nav).toMatch(/justify-content:\s*space-between;/)
-
-    // No width to spare: the label gives up its fixed 150px box and truncates
-    // rather than pushing the next-day arrow off the edge of the leaf.
-    const label = readRuleAfter(
-      css,
-      '.top-bar-container > .date-nav-container.compact .date-nav-label {',
-      query,
-    )
-    expect(label).toMatch(/text-overflow:\s*ellipsis;/)
+    // Below the ~338px the row needs for that box, the label is the one thing
+    // allowed to give: it truncates rather than pushing an arrow off the edge.
     expect(label).toMatch(/min-width:\s*0;/)
-    // An ellipsis does nothing to a flex container, which is what the label is
-    // at every other width.
+    expect(label).toMatch(/text-overflow:\s*ellipsis;/)
+    // An ellipsis does nothing to a flex container, which this used to be.
     expect(label).toMatch(/display:\s*block;/)
 
-    // `.date-nav-container.compact` sets its own column and centring later in
-    // the sheet, so the narrow rule has to outrank it rather than merely
-    // follow it -- hence the `.top-bar-container >` qualifier above.
-    expect(css.indexOf('\n.date-nav-container.compact {')).toBeGreaterThan(
-      css.indexOf(query),
-    )
+    // No width-keyed exception left: the phone rule that used to shrink the
+    // label to its text is gone, along with the two-row header and the hidden
+    // calendar glyph it belonged to.
+    expect(css).not.toContain('@container taskchute-view (max-width: 380px)')
+    expect(css).not.toMatch(/\.calendar-btn\s*\{[^}]*display:\s*none/)
+
+    // The compact variant only tunes the type; anything it said about the box
+    // would override the rule above on source order.
+    const compact = readRule(css, '.date-nav-container.compact .date-nav-label {')
+    expect(compact).not.toMatch(/width:/)
+    expect(compact).not.toMatch(/flex:/)
   })
 
   test('the move calendar keeps its arrows and Today button compact on mobile', () => {


### PR DESCRIPTION
## Problem

The phone-width block added in #159 (`@container taskchute-view (max-width: 380px)`) did three things to squeeze the header into a narrow leaf, and two of them turned out to be regressions:

- It stacked the bar into two rows and **hid the calendar glyph** (`.calendar-btn { display: none }`), so on a phone there was nothing left saying the date opens a picker.
- It made the date label **give up its fixed 150px box** (`width: auto`) so it could truncate. The label then sized itself to the string, so `Today (9/2 Wed)` → `9/3 Thu` moved the arrows and the glyph every time the date changed.

## Change

Drop the 380px block entirely.

- The header is **one row at every width**, and the calendar glyph stays.
- `.date-nav-label` keeps the 150px box that holds its longest string (`Today (12/31 Wed)`), so the three nav controls hold their positions as the date changes.
- What survives from the narrow layout is the ellipsis. The label switches from `display: flex` to `display: block` (an ellipsis has no effect on a flex container) and from `min-width: 150px; flex-shrink: 0` to `flex: 0 1 150px; min-width: 0`, so it is allowed to shrink and truncate to `Today (9/2…` rather than push the next-day arrow off the edge of a leaf too narrow for the 338px the row asks for — 30 + 10 + [30 + 6 + 30 + 6 + 150 + 6 + 30] + 10 + 30.

The top-bar grid and the navigator's centring are untouched, so the cluster still sits on the visual centre line of the view.

## Tests

`tests/styles/style-regressions.test.ts` now pins the label's fixed box *and* its truncation fallback, and guards the two regressions above: no rule anywhere hides `.calendar-btn`, and no width-keyed exception for the label remains.

- `npm test` — 3287 passing
- `tsc --noEmit`, CSS review lint — clean

Not yet verified on a device: worth checking that the cluster stays put while narrowing a leaf from wide down to ~340px, and that the date only truncates below that.