### PR TITLE
Keep the header's filter clear of the date navigator

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2803,9 +2803,18 @@ body.is-phone .taskchute-modal .modal-button-container {
 .top-bar-container {
   /* Keep the date navigator on the visual centre line of the whole view.
      Equal outer tracks prevent controls added on either side (for example
-     the AI board-view switch) from pushing the navigator off centre. */
+     the AI board-view switch) from pushing the navigator off centre.
+
+     The outer tracks bottom out at `min-content` rather than 0: a track
+     narrower than its contents does not clip them, and the action section is
+     `justify-self: end`, so the overflow spills leftwards and covers the
+     navigator's next-day arrow. Where the row is too tight to stay symmetric
+     the navigator drifts off centre instead, which is the lesser fault. The
+     switch labels are translated ("Human/AI/Mixed" against "人間/AI/混合"),
+     so the floor has to come from the contents rather than from a
+     pixel breakpoint. */
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-columns: minmax(min-content, 1fr) auto minmax(min-content, 1fr);
   align-items: center;
   gap: 10px;
   margin-bottom: 10px;
@@ -2859,12 +2868,13 @@ body.is-phone .taskchute-modal .modal-button-container {
 }
 
 /* Obsidian leaf splits do not change the viewport width, so use the view
-   container instead of a media query. At narrow widths the right-side switch
-   and add action stay together on a second row while the drawer returns to
-   its original top-left position. The `has-board-view-switch` marker class is
-   toggled by TaskHeaderController: `:has()` would express the same thing, but
-   Obsidian's plugin review flags it for the invalidation cost it puts on every
-   ancestor of the switch. */
+   container instead of a media query. At narrow widths the board-view filter
+   drops to a second row on its own; the drawer, the date navigator and the add
+   action keep the top row they had, so the header still reads as the familiar
+   one-line header with a filter parked underneath. The `has-board-view-switch`
+   marker class is toggled by TaskHeaderController: `:has()` would express the
+   same thing, but Obsidian's plugin review flags it for the invalidation cost
+   it puts on every ancestor of the switch. */
 @container taskchute-view (max-width: 680px) {
   .top-bar-container.has-board-view-switch {
     grid-template-rows: repeat(2, 30px);
@@ -2882,8 +2892,26 @@ body.is-phone .taskchute-modal .modal-button-container {
     justify-self: start;
   }
 
+  /* The filter and the add action share one flex section so they read as a
+     pair at comfortable widths. Here they belong on different rows, which a
+     single grid item cannot do, so the section stops being a box of its own
+     and hands its children straight to the grid. */
   .top-bar-container > .header-action-section.has-board-view-switch {
-    grid-column: 1 / -1;
+    display: contents;
+  }
+
+  .top-bar-container.has-board-view-switch .add-task-button.repositioned {
+    grid-column: 3;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  /* Scrolling moves from the section to the control itself. It doubles as the
+     reason the span stays honest: a scroll container's automatic minimum size
+     is 0, so reaching across to column 2 cannot widen the outer track that
+     `.top-bar-container` floors at `min-content`. */
+  .top-bar-container.has-board-view-switch .ai-board-view-switch {
+    grid-column: 2 / -1;
     grid-row: 2;
     justify-self: end;
     max-width: 100%;
@@ -2891,9 +2919,18 @@ body.is-phone .taskchute-modal .modal-button-container {
     scrollbar-width: none;
   }
 
-  .top-bar-container
-    > .header-action-section.has-board-view-switch::-webkit-scrollbar {
+  .top-bar-container.has-board-view-switch
+    .ai-board-view-switch::-webkit-scrollbar {
     display: none;
+  }
+
+  /* The optional terminal action (off by default) has no room left on the top
+     row, so it takes the far end of the second one. The filter starts at
+     column 2, which leaves this cell free. */
+  .top-bar-container.has-board-view-switch .robot-terminal-button {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: start;
   }
 }
 

--- a/tests/ui/header/task-header-layout.test.ts
+++ b/tests/ui/header/task-header-layout.test.ts
@@ -26,7 +26,7 @@ describe('TaskChute header layout', () => {
 
     expect(topBar).toMatch(/display:\s*grid;/)
     expect(topBar).toMatch(
-      /grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto\s+minmax\(0,\s*1fr\);/,
+      /grid-template-columns:\s*minmax\(min-content,\s*1fr\)\s+auto\s+minmax\(min-content,\s*1fr\);/,
     )
     expect(drawer).toMatch(/grid-column:\s*1;/)
     expect(drawer).toMatch(/justify-self:\s*start;/)
@@ -36,7 +36,17 @@ describe('TaskChute header layout', () => {
     expect(actions).toMatch(/justify-self:\s*end;/)
   })
 
-  test('narrow split keeps the switch and add action together below the centred date', () => {
+  test('outer tracks never shrink below the controls they hold', () => {
+    // A zero floor lets the action track become narrower than the switch and
+    // add button it holds. They are `justify-self: end`, so the overflow runs
+    // leftwards and hides the date navigator's next-day arrow.
+    const css = fs.readFileSync(path.join(ROOT, 'styles.css'), 'utf8')
+    const topBar = readRule(css, '.top-bar-container {')
+
+    expect(topBar).not.toMatch(/grid-template-columns:[^;]*minmax\(0,/)
+  })
+
+  test('narrow split drops only the filter to a second row', () => {
     const css = fs.readFileSync(path.join(ROOT, 'styles.css'), 'utf8')
     const viewRoot = readRule(css, '.taskchute-view-root {')
     const queryStart = css.indexOf('@container taskchute-view (max-width: 680px)')
@@ -55,8 +65,21 @@ describe('TaskChute header layout', () => {
     expect(query).toMatch(
       /\.top-bar-container\s*>\s*\.drawer-toggle\s*\{[\s\S]*grid-column:\s*1;[\s\S]*grid-row:\s*1;/,
     )
+    // The section holds the filter and the add action in one flex box, so it
+    // has to dissolve before the grid can put them on different rows.
     expect(query).toMatch(
-      /\.header-action-section\.has-board-view-switch\s*\{[\s\S]*grid-column:\s*1\s*\/\s*-1;[\s\S]*grid-row:\s*2;[\s\S]*justify-self:\s*end;/,
+      /\.header-action-section\.has-board-view-switch\s*\{[\s\S]*display:\s*contents;/,
+    )
+    expect(query).toMatch(
+      /\.add-task-button\.repositioned\s*\{[\s\S]*grid-column:\s*3;[\s\S]*grid-row:\s*1;[\s\S]*justify-self:\s*end;/,
+    )
+    expect(query).toMatch(
+      /\.ai-board-view-switch\s*\{[\s\S]*grid-row:\s*2;[\s\S]*justify-self:\s*end;/,
+    )
+    // The add action riding down with the filter is the regression this
+    // layout exists to prevent.
+    expect(query).not.toMatch(
+      /\.add-task-button\.repositioned\s*\{[^}]*grid-row:\s*2/,
     )
   })
 


### PR DESCRIPTION
## Problem

On desktop with the AI Task feature on, the Human / AI / Mixed filter covered the date navigator and hid the next-day arrow.

The header grid was `minmax(0, 1fr) auto minmax(0, 1fr)`. A `0` floor lets the third track become narrower than the `.header-action-section` it holds, and that section is `justify-self: end`, so the overflow runs *leftwards* over the navigator. It showed up in the band between the 680px two-row layout and the width where the row still fits symmetrically.


The narrow layout had a second problem: it dropped the whole action section to row two, so the add action rode down with the filter and left the top row half empty.

## Change

- Floor the outer tracks at `min-content`. Where the row is too tight to stay symmetric the navigator drifts off centre — the lesser fault — and the floor comes from the contents rather than from a pixel breakpoint the translated labels (`Human/AI/Mixed` against `人間/AI/混合`) would outgrow.
- In the `max-width: 680px` container query, give `.header-action-section` `display: contents` so the grid can place its children separately, and drop only the filter to row two. The drawer, the date navigator and the add action keep the top row. The optional terminal action (off by default) takes the far end of row two, where the filter's `2 / -1` span leaves it room.
- Scrolling moves from the section to the filter itself. That doubles as the reason the span stays honest: a scroll container's automatic minimum size is 0, so reaching across to column 2 cannot widen the floored outer track.

No DOM or TypeScript changes.

## Testing

- `npx jest` — 228 suites, 3288 tests pass. `tests/ui/header/task-header-layout.test.ts` pins the new track floors and asserts the add action never carries `grid-row: 2`.
- `npm run build`
- Checked by hand in Obsidian across leaf widths: wide (navigator centred, one row), ~690px (arrow visible, nothing overlapping), and below 680px (filter alone on row two, add action still top right).
