### PR TITLE
fix(license): count a seat per machine, not per vault

### DIFF
--- a/src/features/license/index.ts
+++ b/src/features/license/index.ts
@@ -12,7 +12,7 @@ import type { App } from 'obsidian'
 import type { TaskChuteSettings } from '../../types'
 import { LicenseApiClient } from './services/LicenseApiClient'
 import { LicenseManager } from './services/LicenseManager'
-import { LicenseStore } from './services/LicenseStore'
+import { createDeviceLocalStorageBridge, LicenseStore } from './services/LicenseStore'
 
 /** Electron's CommonJS require, available in Obsidian desktop only. */
 declare function require(moduleId: string): unknown
@@ -72,46 +72,47 @@ function cleanPart(value: unknown): string | undefined {
 }
 
 /**
- * Join the machine and vault names into one seat label.
+ * The machine's name as a seat label.
  *
- * Both halves matter: one person often runs several vaults on one machine, and
- * the same vault name can exist on several machines. Kept pure and separate
- * from the platform lookups so the formatting can be tested directly.
+ * A seat is one machine, so the machine name is the whole label — the vault
+ * name used to be appended, but every vault on a machine now shares one seat
+ * and one device id, which would leave whichever vault refreshed its token last
+ * naming the seat for all of them. Kept pure and separate from the platform
+ * lookups so the formatting can be tested directly.
  */
-export function formatDeviceLabel(host: unknown, vault: unknown): string | undefined {
-  const parts = [cleanPart(host), cleanPart(vault)].filter(
-    (part): part is string => part !== undefined,
-  )
-  if (parts.length === 0) return undefined
+export function formatDeviceLabel(host: unknown): string | undefined {
+  const cleaned = cleanPart(host)
+  if (cleaned === undefined) return undefined
 
   // Truncated rather than dropped: a clipped label still identifies the seat.
-  return parts.join(' / ').slice(0, DEVICE_LABEL_MAX_LENGTH)
+  return cleaned.slice(0, DEVICE_LABEL_MAX_LENGTH)
 }
 
-/** Human-readable name for this seat, as "<hostname> / <vault>". */
-export function describeDeviceLabel(app: App): string | undefined {
-  let vault: unknown
-  try {
-    vault = app.vault?.getName?.()
-  } catch {
-    // A label only helps the user pick a seat to release; losing it is cosmetic.
-    vault = undefined
-  }
-
-  return formatDeviceLabel(readHostname() ?? describePlatform(), vault)
+/** Human-readable name for this seat, as "<hostname>" or the platform name. */
+export function describeDeviceLabel(): string | undefined {
+  return formatDeviceLabel(readHostname() ?? describePlatform())
 }
 
 export function createLicenseManager(plugin: LicensePluginLike): LicenseManager {
   const log = (level: string, ...args: unknown[]) => plugin._log?.(level, ...args)
 
+  // The device state is kept out of the vault-scoped store so that every vault
+  // on one machine shares a single seat; plugin.app is passed only so installs
+  // written by an older version can be migrated. Where the raw store is
+  // unusable the vault-scoped one remains better than no persistence at all —
+  // it costs extra seats, losing the id costs one on every launch.
+  //
   // App exposes loadLocalStorage/saveLocalStorage but does not declare them in
   // the public typings; the same cast is used by AiCustomModelStore's callers.
-  const store = new LicenseStore(plugin.app)
+  const deviceStorage = createDeviceLocalStorageBridge()
+  const store = deviceStorage
+    ? new LicenseStore(deviceStorage, plugin.app)
+    : new LicenseStore(plugin.app)
   const client = new LicenseApiClient({ log })
 
   const platform = describePlatform()
   const pluginVersion = plugin.manifest?.version
-  const deviceLabel = describeDeviceLabel(plugin.app)
+  const deviceLabel = describeDeviceLabel()
 
   const manager = new LicenseManager({
     client,

--- a/src/features/license/services/LicenseStore.ts
+++ b/src/features/license/services/LicenseStore.ts
@@ -5,13 +5,21 @@
  * carries the entitlement to a new machine, which then activates itself.
  *
  * Everything device-bound — the device id, the token signed against it, and the
- * last known server time — lives in Obsidian's device-local storage. This is a
- * deliberate deviation from the API's SPEC 11-1, which assumes both go in
- * data.json: with Obsidian Sync that file is shared, so a synced token would
- * arrive on a second machine bound to the first machine's device id and fail
- * verification with `device-mismatch` forever.
+ * last known server time — lives in device-local storage. This is a deliberate
+ * deviation from the API's SPEC 11-1, which assumes both go in data.json: with
+ * Obsidian Sync that file is shared, so a synced token would arrive on a second
+ * machine bound to the first machine's device id and fail verification with
+ * `device-mismatch` forever.
  *
- * Follows the precedent set by AiCustomModelStore.
+ * The storage is the raw `window.localStorage`, *not* Obsidian's
+ * `App#saveLocalStorage`. The latter prefixes every key with the vault's app
+ * id, which would make each vault on one machine present a different device id
+ * and consume a seat of its own. The raw store is shared by every vault of one
+ * Obsidian install, which is as close to "one machine" as the plugin sandbox
+ * gets — the same approach DeviceIdentityService already takes for the
+ * execution log. Older installs kept their state in the vault-scoped store, so
+ * a legacy bridge can be passed in and is read once to adopt its device id
+ * (see `read`).
  */
 import type { LicenseSummary } from './LicenseApiClient'
 
@@ -41,10 +49,45 @@ export interface LicenseDeviceState {
   seatReleasedAt?: number
 }
 
-/** Duck-typed App#loadLocalStorage / App#saveLocalStorage bridge. */
+/**
+ * Key/value storage for the device state. Shaped after Obsidian's
+ * `App#loadLocalStorage` / `App#saveLocalStorage` so the App object itself can
+ * still be passed as the legacy bridge.
+ */
 export interface LicenseStorageBridge {
   loadLocalStorage?: (key: string) => unknown
   saveLocalStorage?: (key: string, value: unknown) => void
+}
+
+/** Written and removed only to find out whether the store accepts writes. */
+const STORAGE_PROBE_KEY = 'taskchute-plus.license-storage-probe'
+
+/**
+ * The vault-independent store, or undefined where it cannot be used.
+ *
+ * Undefined has to stay distinguishable from "empty": a bridge that silently
+ * drops writes would hand out a fresh device id on every launch and burn a seat
+ * each time, so the caller falls back to the vault-scoped store instead.
+ */
+export function createDeviceLocalStorageBridge(): LicenseStorageBridge | undefined {
+  try {
+    const storage = window.localStorage
+    if (!storage) return undefined
+
+    // Presence is not permission: private modes and hardened setups expose the
+    // object and throw on write.
+    storage.setItem(STORAGE_PROBE_KEY, '1')
+    storage.removeItem(STORAGE_PROBE_KEY)
+
+    return {
+      loadLocalStorage: (key) => storage.getItem(key) ?? undefined,
+      saveLocalStorage: (key, value) => {
+        storage.setItem(key, JSON.stringify(value))
+      },
+    }
+  } catch {
+    return undefined
+  }
 }
 
 const DEVICE_ID_PREFIX = 'DEVICE-'
@@ -91,10 +134,63 @@ function readPositiveInt(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined
 }
 
+/**
+ * One store's state, or undefined when it holds nothing usable.
+ *
+ * A record without a valid device id is treated as absent in full: whatever
+ * token sits beside it is signed against an id this device can no longer
+ * present, so it could never verify.
+ */
+function readState(bridge: LicenseStorageBridge): LicenseDeviceState | undefined {
+  let raw: unknown
+  try {
+    raw = bridge.loadLocalStorage?.(LICENSE_DEVICE_STATE_STORAGE_KEY)
+  } catch {
+    return undefined
+  }
+
+  // The raw store hands back the JSON text; Obsidian's App parses it for us.
+  if (typeof raw === 'string') {
+    try {
+      raw = JSON.parse(raw) as unknown
+    } catch {
+      return undefined
+    }
+  }
+
+  if (typeof raw !== 'object' || raw === null) return undefined
+
+  const record = raw as Record<string, unknown>
+  if (!isValidDeviceId(record['deviceId'])) return undefined
+
+  const token = typeof record['token'] === 'string' ? record['token'] : undefined
+  const expiresAt = readPositiveInt(record['expiresAt'])
+  const lastServerTimeSec = readPositiveInt(record['lastServerTimeSec'])
+  const license = readLicenseSummary(record['license'])
+  const seatReleasedAt = readPositiveInt(record['seatReleasedAt'])
+
+  return {
+    deviceId: record['deviceId'],
+    ...(token !== undefined ? { token } : {}),
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
+    ...(lastServerTimeSec !== undefined ? { lastServerTimeSec } : {}),
+    ...(license !== undefined ? { license } : {}),
+    ...(seatReleasedAt !== undefined ? { seatReleasedAt } : {}),
+  }
+}
+
 export class LicenseStore {
   private state: LicenseDeviceState
 
-  constructor(private readonly bridge: LicenseStorageBridge) {
+  /**
+   * `legacy` is the store an older version of the plugin wrote to (the
+   * vault-scoped one). It is only ever read, and only when `bridge` holds
+   * nothing usable.
+   */
+  constructor(
+    private readonly bridge: LicenseStorageBridge,
+    private readonly legacy?: LicenseStorageBridge,
+  ) {
     this.state = this.read()
     // Persist immediately so a freshly generated device id survives a crash
     // before the first activation; otherwise a seat could be claimed under an
@@ -180,41 +276,24 @@ export class LicenseStore {
     return now < lastSeen - toleranceSec
   }
 
+  /**
+   * The stored state, migrating from the legacy store when this one is empty.
+   *
+   * Adopting the legacy device id rather than minting a new one keeps the seat
+   * this vault already holds. Where several vaults on one machine each hold a
+   * seat, whichever launches first wins the machine's id and the others fall in
+   * behind it; their old seats stay until the user releases them from the
+   * device list. The legacy entry is left in place — it is never written again,
+   * and it costs nothing to leave a way back if this store is ever wiped.
+   */
   private read(): LicenseDeviceState {
-    let raw: unknown
-    try {
-      raw = this.bridge.loadLocalStorage?.(LICENSE_DEVICE_STATE_STORAGE_KEY)
-    } catch {
-      raw = undefined
-    }
+    const current = readState(this.bridge)
+    if (current) return current
 
-    // Obsidian returns the parsed value, but older vaults may hold a string.
-    if (typeof raw === 'string') {
-      try {
-        raw = JSON.parse(raw) as unknown
-      } catch {
-        raw = undefined
-      }
-    }
+    const migrated = this.legacy ? readState(this.legacy) : undefined
+    if (migrated) return migrated
 
-    const record =
-      typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>) : {}
-
-    const deviceId = isValidDeviceId(record['deviceId']) ? record['deviceId'] : generateDeviceId()
-    const token = typeof record['token'] === 'string' ? record['token'] : undefined
-    const expiresAt = readPositiveInt(record['expiresAt'])
-    const lastServerTimeSec = readPositiveInt(record['lastServerTimeSec'])
-    const license = readLicenseSummary(record['license'])
-    const seatReleasedAt = readPositiveInt(record['seatReleasedAt'])
-
-    return {
-      deviceId,
-      ...(token !== undefined ? { token } : {}),
-      ...(expiresAt !== undefined ? { expiresAt } : {}),
-      ...(lastServerTimeSec !== undefined ? { lastServerTimeSec } : {}),
-      ...(license !== undefined ? { license } : {}),
-      ...(seatReleasedAt !== undefined ? { seatReleasedAt } : {}),
-    }
+    return { deviceId: generateDeviceId() }
   }
 
   private write(): void {

--- a/tests/features/license/device-label.test.ts
+++ b/tests/features/license/device-label.test.ts
@@ -1,43 +1,34 @@
 /**
- * The label is what a user reads when choosing which seat to release, so it
- * has to name both the machine and the vault — one person often runs several
- * vaults on one machine, and the same vault name exists on several machines.
+ * The label is what a user reads when choosing which seat to release. A seat is
+ * one machine — every vault on it shares a device id — so the label names the
+ * machine and nothing else.
  */
 import { formatDeviceLabel } from '../../../src/features/license'
 
 describe('formatDeviceLabel', () => {
-  test('joins the machine and the vault', () => {
-    expect(formatDeviceLabel('workbench', 'Notes')).toBe('workbench / Notes')
+  test('names the machine', () => {
+    expect(formatDeviceLabel('workbench')).toBe('workbench')
   })
 
   test('drops the .local suffix macOS reports', () => {
-    expect(formatDeviceLabel('MacBook-Pro.local', 'Notes')).toBe('MacBook-Pro / Notes')
+    expect(formatDeviceLabel('MacBook-Pro.local')).toBe('MacBook-Pro')
   })
 
   test('trims surrounding whitespace', () => {
-    expect(formatDeviceLabel('  workbench  ', ' Notes ')).toBe('workbench / Notes')
+    expect(formatDeviceLabel('  workbench  ')).toBe('workbench')
   })
 
   test.each([
-    ['a missing vault name', undefined],
-    ['a blank vault name', '   '],
-    ['a non-string vault name', 42],
-  ])('omits %s rather than emitting a dangling separator', (_label, vault) => {
-    expect(formatDeviceLabel('workbench', vault)).toBe('workbench')
-  })
-
-  test('falls back to the vault alone when the machine is unknown', () => {
-    // Mobile has no require('os') and may not match a known platform.
-    expect(formatDeviceLabel(undefined, 'Notes')).toBe('Notes')
-  })
-
-  test('returns undefined when nothing is knowable', () => {
+    ['a missing name', undefined],
+    ['a blank name', '   '],
+    ['a non-string name', 42],
+  ])('returns undefined for %s', (_label, host) => {
     // The API treats the label as optional, so sending nothing is valid.
-    expect(formatDeviceLabel(undefined, undefined)).toBeUndefined()
+    expect(formatDeviceLabel(host)).toBeUndefined()
   })
 
   test('truncates to the length the API accepts', () => {
     // The API caps `label` at 100 characters; exceeding it fails the request.
-    expect(formatDeviceLabel('h'.repeat(80), 'v'.repeat(80))).toHaveLength(100)
+    expect(formatDeviceLabel('h'.repeat(140))).toHaveLength(100)
   })
 })

--- a/tests/features/license/license-store.test.ts
+++ b/tests/features/license/license-store.test.ts
@@ -1,4 +1,5 @@
 import {
+  createDeviceLocalStorageBridge,
   generateDeviceId,
   LICENSE_DEVICE_STATE_STORAGE_KEY,
   LicenseStore,
@@ -193,5 +194,110 @@ describe('LicenseStore', () => {
 
       expect(store.getState().lastServerTimeSec).toBe(2_000_000_000)
     })
+  })
+})
+
+describe('createDeviceLocalStorageBridge', () => {
+  const realStorage = window.localStorage
+
+  afterEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: realStorage,
+      configurable: true,
+    })
+    realStorage.clear()
+  })
+
+  test('stores the state under an unprefixed key', () => {
+    const bridge = createDeviceLocalStorageBridge()
+    const store = new LicenseStore(bridge!)
+
+    // Unprefixed is the whole point: Obsidian's App#saveLocalStorage would put
+    // the vault's app id in front of it and give each vault its own seat.
+    const raw = window.localStorage.getItem(LICENSE_DEVICE_STATE_STORAGE_KEY)
+    expect(JSON.parse(raw ?? '{}')).toMatchObject({ deviceId: store.getDeviceId() })
+  })
+
+  test('gives every vault on the machine the same device id', () => {
+    // Two vaults are two LicenseStore instances over one browser storage.
+    const first = new LicenseStore(createDeviceLocalStorageBridge()!)
+    const second = new LicenseStore(createDeviceLocalStorageBridge()!)
+
+    expect(second.getDeviceId()).toBe(first.getDeviceId())
+  })
+
+  test('reports storage that refuses writes as unusable', () => {
+    // Handing back a bridge that drops writes would mint a new device id — and
+    // burn a seat — on every launch, so it has to be distinguishable.
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('denied')
+        },
+        removeItem: () => undefined,
+      },
+      configurable: true,
+    })
+
+    expect(createDeviceLocalStorageBridge()).toBeUndefined()
+  })
+
+  test('reports a missing storage as unusable', () => {
+    Object.defineProperty(window, 'localStorage', { value: undefined, configurable: true })
+
+    expect(createDeviceLocalStorageBridge()).toBeUndefined()
+  })
+})
+
+describe('LicenseStore migration from the vault-scoped store', () => {
+  test('adopts the legacy device id so the seat is kept', () => {
+    const legacy = createBridge({ deviceId: 'DEVICE-LEGACY01', token: 't', expiresAt: 99 })
+    const bridge = createBridge()
+
+    const store = new LicenseStore(bridge, legacy)
+
+    expect(store.getDeviceId()).toBe('DEVICE-LEGACY01')
+    expect(store.getState().token).toBe('t')
+    // Copied across on construction, so the next launch reads it from the
+    // shared store whether or not the legacy entry still exists.
+    expect(bridge.store.get(LICENSE_DEVICE_STATE_STORAGE_KEY)).toMatchObject({
+      deviceId: 'DEVICE-LEGACY01',
+      token: 't',
+    })
+  })
+
+  test('leaves the legacy entry alone once migrated', () => {
+    const legacy = createBridge({ deviceId: 'DEVICE-LEGACY01' })
+    const store = new LicenseStore(createBridge(), legacy)
+
+    store.saveToken('TCPT1.a.b', 1787604800, SUMMARY, 1787000000)
+
+    expect(legacy.store.get(LICENSE_DEVICE_STATE_STORAGE_KEY)).toEqual({
+      deviceId: 'DEVICE-LEGACY01',
+    })
+  })
+
+  test('ignores the legacy store once this machine has an id', () => {
+    // The second vault to launch finds the machine id already set and falls in
+    // behind it rather than dragging its own seat across.
+    const bridge = createBridge({ deviceId: 'DEVICE-MACHINE01' })
+    const legacy = createBridge({ deviceId: 'DEVICE-LEGACY01' })
+
+    expect(new LicenseStore(bridge, legacy).getDeviceId()).toBe('DEVICE-MACHINE01')
+  })
+
+  test('falls through to a fresh id when neither store has one', () => {
+    const store = new LicenseStore(createBridge(), createBridge('not json'))
+
+    expect(store.getDeviceId()).toMatch(/^DEVICE-[0-9A-F]+$/)
+  })
+
+  test('drops a token whose device id did not survive', () => {
+    // The token is signed against an id this device can no longer present, so
+    // keeping it would only produce a device-mismatch on the next call.
+    const store = new LicenseStore(createBridge({ deviceId: 'short', token: 't' }))
+
+    expect(store.getState().token).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Problem

The license device state lived in Obsidian's `App#saveLocalStorage`, which prefixes every key with the vault's app id. Each vault on one machine therefore presented a device id of its own and consumed a seat of its own — a three-seat licence could run out on a single laptop.

The server has always counted seats by `device_id` (`device_uid = license_id:device_id`), so this is entirely a client-side problem. No API change.

## Change

- **`LicenseStore`** now persists to the raw `window.localStorage` under an unprefixed key. Every vault of one Obsidian install shares that store, which is as close to "one machine" as the plugin sandbox gets — and it is the store `DeviceIdentityService` already uses for the execution log.
- **Migration.** The vault-scoped store is passed in as a read-only legacy bridge and consulted once, when the shared store holds nothing. Its device id is adopted rather than replaced, so the seat a vault already holds is kept instead of re-bought. The legacy entry is never written again and is left in place as a way back if the shared store is ever wiped.
- **Fallback.** `createDeviceLocalStorageBridge()` probes the store with a write and returns `undefined` when it is unusable, in which case the vault-scoped store still backs the state. "Unusable" has to stay distinguishable from "empty": a bridge that silently drops writes would mint a new device id — and burn a seat — on every launch.
- **Seat label** drops the vault name. One row now stands for the whole machine, and whichever vault refreshed its token last would otherwise name the seat for all of them. Desktop shows the hostname, mobile the platform name.
- A record whose device id did not survive validation is now discarded in full. Previously a fresh id could be paired with the old token, which could only ever fail as `device-mismatch`.

## Notes for the release

Users who ran several vaults on one machine keep the seat of whichever vault launches first; the others fall in behind that id. The seats their old ids hold stay on the server until released from the device list — reclaiming them automatically would risk taking a seat that belongs to another machine. Worth a line in the release notes.

## Verification

`npm run lint`, `npm run typecheck`, `npm run review:obsidian` (0 errors, 0 warnings) and the full Jest suite (3298 tests) pass.

Tests added for the new behaviour: state stored under an unprefixed key, two vaults resolving to one device id, storage that refuses writes reported as unusable, adoption of a legacy id, no writes back to the legacy store, and the legacy store ignored once the machine has an id. The device-label tests were rewritten for the single-part label.