### PR TITLE
Make the recipe checklists draggable on iPad

### DIFF
--- a/src/features/recipe/modals/RecipeManagerModal.ts
+++ b/src/features/recipe/modals/RecipeManagerModal.ts
@@ -72,6 +72,7 @@ export default class RecipeManagerModal extends Modal {
   }
 
   onClose(): void {
+    this.activeEditor?.destroy()
     this.activeEditor = null
     this.contentEl.empty()
   }
@@ -98,7 +99,10 @@ export default class RecipeManagerModal extends Modal {
   }
 
   private render(): void {
-        this.activeEditor = null
+    // Re-rendering discards the form, so a reorder still in flight has to go
+    // with it -- its ghost is on `body` and would otherwise be orphaned.
+    this.activeEditor?.destroy()
+    this.activeEditor = null
     this.contentEl.empty()
     if (this.mode === 'edit') {
       this.renderEdit()

--- a/src/features/recipe/modals/RecipeSelectModal.ts
+++ b/src/features/recipe/modals/RecipeSelectModal.ts
@@ -79,12 +79,18 @@ export class RecipeSelectModal extends Modal {
 
   onClose(): void {
     this.hideSuggestions()
+    this.inlineEditor?.destroy()
+    this.createEditor?.destroy()
     this.inlineEditor = null
     this.createEditor = null
     this.contentEl.empty()
   }
 
   private render(): void {
+    // Re-rendering discards the forms, so a reorder still in flight has to go
+    // with them -- its ghost is on `body` and would otherwise be orphaned.
+    this.inlineEditor?.destroy()
+    this.createEditor?.destroy()
     this.inlineEditor = null
     this.createEditor = null
     this.saveButton = null

--- a/src/features/recipe/ui/RecipeEditorForm.ts
+++ b/src/features/recipe/ui/RecipeEditorForm.ts
@@ -1,5 +1,6 @@
 import { t } from '../../../i18n'
 import { applyIcon } from '../../../ui/icons'
+import RecipeReorderPointerDrag, { appendRecipeDragHandleIcon } from './RecipeReorderPointerDrag'
 
 let recipeEditorFormId = 0
 
@@ -45,7 +46,16 @@ export class RecipeEditorForm {
   private readonly stepsList: HTMLElement
   private readonly qualityList: HTMLElement
   private errorEl: HTMLElement
-  private dragged: { kind: ChecklistKind; index: number } | null = null
+  private readonly pointerDrag = new RecipeReorderPointerDrag({
+    rowSelector: '.recipe-step-row',
+    draggingClass: 'recipe-run-step--dragging',
+    dropBeforeClass: 'recipe-run-step--drop-before',
+    dropAfterClass: 'recipe-run-step--drop-after',
+    ghostClass: 'recipe-reorder-drag-ghost',
+    onReorder: (kind, fromIndex, toIndex) => {
+      this.reorder(kind as ChecklistKind, fromIndex, toIndex)
+    },
+  })
 
   constructor(
     private readonly container: HTMLElement,
@@ -215,6 +225,17 @@ export class RecipeEditorForm {
     })
   }
 
+  /**
+   * Abandons a reorder in flight and removes its ghost.
+   *
+   * The ghost is parented to `body` so it can follow the pointer, which means
+   * closing the dialog mid-drag -- Escape, most easily -- would strand it on
+   * screen with no pointer events left to clean it up.
+   */
+  destroy(): void {
+    this.pointerDrag.cancel()
+  }
+
   focus(): void {
     if (this.titleInput) {
       this.titleInput.focus()
@@ -235,33 +256,20 @@ export class RecipeEditorForm {
       const row = list.createDiv({ cls: rowClass })
       row.setAttribute('data-recipe-list-kind', kind)
       row.setAttribute('data-recipe-item-index', String(index))
-      row.addEventListener('dragover', (event) => {
-        if (!this.dragged || this.dragged.kind !== kind || this.dragged.index === index) return
-        event.preventDefault()
-        row.classList.add('recipe-run-step--drop-target')
-      })
-      row.addEventListener('dragleave', () => row.classList.remove('recipe-run-step--drop-target'))
-      row.addEventListener('drop', (event) => {
-        event.preventDefault()
-        row.classList.remove('recipe-run-step--drop-target')
-        if (!this.dragged || this.dragged.kind !== kind) return
-        const fromIndex = this.dragged.index
-        this.dragged = null
-        this.reorder(kind, fromIndex, index)
-      })
+      this.pointerDrag.registerRow(row, kind, index)
 
       const handleClass = kind === 'steps' ? 'recipe-step-drag-handle' : 'recipe-quality-drag-handle'
       const handle = row.createEl('button', {
         cls: `recipe-list-drag-handle ${handleClass}`,
         attr: {
           type: 'button',
-          draggable: 'true',
           title: t('recipes.manager.reorderStep', 'ドラッグして並び替え'),
           'aria-label': t('recipes.manager.reorderStep', 'ドラッグして並び替え'),
           'aria-keyshortcuts': 'Alt+ArrowUp Alt+ArrowDown',
         },
       })
-      this.appendDragHandleIcon(handle)
+      appendRecipeDragHandleIcon(handle)
+      this.pointerDrag.attachHandle(handle, row)
       handle.addEventListener('click', (event) => {
         event.preventDefault()
         event.stopPropagation()
@@ -273,18 +281,6 @@ export class RecipeEditorForm {
         if (targetIndex < 0 || targetIndex >= values.length) return
         this.reorder(kind, index, targetIndex)
         this.getList(kind).querySelectorAll<HTMLButtonElement>('.recipe-list-drag-handle')[targetIndex]?.focus()
-      })
-      handle.addEventListener('dragstart', (event) => {
-        this.dragged = { kind, index }
-        row.classList.add('recipe-run-step--dragging')
-        event.dataTransfer?.setData('text/plain', `${kind}:${index}`)
-        if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
-      })
-      handle.addEventListener('dragend', () => {
-        this.dragged = null
-        row.classList.remove('recipe-run-step--dragging')
-        list.querySelectorAll('.recipe-run-step--drop-target')
-          .forEach((element) => element.classList.remove('recipe-run-step--drop-target'))
       })
 
       const isQuality = kind === 'quality'
@@ -444,24 +440,5 @@ export class RecipeEditorForm {
 
   private normalizeLines(values: string[]): string[] {
     return values.map((value) => value.trim()).filter((value) => value.length > 0)
-  }
-
-  private appendDragHandleIcon(container: HTMLElement): void {
-    const svg = createSvg('svg')
-    svg.setAttribute('viewBox', '0 0 12 16')
-    svg.setAttribute('width', '12')
-    svg.setAttribute('height', '16')
-    svg.setAttribute('aria-hidden', 'true')
-    svg.classList.add('recipe-step-drag-handle-icon')
-    ;[
-      ['2', '2'], ['8', '2'], ['2', '8'], ['8', '8'], ['2', '14'], ['8', '14'],
-    ].forEach(([cx, cy]) => {
-      const circle = createSvg('circle')
-      circle.setAttribute('cx', cx)
-      circle.setAttribute('cy', cy)
-      circle.setAttribute('r', '1.5')
-      svg.appendChild(circle)
-    })
-    container.appendChild(svg)
   }
 }

--- a/src/features/recipe/ui/RecipeReorderPointerDrag.ts
+++ b/src/features/recipe/ui/RecipeReorderPointerDrag.ts
@@ -1,0 +1,339 @@
+import {
+  parkTooltipSources,
+  restoreTooltipSources,
+  stripTooltipSources,
+} from '../../../ui/tooltipSources'
+
+/** The slice of a pointer position the drop math reads. */
+interface DragPoint {
+  clientX: number
+  clientY: number
+}
+
+export interface RecipeReorderPointerDragOptions {
+  /** Selector matching a droppable row, resolved from the element under the pointer. */
+  rowSelector: string
+  /** Toggled on the row being dragged. */
+  draggingClass: string
+  /** Toggled on the hovered row when the dragged row will land above it. */
+  dropBeforeClass: string
+  /** Toggled on the hovered row when the dragged row will land below it. */
+  dropAfterClass: string
+  /** Applied to the floating clone that follows the pointer. */
+  ghostClass: string
+  onReorder: (kind: string, fromIndex: number, toIndex: number) => void
+}
+
+interface RowIdentity {
+  kind: string
+  index: number
+}
+
+interface DragSession {
+  pointerId: number
+  handle: HTMLElement
+  row: HTMLElement
+  source: RowIdentity
+  startX: number
+  startY: number
+  grabOffsetX: number
+  grabOffsetY: number
+  started: boolean
+  ghost: HTMLElement | null
+  /** The grip's tooltip attributes, parked for the duration of the drag. */
+  parkedTooltip: Map<string, string>
+  hover: HTMLElement | null
+  scroller: HTMLElement | null
+  scrollFrame: number | null
+  lastClientY: number
+}
+
+/** Movement before a press on the grip counts as a drag rather than a tap. */
+const DRAG_THRESHOLD_PX = 6
+/** Distance from the scroller's edge at which the list starts following. */
+const EDGE_SCROLL_ZONE_PX = 48
+const EDGE_SCROLL_STEP_PX = 12
+
+/**
+ * Reordering by pointer events instead of the HTML5 drag-and-drop API.
+ *
+ * iPadOS and iOS never fire `dragstart` for in-page content, so the grips in the
+ * recipe editor and the run popover were inert on a tablet while working on the
+ * desktop -- `Alt+Arrow` was the only path that ever moved a row there. Driving
+ * the gesture from Pointer Events gives a mouse, a pen and a finger one shared
+ * implementation, the same way the task list already works.
+ *
+ * Rows carry no listeners of their own: the row under the pointer is resolved
+ * with `elementFromPoint` on every move, which is what lets the same code
+ * hit-test a cursor and a finger without caring which it has.
+ */
+export default class RecipeReorderPointerDrag {
+  private readonly rows = new WeakMap<HTMLElement, RowIdentity>()
+  private session: DragSession | null = null
+
+  constructor(private readonly options: RecipeReorderPointerDragOptions) {}
+
+  /** Rows are drop targets only; they need no listeners, just an identity. */
+  registerRow(row: HTMLElement, kind: string, index: number): void {
+    this.rows.set(row, { kind, index })
+  }
+
+  attachHandle(handle: HTMLElement, row: HTMLElement): void {
+    handle.addEventListener('pointerdown', (event) => {
+      // Secondary buttons open the context menu; a non-primary pointer is a
+      // second finger landing mid-drag.
+      if (!event.isPrimary || event.button !== 0) return
+      if (this.session) return
+      this.begin(event, handle, row)
+    })
+    handle.addEventListener('pointermove', (event) => this.move(event))
+    handle.addEventListener('pointerup', (event) => this.finish(event))
+    handle.addEventListener('pointercancel', (event) => {
+      if (this.session?.pointerId !== event.pointerId) return
+      this.teardown(this.session)
+    })
+  }
+
+  /**
+   * Abandons any drag in flight and takes the ghost with it.
+   *
+   * A pointer drag normally ends with `pointerup` or `pointercancel`, but the
+   * host can disappear first -- Escape closes the run popover mid-drag, the row
+   * and its grip go with it, and no further pointer event is ever delivered.
+   * The ghost is parented to `body`, so without this it stays on screen with
+   * nothing left to remove it. Every owner must call this when it tears down.
+   */
+  cancel(): void {
+    this.teardown(this.session)
+  }
+
+  private begin(event: PointerEvent, handle: HTMLElement, row: HTMLElement): void {
+    const source = this.rows.get(row)
+    if (!source) return
+
+    const rect = row.getBoundingClientRect()
+    this.session = {
+      pointerId: event.pointerId,
+      handle,
+      row,
+      source,
+      startX: event.clientX,
+      startY: event.clientY,
+      grabOffsetX: event.clientX - rect.left,
+      grabOffsetY: event.clientY - rect.top,
+      started: false,
+      ghost: null,
+      parkedTooltip: new Map(),
+      hover: null,
+      scroller: this.findScroller(row),
+      scrollFrame: null,
+      lastClientY: event.clientY,
+    }
+    // Capture up front: once the finger leaves the small grip -- which it does
+    // immediately -- only the capturing element keeps receiving moves.
+    try {
+      handle.setPointerCapture(event.pointerId)
+    } catch {
+      // Synthetic pointers in tests, and pens that leave range, have no capture
+      // to take. Hit-testing still works without it.
+    }
+  }
+
+  private move(event: PointerEvent): void {
+    const session = this.session
+    if (!session || session.pointerId !== event.pointerId) return
+
+    if (!session.started) {
+      const dx = event.clientX - session.startX
+      const dy = event.clientY - session.startY
+      if (Math.sqrt(dx * dx + dy * dy) < DRAG_THRESHOLD_PX) return
+      this.start(session)
+    }
+
+    // Keeps a pen or a trackpad from selecting the row's text under the ghost.
+    event.preventDefault()
+    session.lastClientY = event.clientY
+    this.positionGhost(session, event)
+    this.updateHover(session, event)
+    this.updateEdgeScroll(session, event.clientY)
+  }
+
+  private start(session: DragSession): void {
+    session.started = true
+    session.row.classList.add(this.options.draggingClass)
+
+    // The pointer stays on the grip for the whole drag, so both the browser's
+    // `title` tooltip and Obsidian's `aria-label` one would hang over the rows
+    // the user is aiming at. Neither can be stacked out of the way -- see
+    // `tooltipSources`.
+    parkTooltipSources(session.handle, session.parkedTooltip)
+
+    const rect = session.row.getBoundingClientRect()
+    const ghost = session.row.cloneNode(true) as HTMLElement
+    ghost.classList.add(this.options.ghostClass)
+    ghost.classList.remove(this.options.draggingClass)
+    ghost.style.width = `${rect.width}px`
+    ghost.style.height = `${rect.height}px`
+    // The clone brings the whole row's tooltip sources with it -- the remove
+    // button's included. It is decoration, so nothing on it should ever raise
+    // a tooltip of its own.
+    stripTooltipSources(ghost)
+    // ownerDocument, not the global one: the view can live in a popped-out window.
+    session.row.ownerDocument.body.appendChild(ghost)
+    session.ghost = ghost
+  }
+
+  private positionGhost(session: DragSession, point: DragPoint): void {
+    const ghost = session.ghost
+    if (!ghost) return
+    ghost.style.transform = `translate3d(${
+      point.clientX - session.grabOffsetX
+    }px, ${point.clientY - session.grabOffsetY}px, 0)`
+  }
+
+  private updateHover(session: DragSession, point: DragPoint): void {
+    const next = this.resolveTarget(session, point)
+    if (next === session.hover) return
+    this.clearHover(session)
+    session.hover = next
+    if (!next) return
+    // The reorder splices the row into the target's index, so a row travelling
+    // down lands below the row it is over and one travelling up lands above it.
+    // Marking that edge is what tells the user where the row will actually go.
+    const target = this.rows.get(next)
+    const landsBelow = target !== undefined && target.index > session.source.index
+    next.classList.add(landsBelow ? this.options.dropAfterClass : this.options.dropBeforeClass)
+  }
+
+  private resolveTarget(session: DragSession, point: DragPoint): HTMLElement | null {
+    // The ghost is `pointer-events: none`, so it never hides what is under it.
+    const element = session.row.ownerDocument.elementFromPoint(point.clientX, point.clientY)
+    if (!(element instanceof Element)) return null
+
+    const row = element.closest(this.options.rowSelector)
+    if (!(row instanceof HTMLElement)) return null
+
+    const identity = this.rows.get(row)
+    if (!identity) return null
+    // A different list in the same popover, or the row already being dragged.
+    if (identity.kind !== session.source.kind) return null
+    if (identity.index === session.source.index) return null
+    return row
+  }
+
+  private clearHover(session: DragSession): void {
+    session.hover?.classList.remove(this.options.dropBeforeClass, this.options.dropAfterClass)
+    session.hover = null
+  }
+
+  /**
+   * The native drag path got edge scrolling from the browser. Driving the
+   * scroller by hand is what keeps a long checklist reachable once that is gone.
+   */
+  private updateEdgeScroll(session: DragSession, clientY: number): void {
+    const scroller = session.scroller
+    if (!scroller) return
+
+    const rect = scroller.getBoundingClientRect()
+    let delta = 0
+    if (clientY - rect.top < EDGE_SCROLL_ZONE_PX) delta = -EDGE_SCROLL_STEP_PX
+    else if (rect.bottom - clientY < EDGE_SCROLL_ZONE_PX) delta = EDGE_SCROLL_STEP_PX
+
+    if (delta === 0) {
+      this.stopEdgeScroll(session)
+      return
+    }
+    if (session.scrollFrame !== null) return
+
+    const step = (): void => {
+      if (this.session !== session) return
+      scroller.scrollTop += delta
+      // Re-hit-test at the held position: the rows under the pointer change as
+      // the list moves even though the pointer itself has not.
+      const ghost = session.ghost
+      if (ghost) {
+        const ghostRect = ghost.getBoundingClientRect()
+        this.updateHover(session, {
+          clientX: ghostRect.left + session.grabOffsetX,
+          clientY: session.lastClientY,
+        })
+      }
+      session.scrollFrame = window.requestAnimationFrame(step)
+    }
+    session.scrollFrame = window.requestAnimationFrame(step)
+  }
+
+  private stopEdgeScroll(session: DragSession): void {
+    if (session.scrollFrame === null) return
+    window.cancelAnimationFrame(session.scrollFrame)
+    session.scrollFrame = null
+  }
+
+  private finish(event: PointerEvent): void {
+    const session = this.session
+    if (!session || session.pointerId !== event.pointerId) return
+
+    // Never moved past the threshold: this was a tap, and the grip's own click
+    // handler is the one that should act on it.
+    if (!session.started) {
+      this.teardown(session)
+      return
+    }
+
+    event.preventDefault()
+    const target = session.hover ? this.rows.get(session.hover) : undefined
+    const source = session.source
+    // Tear down before reordering: the callback re-renders the list, which
+    // detaches the very row, handle and ghost this session still points at.
+    this.teardown(session)
+    if (!target) return
+    this.options.onReorder(source.kind, source.index, target.index)
+  }
+
+  private teardown(session: DragSession | null): void {
+    if (!session) return
+    this.stopEdgeScroll(session)
+    this.clearHover(session)
+    session.ghost?.remove()
+    session.row.classList.remove(this.options.draggingClass)
+    restoreTooltipSources(session.handle, session.parkedTooltip)
+    try {
+      session.handle.releasePointerCapture(session.pointerId)
+    } catch {
+      // Already released with the pointer itself.
+    }
+    this.session = null
+  }
+
+  private findScroller(from: HTMLElement): HTMLElement | null {
+    let node: HTMLElement | null = from.parentElement
+    while (node) {
+      const overflowY = node.ownerDocument.defaultView?.getComputedStyle(node).overflowY
+      if ((overflowY === 'auto' || overflowY === 'scroll') && node.scrollHeight > node.clientHeight) {
+        return node
+      }
+      node = node.parentElement
+    }
+    return null
+  }
+}
+
+/** The six-dot grip shared by the recipe editor and the run popover. */
+export function appendRecipeDragHandleIcon(container: HTMLElement): void {
+  const svg = createSvg('svg')
+  svg.setAttribute('viewBox', '0 0 12 16')
+  svg.setAttribute('width', '12')
+  svg.setAttribute('height', '16')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.classList.add('recipe-step-drag-handle-icon')
+  ;[
+    ['2', '2'], ['8', '2'], ['2', '8'], ['8', '8'], ['2', '14'], ['8', '14'],
+  ].forEach(([cx, cy]) => {
+    const circle = createSvg('circle')
+    circle.setAttribute('cx', cx)
+    circle.setAttribute('cy', cy)
+    circle.setAttribute('r', '1.5')
+    svg.appendChild(circle)
+  })
+  container.appendChild(svg)
+}

--- a/src/features/recipe/ui/RecipeRunPopover.ts
+++ b/src/features/recipe/ui/RecipeRunPopover.ts
@@ -8,6 +8,7 @@ import {
   createRecipeProgressKeyForInstance,
 } from '../services/RecipeService'
 import { t } from '../../../i18n'
+import RecipeReorderPointerDrag, { appendRecipeDragHandleIcon } from './RecipeReorderPointerDrag'
 
 let recipeRunPopoverId = 0
 
@@ -24,17 +25,21 @@ export class RecipeRunPopover {
   private popover: HTMLElement | null = null
   private outsideHandler: ((event: MouseEvent | TouchEvent) => void) | null = null
   private outsideHandlerDocument: Document | null = null
-  private draggedItem: { kind: 'steps' | 'quality'; index: number } | null = null
   private showToken = 0
   private escapeKeyHandler: ((event: KeyboardEvent) => void) | null = null
   private escapeKeyDocument: Document | null = null
   private anchor: HTMLElement | null = null
   private popoverId: string | null = null
+  private pointerDrag: RecipeReorderPointerDrag | null = null
 
   constructor(private readonly host: RecipeRunPopoverHost) {}
 
   close(restoreAnchorFocus = false): void {
     this.showToken += 1
+    // Escape can land mid-drag. The ghost lives on `body`, so removing the
+    // popover alone would leave it behind with no pointer events coming.
+    this.pointerDrag?.cancel()
+    this.pointerDrag = null
     this.popover?.remove()
     this.popover = null
     if (this.outsideHandler) {
@@ -115,8 +120,22 @@ export class RecipeRunPopover {
     this.anchor = anchor
     this.popoverId = popoverId
 
+    // Rewritten on every render so a drop always reorders the rows the user can
+    // actually see, not the ones that were on screen when the popover opened.
+    const reorderByKind = new Map<string, (fromIndex: number, toIndex: number) => void>()
+    const pointerDrag = new RecipeReorderPointerDrag({
+      rowSelector: '.recipe-run-step',
+      draggingClass: 'recipe-run-step--dragging',
+      dropBeforeClass: 'recipe-run-step--drop-before',
+      dropAfterClass: 'recipe-run-step--drop-after',
+      ghostClass: 'recipe-reorder-drag-ghost',
+      onReorder: (kind, fromIndex, toIndex) => reorderByKind.get(kind)?.(fromIndex, toIndex),
+    })
+    this.pointerDrag = pointerDrag
+
     const renderBody = () => {
       popover.empty()
+      reorderByKind.clear()
       const header = popover.createDiv( { cls: 'recipe-run-header' })
       const titleRow = header.createDiv( { cls: 'recipe-run-title-row' })
       titleRow.createDiv( {
@@ -176,6 +195,34 @@ export class RecipeRunPopover {
           cls: kind === 'steps' ? 'recipe-run-steps' : 'recipe-run-quality-checks',
         })
         const displayItems = this.applyStepOrder(items, order)
+        const commitReorder = (fromIndex: number, toIndex: number): void => {
+          const nextOrder = this.reorderStepOrder(displayItems, fromIndex, toIndex)
+          const now = Date.now()
+          if (kind === 'steps') {
+            stepOrder = nextOrder
+            stepsUpdatedAt = now
+          } else {
+            qualityCheckOrder = nextOrder
+            qualityChecksUpdatedAt = now
+          }
+          this.saveProgress(
+            recipe,
+            progressKey,
+            dateKey,
+            checked,
+            stepOrder,
+            completedAtByStepId,
+            checkedQuality,
+            qualityCheckOrder,
+            completedAtByQualityCheckId,
+            stepsUpdatedAt,
+            qualityChecksUpdatedAt,
+            now,
+          )
+          this.host.onProgressChanged()
+          renderBody()
+        }
+        reorderByKind.set(kind, commitReorder)
         if (displayItems.length === 0) {
           list.createDiv({
             cls: 'recipe-empty-state',
@@ -189,147 +236,70 @@ export class RecipeRunPopover {
             cls: kind === 'steps' ? 'recipe-run-step' : 'recipe-run-step recipe-run-quality-check',
             attr: { 'data-step-index': String(index), 'data-recipe-list-kind': kind },
           })
-        row.addEventListener('dragover', (event) => {
-          if (!this.draggedItem || this.draggedItem.kind !== kind || this.draggedItem.index === index) return
-          event.preventDefault()
-          row.classList.add('recipe-run-step--drop-target')
-        })
-        row.addEventListener('dragleave', () => {
-          row.classList.remove('recipe-run-step--drop-target')
-        })
-        row.addEventListener('drop', (event) => {
-          event.preventDefault()
-          row.classList.remove('recipe-run-step--drop-target')
-          if (!this.draggedItem || this.draggedItem.kind !== kind) return
-          const fromIndex = this.draggedItem.index
-          this.draggedItem = null
-          const nextOrder = this.reorderStepOrder(displayItems, fromIndex, index)
-          const now = Date.now()
-          if (kind === 'steps') {
-            stepOrder = nextOrder
-            stepsUpdatedAt = now
-          } else {
-            qualityCheckOrder = nextOrder
-            qualityChecksUpdatedAt = now
-          }
-          this.saveProgress(
-            recipe,
-            progressKey,
-            dateKey,
-            checked,
-            stepOrder,
-            completedAtByStepId,
-            checkedQuality,
-            qualityCheckOrder,
-            completedAtByQualityCheckId,
-            stepsUpdatedAt,
-            qualityChecksUpdatedAt,
-            now,
-          )
-          this.host.onProgressChanged()
-          renderBody()
-        })
-        const handle = row.createEl('button', {
-          cls: 'recipe-step-drag-handle',
-          attr: {
-            type: 'button',
-            draggable: 'true',
-            title: t('recipes.run.reorderStep', 'ドラッグして並び替え'),
-            'aria-label': t('recipes.run.reorderStep', 'ドラッグして並び替え'),
-            'aria-keyshortcuts': 'Alt+ArrowUp Alt+ArrowDown',
-          },
-        })
-        this.appendDragHandleIcon(handle)
-        handle.addEventListener('click', (event) => {
-          event.preventDefault()
-          event.stopPropagation()
-        })
-        handle.addEventListener('keydown', (event) => {
-          if (!event.altKey || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return
-          event.preventDefault()
-          const targetIndex = event.key === 'ArrowUp' ? index - 1 : index + 1
-          if (targetIndex < 0 || targetIndex >= displayItems.length) return
-          const nextOrder = this.reorderStepOrder(displayItems, index, targetIndex)
-          const now = Date.now()
-          if (kind === 'steps') {
-            stepOrder = nextOrder
-            stepsUpdatedAt = now
-          } else {
-            qualityCheckOrder = nextOrder
-            qualityChecksUpdatedAt = now
-          }
-          this.saveProgress(
-            recipe,
-            progressKey,
-            dateKey,
-            checked,
-            stepOrder,
-            completedAtByStepId,
-            checkedQuality,
-            qualityCheckOrder,
-            completedAtByQualityCheckId,
-            stepsUpdatedAt,
-            qualityChecksUpdatedAt,
-            now,
-          )
-          this.host.onProgressChanged()
-          renderBody()
-          popover.querySelectorAll<HTMLButtonElement>(
-            `.recipe-run-section--${kind} .recipe-step-drag-handle`,
-          )[targetIndex]?.focus()
-        })
-        handle.addEventListener('dragstart', (event) => {
-          this.draggedItem = { kind, index }
-          row.classList.add('recipe-run-step--dragging')
-          event.dataTransfer?.setData('text/plain', String(index))
-          if (event.dataTransfer) {
-            event.dataTransfer.effectAllowed = 'move'
-          }
-        })
-        handle.addEventListener('dragend', () => {
-          this.draggedItem = null
-          row.classList.remove('recipe-run-step--dragging')
-          list.querySelectorAll('.recipe-run-step--drop-target')
-            .forEach((element) => element.classList.remove('recipe-run-step--drop-target'))
-        })
-        const label = row.createEl('label', { cls: 'recipe-run-step-check' })
-        const checkbox = label.createEl('input', { attr: { type: 'checkbox' } })
-        checkbox.checked = checkedIds.has(item.id)
-        label.createSpan({ cls: 'recipe-run-step-text', text: item.text })
-        checkbox.addEventListener('change', () => {
-          const now = Date.now()
-          if (kind === 'steps') {
-            stepsUpdatedAt = now
-          } else {
-            qualityChecksUpdatedAt = now
-          }
-          if (checkbox.checked) {
-            checkedIds.add(item.id)
-            if (!completedAt[item.id]) {
-              completedAt[item.id] = new Date(now).toISOString()
+          pointerDrag.registerRow(row, kind, index)
+          const handle = row.createEl('button', {
+            cls: 'recipe-step-drag-handle',
+            attr: {
+              type: 'button',
+              title: t('recipes.run.reorderStep', 'ドラッグして並び替え'),
+              'aria-label': t('recipes.run.reorderStep', 'ドラッグして並び替え'),
+              'aria-keyshortcuts': 'Alt+ArrowUp Alt+ArrowDown',
+            },
+          })
+          appendRecipeDragHandleIcon(handle)
+          pointerDrag.attachHandle(handle, row)
+          handle.addEventListener('click', (event) => {
+            event.preventDefault()
+            event.stopPropagation()
+          })
+          handle.addEventListener('keydown', (event) => {
+            if (!event.altKey || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return
+            event.preventDefault()
+            const targetIndex = event.key === 'ArrowUp' ? index - 1 : index + 1
+            if (targetIndex < 0 || targetIndex >= displayItems.length) return
+            commitReorder(index, targetIndex)
+            popover.querySelectorAll<HTMLButtonElement>(
+              `.recipe-run-section--${kind} .recipe-step-drag-handle`,
+            )[targetIndex]?.focus()
+          })
+          const label = row.createEl('label', { cls: 'recipe-run-step-check' })
+          const checkbox = label.createEl('input', { attr: { type: 'checkbox' } })
+          checkbox.checked = checkedIds.has(item.id)
+          label.createSpan({ cls: 'recipe-run-step-text', text: item.text })
+          checkbox.addEventListener('change', () => {
+            const now = Date.now()
+            if (kind === 'steps') {
+              stepsUpdatedAt = now
+            } else {
+              qualityChecksUpdatedAt = now
             }
-          } else {
-            checkedIds.delete(item.id)
-            delete completedAt[item.id]
-          }
-          this.saveProgress(
-            recipe,
-            progressKey,
-            dateKey,
-            checked,
-            stepOrder,
-            completedAtByStepId,
-            checkedQuality,
-            qualityCheckOrder,
-            completedAtByQualityCheckId,
-            stepsUpdatedAt,
-            qualityChecksUpdatedAt,
-            now,
-          )
-          this.host.onProgressChanged()
-          renderBody()
+            if (checkbox.checked) {
+              checkedIds.add(item.id)
+              if (!completedAt[item.id]) {
+                completedAt[item.id] = new Date(now).toISOString()
+              }
+            } else {
+              checkedIds.delete(item.id)
+              delete completedAt[item.id]
+            }
+            this.saveProgress(
+              recipe,
+              progressKey,
+              dateKey,
+              checked,
+              stepOrder,
+              completedAtByStepId,
+              checkedQuality,
+              qualityCheckOrder,
+              completedAtByQualityCheckId,
+              stepsUpdatedAt,
+              qualityChecksUpdatedAt,
+              now,
+            )
+            this.host.onProgressChanged()
+            renderBody()
+          })
         })
-      })
       }
 
       if (recipe.steps.length > 0) {
@@ -388,31 +358,6 @@ export class RecipeRunPopover {
     }
     this.escapeKeyDocument = ownerDocument
     ownerDocument.addEventListener('keydown', this.escapeKeyHandler)
-  }
-
-  private appendDragHandleIcon(container: HTMLElement): void {
-    const svg = createSvg('svg')
-    svg.setAttribute('viewBox', '0 0 12 16')
-    svg.setAttribute('width', '12')
-    svg.setAttribute('height', '16')
-    svg.setAttribute('aria-hidden', 'true')
-    svg.classList.add('recipe-step-drag-handle-icon')
-    const dots = [
-      { cx: '2', cy: '2' },
-      { cx: '8', cy: '2' },
-      { cx: '2', cy: '8' },
-      { cx: '8', cy: '8' },
-      { cx: '2', cy: '14' },
-      { cx: '8', cy: '14' },
-    ]
-    dots.forEach(({ cx, cy }) => {
-      const circle = createSvg('circle')
-      circle.setAttribute('cx', cx)
-      circle.setAttribute('cy', cy)
-      circle.setAttribute('r', '1.5')
-      svg.appendChild(circle)
-    })
-    container.appendChild(svg)
   }
 
   private appendEditIcon(container: HTMLElement): void {

--- a/src/ui/tooltipSources.ts
+++ b/src/ui/tooltipSources.ts
@@ -1,0 +1,54 @@
+/**
+ * Attributes that raise a tooltip over whatever the user is aiming at.
+ *
+ * `title` is the browser's own; `aria-label` is Obsidian's, which renders a
+ * `.tooltip` element of its own on hover. During a pointer drag the pointer
+ * stays on the element it grabbed for the whole gesture, so both tooltips
+ * linger over the very rows the user is trying to aim at.
+ *
+ * Neither can be moved out of the way with a stacking level: the browser's is
+ * drawn outside the page entirely, and Obsidian's sits on `--layer-tooltip`
+ * (~70) -- far below the 10000-band this plugin's popovers occupy, so inside a
+ * popover it renders *behind* the very thing it belongs to. Taking the
+ * attributes away for the duration of the drag is the only fix.
+ */
+const TOOLTIP_ATTRIBUTES = ['title', 'aria-label'] as const
+
+/** Matches anything `parkTooltipSources` would strip. */
+export const TOOLTIP_SOURCE_SELECTOR = '[title], [aria-label]'
+
+/**
+ * Strips the tooltip attributes off `element`, recording them in `parked` so
+ * `restoreTooltipSources` can put them back.
+ *
+ * Pass `null` for an element that is thrown away rather than restored -- a
+ * drag ghost, typically.
+ */
+export function parkTooltipSources(
+  element: HTMLElement,
+  parked: Map<string, string> | null,
+): void {
+  for (const attribute of TOOLTIP_ATTRIBUTES) {
+    const value = element.getAttribute(attribute)
+    if (value === null) continue
+    parked?.set(attribute, value)
+    element.removeAttribute(attribute)
+  }
+}
+
+/** Puts back everything `parkTooltipSources` recorded, and empties the map. */
+export function restoreTooltipSources(
+  element: HTMLElement,
+  parked: Map<string, string>,
+): void {
+  parked.forEach((value, attribute) => element.setAttribute(attribute, value))
+  parked.clear()
+}
+
+/** Strips the tooltip attributes off a subtree that will never be restored. */
+export function stripTooltipSources(root: HTMLElement): void {
+  parkTooltipSources(root, null)
+  root
+    .querySelectorAll<HTMLElement>(TOOLTIP_SOURCE_SELECTOR)
+    .forEach((node) => parkTooltipSources(node, null))
+}

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,33 @@
      `applyIcon()` / `createIconSpan()`. Individual call sites override it by
      redeclaring the property on the icon host. */
   --taskchute-icon-size: 18px;
+
+  /* Stacking order, low to high. Every z-index the plugin sets comes from this
+     list, so the layering can be read in one place rather than inferred from
+     bare numbers scattered across the sheet -- which is how a drag ghost ended
+     up sliding underneath the popover it was dragged out of. Values are the
+     ones already in use; the names say what each level is for.
+
+     Obsidian's own `--layer-*` variables are deliberately not used here: they
+     top out around 100, far below the 10000-band this sheet already occupies,
+     so borrowing them silently buries whatever they are applied to. */
+  --tc-z-behind: -1;
+  --tc-z-raised: 1;
+  --tc-z-sticky: 2;
+  --tc-z-nav-overlay: 999;
+  --tc-z-panel: 1000;
+  --tc-z-confirm-overlay: 1100;
+  --tc-z-suggestion: 1200;
+  --tc-z-menu: 1300;
+  --tc-z-menu-nested: 1350;
+  --tc-z-sheet-overlay: 9998;
+  --tc-z-sheet: 9999;
+  --tc-z-popover: 10000;
+  --tc-z-popover-nested: 10001;
+  --tc-z-popover-top: 10020;
+  /* Above every popover: a ghost follows the pointer across the whole window
+     and is parented to `body`, so it has to clear whatever it is dragged over. */
+  --tc-z-drag-ghost: 10030;
 }
 
 /* Obsidian publishes every one of its own variables -- `--size-*`, `--icon-*`,
@@ -92,7 +119,7 @@ body.is-phone {
 /* ===== Time Edit Popup ===== */
 .taskchute-time-popup {
   position: fixed;
-  z-index: 10000;
+  z-index: var(--tc-z-popover);
   left: var(--time-popup-left, 0);
   top: var(--time-popup-top, 0);
   background: var(--background-primary);
@@ -517,7 +544,7 @@ body.is-phone {
   box-shadow: var(--tc-shadow-popup);
   max-height: min(320px, 60vh);
   overflow-y: auto;
-  z-index: 1000;
+  z-index: var(--tc-z-panel);
 }
 
 .taskchute-autocomplete-suggestions .suggestion-item {
@@ -844,7 +871,7 @@ body.is-phone {
 
 .ai-working-directory-select__menu {
   position: absolute;
-  z-index: 1300;
+  z-index: var(--tc-z-menu);
   top: calc(100% + 4px);
   right: 0;
   left: 0;
@@ -1010,7 +1037,7 @@ body.is-phone {
 
 .ai-model-select__menu {
   position: absolute;
-  z-index: 1350;
+  z-index: var(--tc-z-menu-nested);
   top: calc(100% + 4px);
   right: 0;
   left: 0;
@@ -1367,7 +1394,7 @@ body.is-phone {
 /* 日付ピッカー */
 .taskchute-date-picker {
   position: absolute;
-  z-index: 10000;
+  z-index: var(--tc-z-popover);
 }
 
 /* 右クリックメニュー / 時間帯メニュー共通の枠 */
@@ -1378,7 +1405,7 @@ body.is-phone {
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--tc-radius-sm);
   padding: 4px 0;
-  z-index: 10000;
+  z-index: var(--tc-z-popover);
   box-shadow: var(--tc-shadow-popup);
   min-width: 150px;
 }
@@ -1617,7 +1644,7 @@ body.is-phone {
 /* カレンダー入力 */
 .taskchute-calendar-input {
   position: fixed;
-  z-index: 10000;
+  z-index: var(--tc-z-popover);
   left: var(--calendar-input-left, 0);
   top: var(--calendar-input-top, 0);
 }
@@ -1626,14 +1653,14 @@ body.is-phone {
   position: fixed;
   opacity: 0.01;
   pointer-events: auto;
-  z-index: 10001;
+  z-index: var(--tc-z-popover-nested);
   left: var(--inline-picker-left, 0);
   top: var(--inline-picker-top, 0);
 }
 
 .taskchute-move-calendar {
   position: fixed;
-  z-index: 10020;
+  z-index: var(--tc-z-popover-top);
   background-color: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--tc-radius-lg);
@@ -1857,7 +1884,7 @@ body.is-phone {
 /* ツールチップ */
 .taskchute-tooltip {
   position: fixed;
-  z-index: 10000;
+  z-index: var(--tc-z-popover);
   background-color: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--tc-radius-sm);
@@ -1885,7 +1912,7 @@ body.is-phone {
 /* インライン入力 */
 .taskchute-inline-input {
   position: absolute;
-  z-index: 1000;
+  z-index: var(--tc-z-panel);
   background-color: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--tc-radius-sm);
@@ -1933,7 +1960,7 @@ body.is-phone {
 /* Additional styles for guideline compliance */
 .taskchute-input-absolute {
   position: absolute;
-  z-index: 10000;
+  z-index: var(--tc-z-popover);
 }
 
 .taskchute-menu-option {
@@ -2759,7 +2786,7 @@ body.is-phone .taskchute-modal .modal-button-container {
 /* Heatmap Tooltip */
 .heatmap-tooltip {
   position: absolute;
-  z-index: 1000;
+  z-index: var(--tc-z-panel);
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--tc-radius-sm);
@@ -2942,7 +2969,7 @@ body.is-phone .taskchute-modal .modal-button-container {
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.3);
-  z-index: 999;
+  z-index: var(--tc-z-nav-overlay);
   transition: opacity 0.3s ease;
 }
 
@@ -2966,7 +2993,7 @@ body.is-phone .taskchute-modal .modal-button-container {
   background: var(--background-primary);
   border-right: 1px solid var(--background-modifier-border);
   box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
+  z-index: var(--tc-z-panel);
   transition: transform 0.3s ease;
   overflow-y: auto;
 }
@@ -3296,7 +3323,7 @@ body.is-phone .taskchute-modal .modal-button-container {
 .task-item-drag-ghost--floating {
   top: 0;
   left: 0;
-  z-index: var(--layer-modal);
+  z-index: var(--tc-z-drag-ghost);
   opacity: 0.85;
   border-radius: var(--tc-radius-sm);
   box-shadow: var(--shadow-l);
@@ -3336,7 +3363,7 @@ body.is-phone .taskchute-modal .modal-button-container {
   border-radius: var(--tc-radius-sm);
   font-size: 12px;
   white-space: nowrap;
-  z-index: 1000;
+  z-index: var(--tc-z-panel);
   pointer-events: none;
 }
 
@@ -3883,7 +3910,7 @@ body.is-phone .taskchute-modal .modal-button-container {
   padding: 4px 0 11px;
   min-width: 140px;
   font-size: 13px;
-  z-index: 1000;
+  z-index: var(--tc-z-panel);
 }
 
 .taskchute-settings-divider {
@@ -4622,7 +4649,7 @@ body.is-phone .taskchute-modal .modal-button-container {
   top: calc(100% + 4px);
   left: 0;
   right: 0;
-  z-index: 1000;
+  z-index: var(--tc-z-panel);
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--tc-radius-lg);
@@ -4845,7 +4872,7 @@ body.is-phone .taskchute-modal .modal-button-container {
 .routine-table__row--head > .routine-table__cell {
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: var(--tc-z-sticky);
   background: var(--background-primary);
   font-weight: 600;
   font-size: 0.88em;
@@ -5550,7 +5577,7 @@ body.is-phone .taskchute-modal .modal-button-container {
 
 .recipe-run-popover {
   position: fixed;
-  z-index: 10000;
+  z-index: var(--tc-z-popover);
   left: var(--taskchute-tooltip-left, 0);
   top: var(--taskchute-tooltip-top, 0);
   width: min(360px, calc(100vw - 20px));
@@ -5714,12 +5741,63 @@ body.is-phone .taskchute-modal .modal-button-container {
   padding: 2px 4px;
 }
 
-.recipe-run-step--drop-target {
-  background: var(--background-modifier-hover);
+/* A wash over the hovered row said "something lands here" without saying where.
+   The accent line sits on the edge the dragged row will actually come to rest
+   against: below the row when it is travelling down, above it when travelling
+   up.
+
+   The line is its own zero-height element rather than a border or an inset
+   shadow on the row: the row is rounded, and both of those bend the line
+   around the corner radius instead of ruling straight across. Absolute
+   positioning also keeps it out of the flow, so nothing shifts while the
+   indicator is being read. */
+.recipe-run-step--drop-before,
+.recipe-run-step--drop-after {
+  position: relative;
+}
+
+.recipe-run-step--drop-before::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 0;
+  border-top: 2px solid var(--interactive-accent);
+  pointer-events: none;
+}
+
+.recipe-run-step--drop-after::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 0;
+  border-top: 2px solid var(--interactive-accent);
+  pointer-events: none;
 }
 
 .recipe-run-step--dragging {
   opacity: 0.55;
+}
+
+/* The row that follows the pointer during a reorder. The native drag image is
+   gone with the HTML5 path, so this clone is the one the user actually sees;
+   `pointer-events: none` is what keeps `elementFromPoint` reporting the row
+   underneath rather than the ghost itself. */
+.recipe-reorder-drag-ghost {
+  position: fixed;
+  top: 0;
+  left: 0;
+  /* The ghost is parented to `body` so it can follow the pointer anywhere, so
+     it has to clear the run popover it is dragged inside. */
+  z-index: var(--tc-z-drag-ghost);
+  pointer-events: none;
+  opacity: 0.85;
+  border-radius: var(--tc-radius-sm);
+  background: var(--background-primary);
+  box-shadow: var(--shadow-l);
 }
 
 .recipe-run-step input[type="checkbox"] {
@@ -5740,6 +5818,14 @@ body.is-phone .taskchute-modal .modal-button-container {
 
 .recipe-list-drag-handle,
 .recipe-step-drag-handle {
+  /* The grip owns the gesture outright: anything short of `none` lets iOS
+     claim the vertical pan, and the checklist scrolls out from under the
+     finger before the drag can start (see RecipeReorderPointerDrag). The two
+     WebKit properties suppress the long-press callout and the text selection
+     that would otherwise fire mid-drag. */
+  touch-action: none;
+  -webkit-touch-callout: none;
+  user-select: none;
   width: 18px;
   height: 24px;
   padding: 0;
@@ -5997,7 +6083,7 @@ body.is-phone .taskchute-modal .modal-button-container {
 }
 
 .recipe-delete-confirm-overlay {
-  z-index: 1100;
+  z-index: var(--tc-z-confirm-overlay);
 }
 
 .recipe-delete-confirm-modal {
@@ -6526,7 +6612,7 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0);
-  z-index: 9998;
+  z-index: var(--tc-z-sheet-overlay);
   transition: background 0.3s ease;
 }
 
@@ -6543,7 +6629,7 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
   background: var(--background-primary);
   border-radius: 16px 16px 0;
   box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
-  z-index: 9999;
+  z-index: var(--tc-z-sheet);
   padding: 16px 16px 32px;
   transform: translateY(100%);
   transition: transform 0.3s ease;
@@ -6643,7 +6729,7 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
   background: var(--background-modifier-hover);
   border-radius: var(--tc-radius-lg);
   pointer-events: none;
-  z-index: -1;
+  z-index: var(--tc-z-behind);
 }
 
 /* Buttons container */
@@ -6814,7 +6900,7 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
 
 .obsidian-task-link-suggestions {
   position: absolute;
-  z-index: 1200;
+  z-index: var(--tc-z-suggestion);
   top: calc(100% + 4px);
   right: 0;
   left: 0;
@@ -7903,7 +7989,7 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
 }
 
 .ai-board-view-switch__segment.is-active {
-  z-index: 1;
+  z-index: var(--tc-z-raised);
   border-left-color: transparent;
   background: color-mix(
     in srgb,

--- a/tests/recipe/recipe-ui.test.ts
+++ b/tests/recipe/recipe-ui.test.ts
@@ -14,6 +14,33 @@ const setActiveDocument = (doc: Document): void => {
   ;(globalThis as typeof globalThis & { activeDocument: Document }).activeDocument = doc
 }
 
+function pointerEvent(type: string, clientX: number, clientY: number): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX,
+    clientY,
+    pointerId: 1,
+    isPrimary: true,
+  })
+}
+
+/**
+ * Reordering runs on Pointer Events, so rows carry no listeners: the drop
+ * target is whatever `elementFromPoint` reports, which the test has to declare.
+ * The move clears the 6px threshold that separates a drag from a tap.
+ */
+function dragHandleOntoRow(handle: HTMLElement, targetRow: HTMLElement): void {
+  const hitTest = jest.spyOn(document, 'elementFromPoint').mockReturnValue(targetRow)
+  try {
+    handle.dispatchEvent(pointerEvent('pointerdown', 0, 0))
+    handle.dispatchEvent(pointerEvent('pointermove', 0, 40))
+    handle.dispatchEvent(pointerEvent('pointerup', 0, 40))
+  } finally {
+    hitTest.mockRestore()
+  }
+}
+
 function ensureCreateEl(): void {
   const proto = HTMLElement.prototype as unknown as {
     createEl?: CreateEl
@@ -122,8 +149,7 @@ describe('recipe UI helpers', () => {
     inputs[0].dispatchEvent(new Event('input', { bubbles: true }))
     const handles = container.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle')
     const rows = container.querySelectorAll<HTMLElement>('.recipe-steps-list .recipe-step-row')
-    handles[0].dispatchEvent(new Event('dragstart', { bubbles: true }))
-    rows[1].dispatchEvent(new Event('drop', { bubbles: true }))
+    dragHandleOntoRow(handles[0], rows[1])
 
     expect(editor.getValue()).toEqual({
       title: '公開準備',
@@ -134,6 +160,156 @@ describe('recipe UI helpers', () => {
       ],
       qualityChecks: [{ id: 'quality-a', text: 'リンク確認' }],
       constraints: ['個人情報を含めない'],
+    })
+  })
+
+  describe('checklist reordering by pointer', () => {
+    function createEditor(): { container: HTMLElement; editor: RecipeEditorForm } {
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      const editor = new RecipeEditorForm(container, {
+        title: '公開準備',
+        steps: [
+          { id: 'step-a', text: '下書き' },
+          { id: 'step-b', text: '公開' },
+        ],
+        qualityChecks: [{ id: 'quality-a', text: 'リンク確認' }],
+      })
+      return { container, editor }
+    }
+
+    const stepTexts = (container: HTMLElement): string[] =>
+      Array.from(container.querySelectorAll<HTMLInputElement>('.recipe-step-input'))
+        .map((input) => input.value)
+        .filter((value) => value.length > 0)
+
+    test('the grips carry no draggable attribute -- iPadOS never fires dragstart', () => {
+      const { container } = createEditor()
+
+      const grips = container.querySelectorAll('.recipe-list-drag-handle')
+      expect(grips.length).toBeGreaterThan(0)
+      grips.forEach((grip) => {
+        expect(grip.getAttribute('draggable')).toBeNull()
+      })
+    })
+
+    test('a press that never clears the threshold leaves the order alone', () => {
+      const { container } = createEditor()
+      const handle = container.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle')[0]
+      const rows = container.querySelectorAll<HTMLElement>('.recipe-steps-list .recipe-step-row')
+      const hitTest = jest.spyOn(document, 'elementFromPoint').mockReturnValue(rows[1])
+
+      handle.dispatchEvent(pointerEvent('pointerdown', 0, 0))
+      handle.dispatchEvent(pointerEvent('pointermove', 0, 3))
+      handle.dispatchEvent(pointerEvent('pointerup', 0, 3))
+      hitTest.mockRestore()
+
+      expect(stepTexts(container)).toEqual(['下書き', '公開'])
+      expect(document.querySelector('.recipe-reorder-drag-ghost')).toBeNull()
+    })
+
+    test('pointercancel abandons the drag and removes the ghost', () => {
+      const { container } = createEditor()
+      const handle = container.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle')[0]
+      const rows = container.querySelectorAll<HTMLElement>('.recipe-steps-list .recipe-step-row')
+      const hitTest = jest.spyOn(document, 'elementFromPoint').mockReturnValue(rows[1])
+
+      handle.dispatchEvent(pointerEvent('pointerdown', 0, 0))
+      handle.dispatchEvent(pointerEvent('pointermove', 0, 40))
+      expect(document.querySelector('.recipe-reorder-drag-ghost')).not.toBeNull()
+
+      handle.dispatchEvent(pointerEvent('pointercancel', 0, 40))
+      hitTest.mockRestore()
+
+      expect(stepTexts(container)).toEqual(['下書き', '公開'])
+      expect(document.querySelector('.recipe-reorder-drag-ghost')).toBeNull()
+      expect(rows[0].classList.contains('recipe-run-step--dragging')).toBe(false)
+      expect(rows[1].classList.contains('recipe-run-step--drop-after')).toBe(false)
+    })
+
+    test('the accent line marks the edge the row will land against', () => {
+      const { container } = createEditor()
+      const handles = container.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle')
+      const rows = container.querySelectorAll<HTMLElement>('.recipe-steps-list .recipe-step-row')
+
+      // Dragging the first row down: it comes to rest below the row it is over.
+      const downwards = jest.spyOn(document, 'elementFromPoint').mockReturnValue(rows[1])
+      handles[0].dispatchEvent(pointerEvent('pointerdown', 0, 0))
+      handles[0].dispatchEvent(pointerEvent('pointermove', 0, 40))
+      expect(rows[1].classList.contains('recipe-run-step--drop-after')).toBe(true)
+      expect(rows[1].classList.contains('recipe-run-step--drop-before')).toBe(false)
+      handles[0].dispatchEvent(pointerEvent('pointercancel', 0, 40))
+      downwards.mockRestore()
+
+      // Dragging the second row up: it comes to rest above the row it is over.
+      const upwards = jest.spyOn(document, 'elementFromPoint').mockReturnValue(rows[0])
+      handles[1].dispatchEvent(pointerEvent('pointerdown', 0, 40))
+      handles[1].dispatchEvent(pointerEvent('pointermove', 0, 0))
+      expect(rows[0].classList.contains('recipe-run-step--drop-before')).toBe(true)
+      expect(rows[0].classList.contains('recipe-run-step--drop-after')).toBe(false)
+      handles[1].dispatchEvent(pointerEvent('pointercancel', 0, 0))
+      upwards.mockRestore()
+
+      expect(container.querySelector('.recipe-run-step--drop-before')).toBeNull()
+      expect(container.querySelector('.recipe-run-step--drop-after')).toBeNull()
+    })
+
+    test('the grip drops both tooltip sources while dragging', () => {
+      const { container } = createEditor()
+      const handle = container.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle')[0]
+      const label = handle.getAttribute('title')
+      expect(label).toBeTruthy()
+      expect(handle.getAttribute('aria-label')).toBe(label)
+
+      handle.dispatchEvent(pointerEvent('pointerdown', 0, 0))
+      handle.dispatchEvent(pointerEvent('pointermove', 0, 40))
+
+      // The pointer stays on the grip for the whole drag, so both the browser's
+      // `title` tooltip and Obsidian's `aria-label` one would hang over the rows
+      // being aimed at. Neither can be stacked out of the way: the browser draws
+      // its own outside the page, and Obsidian's sits far below the popover.
+      expect(handle.getAttribute('title')).toBeNull()
+      expect(handle.getAttribute('aria-label')).toBeNull()
+      // The clone brings the row's other tooltip sources along too -- the remove
+      // button's included -- and decoration should never raise one.
+      expect(
+        document
+          .querySelector('.recipe-reorder-drag-ghost')
+          ?.querySelector('[title], [aria-label]'),
+      ).toBeNull()
+
+      handle.dispatchEvent(pointerEvent('pointercancel', 0, 40))
+
+      expect(handle.getAttribute('title')).toBe(label)
+      expect(handle.getAttribute('aria-label')).toBe(label)
+    })
+
+    test('tearing down the form mid-drag takes the ghost with it', () => {
+      const { container, editor } = createEditor()
+      const handle = container.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle')[0]
+
+      handle.dispatchEvent(pointerEvent('pointerdown', 0, 0))
+      handle.dispatchEvent(pointerEvent('pointermove', 0, 40))
+      expect(document.querySelector('.recipe-reorder-drag-ghost')).not.toBeNull()
+
+      // Escape closes the dialog: the row and its grip go away, so no further
+      // pointer event will ever arrive to clean up after the drag.
+      editor.destroy()
+      container.remove()
+
+      expect(document.querySelector('.recipe-reorder-drag-ghost')).toBeNull()
+    })
+
+    test('a step will not drop onto a quality check row', () => {
+      const { container } = createEditor()
+      const handle = container.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle')[0]
+      const qualityRow = container.querySelector<HTMLElement>(
+        '.recipe-quality-checks-list .recipe-step-row',
+      )
+
+      dragHandleOntoRow(handle, qualityRow as HTMLElement)
+
+      expect(stepTexts(container)).toEqual(['下書き', '公開'])
     })
   })
 
@@ -573,8 +749,7 @@ describe('recipe UI helpers', () => {
 
     const handles = Array.from(document.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle'))
     const rows = Array.from(document.querySelectorAll<HTMLElement>('.recipe-step-row'))
-    handles[0]?.dispatchEvent(new Event('dragstart', { bubbles: true }))
-    rows[1]?.dispatchEvent(new Event('drop', { bubbles: true }))
+    dragHandleOntoRow(handles[0], rows[1])
     expect(Array.from(document.querySelectorAll<HTMLInputElement>('.recipe-step-input')).map((input) => input.value)).toEqual([
       '散歩する',
       '筋トレをする',
@@ -638,6 +813,47 @@ describe('recipe UI helpers', () => {
     expect(container.querySelector('.recipe-task-badge')).toBeNull()
   })
 
+  test('closing the run popover mid-drag takes the ghost with it', async () => {
+    const anchor = document.createElement('button')
+    document.body.appendChild(anchor)
+    const popover = new RecipeRunPopover({
+      service: {
+        loadRecipe: jest.fn(async () => ({
+          path: 'TaskChute/Recipes/A.md',
+          title: 'aaa',
+          file: {},
+          steps: [
+            { id: 'step-1-a', text: 'a' },
+            { id: 'step-2-b', text: 'b' },
+          ],
+        })),
+        saveRecipe: jest.fn(),
+      } as never,
+      getDateKey: () => '2026-05-04',
+      getProgress: () => undefined,
+      setProgress: jest.fn(),
+      openRecipeEditor: jest.fn(),
+      onProgressChanged: jest.fn(),
+    })
+
+    await popover.show({
+      instanceId: 'TaskChute/Task/A.md_2026-05-04_111_aaa',
+      task: { path: 'TaskChute/Task/A.md', recipePath: 'TaskChute/Recipes/A.md' },
+    } as never, anchor)
+
+    const handle = document.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle')[0]
+    handle.dispatchEvent(pointerEvent('pointerdown', 0, 0))
+    handle.dispatchEvent(pointerEvent('pointermove', 0, 40))
+    expect(document.querySelector('.recipe-reorder-drag-ghost')).not.toBeNull()
+
+    // Escape takes the popover -- and the grip -- away, so no pointerup or
+    // pointercancel will ever arrive to end the drag.
+    popover.close()
+
+    expect(document.querySelector('.recipe-reorder-drag-ghost')).toBeNull()
+    anchor.remove()
+  })
+
   test('run popover stores drag ordering only in daily progress state without saving recipe source', async () => {
     const anchor = document.createElement('button')
     document.body.appendChild(anchor)
@@ -683,8 +899,7 @@ describe('recipe UI helpers', () => {
 
     const handles = Array.from(document.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle'))
     const rows = Array.from(document.querySelectorAll<HTMLElement>('.recipe-run-step'))
-    handles[0]?.dispatchEvent(new Event('dragstart', { bubbles: true }))
-    rows[1]?.dispatchEvent(new Event('drop', { bubbles: true }))
+    dragHandleOntoRow(handles[0], rows[1])
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(saveRecipe).not.toHaveBeenCalled()
@@ -1157,8 +1372,7 @@ describe('recipe UI helpers', () => {
     expect(document.querySelector('.recipe-edit-form .recipe-danger-button')).toBeNull()
     const handles = Array.from(document.querySelectorAll<HTMLButtonElement>('.recipe-step-drag-handle'))
     const rows = Array.from(document.querySelectorAll<HTMLElement>('.recipe-step-row'))
-    handles[0]?.dispatchEvent(new Event('dragstart', { bubbles: true }))
-    rows[1]?.dispatchEvent(new Event('drop', { bubbles: true }))
+    dragHandleOntoRow(handles[0], rows[1])
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     document.querySelector<HTMLFormElement>('.recipe-edit-form')?.dispatchEvent(

--- a/tests/styles/style-regressions.test.ts
+++ b/tests/styles/style-regressions.test.ts
@@ -69,6 +69,14 @@ const lastPaintingRuleIndex = (css: string, selectorStart: string): number => {
   return found
 }
 
+/** Resolves one of the `--tc-z-*` stacking tokens back to its number. */
+const layerToken = (css: string, token: string): number => {
+  const match = new RegExp(`^\\s*${token}:\\s*(-?\\d+);`, 'm').exec(css)
+  expect(match).not.toBeNull()
+
+  return Number((match as RegExpExecArray)[1])
+}
+
 describe('style regressions', () => {
   test('AI runs participates in vertical layout so the task list remains scrollable', () => {
     const css = styles()
@@ -531,6 +539,49 @@ describe('style regressions', () => {
 
     const touchActionRule = readRule(styles(), '.taskchute-container button,')
     expect(touchActionRule).not.toContain('drag-handle')
+  })
+
+  test('the recipe grips claim the whole gesture too', () => {
+    // The recipe checklists reorder on Pointer Events for the same reason the
+    // task list does, so their grips need the same gesture ownership.
+    const gripRule = readRule(styles(), '.recipe-list-drag-handle,')
+
+    expect(gripRule).toMatch(/touch-action:\s*none;/)
+    expect(gripRule).toMatch(/user-select:\s*none;/)
+    expect(gripRule).toMatch(/-webkit-touch-callout:\s*none;/)
+  })
+
+  test('the recipe drop indicator is an accent line on the landing edge', () => {
+    // A background wash said "something lands here" without saying where.
+    // The rows are rounded, so a border or an inset shadow on the row itself
+    // bends the line around the corner radius. The indicator is its own
+    // zero-height element instead.
+    const css = styles()
+    const before = readRule(css, '.recipe-run-step--drop-before::after {')
+    const after = readRule(css, '.recipe-run-step--drop-after::after {')
+
+    for (const line of [before, after]) {
+      expect(line).toMatch(/position:\s*absolute;/)
+      expect(line).toMatch(/height:\s*0;/)
+      expect(line).toMatch(/border-top:\s*2px solid var\(--interactive-accent\);/)
+    }
+    expect(before).toMatch(/top:\s*0;/)
+    expect(after).toMatch(/bottom:\s*0;/)
+  })
+
+  test('the recipe reorder ghost stays out of its own hit test', () => {
+    // `elementFromPoint` has to report the row underneath, not the clone that
+    // is following the pointer.
+    const ghostRule = readRule(styles(), '.recipe-reorder-drag-ghost {')
+
+    expect(ghostRule).toMatch(/position:\s*fixed;/)
+    expect(ghostRule).toMatch(/pointer-events:\s*none;/)
+    // The run popover sits on --tc-z-popover; anything lower hides the ghost
+    // behind the list it was dragged out of.
+    expect(ghostRule).toMatch(/z-index:\s*var\(--tc-z-drag-ghost\);/)
+    expect(layerToken(styles(), '--tc-z-drag-ghost')).toBeGreaterThan(
+      layerToken(styles(), '--tc-z-popover'),
+    )
   })
 
   test('mobile touch-action covers non-button tap targets', () => {

--- a/tests/ui/header/task-header-layout.test.ts
+++ b/tests/ui/header/task-header-layout.test.ts
@@ -151,7 +151,7 @@ describe('TaskChute header layout', () => {
     expect(lastSegment).toMatch(/border-radius:\s*0\s+6px\s+6px\s+0;/)
     expect(active).toMatch(/background:\s*color-mix\(/)
     expect(active).toMatch(/box-shadow:\s*none;/)
-    expect(active).toMatch(/z-index:\s*1;/)
+    expect(active).toMatch(/z-index:\s*var\(--tc-z-raised\);/)
     expect(activeFrame).toMatch(
       /border:\s*1px\s+solid\s+var\(--ai-board-view-active-border\);/,
     )


### PR DESCRIPTION
## Why

iPadOS and iOS never fire `dragstart` for in-page content, so the drag grips in the recipe run popover and the recipe editor were inert on a tablet. `Alt+ArrowUp` / `Alt+ArrowDown` was the only path that ever moved a row there, which is not usable without a keyboard.

The task list already moved to Pointer Events for exactly this reason (8cf8e46). The recipe checklists now follow, so a mouse, a pen and a finger all drive one implementation.

The project board and the AI workspace file tree still use the HTML5 API and have the same problem. They are deliberately left for a separate PR.

## What changed

**Reordering runs on Pointer Events.** `RecipeReorderPointerDrag` holds the gesture: a 6px threshold to separate a drag from a tap, pointer capture, a ghost that follows the pointer, edge auto-scroll, and `elementFromPoint` hit-testing so rows need no listeners of their own. `RecipeRunPopover` and `RecipeEditorForm` had near-identical copies of the old handlers; both now share this one module, along with the six-dot grip icon they each used to build separately. The `Alt+Arrow` keyboard path is unchanged.

**The drop indicator says where the row lands.** A wash over the hovered row said "something lands here" without saying where. It is now an accent line on the edge the row will actually come to rest against — below when travelling down, above when travelling up. The line is its own zero-height element rather than a border or an inset shadow, because the rows are rounded and both of those bend the line around the corner radius instead of ruling straight across.

**z-index is now managed by tokens.** Every z-index in the plugin's own CSS comes from a `--tc-z-*` scale on `:root`; no bare numbers remain. This started as a bug: the ghost is parented to `body` and was sitting on Obsidian's `--layer-modal` (~100), far below the 10000-band this sheet already occupies, so it slid underneath the popover it had been dragged out of. Values are the ones already in use, so this is a rename rather than a re-layering.

**The ghost no longer outlives its host.** A pointer drag normally ends with `pointerup` or `pointercancel`, but Escape can close the popover or the dialog first — the row and its grip vanish and no further pointer event is ever delivered, leaving the ghost stranded on screen. `cancel()` / `destroy()` are called from the popover's `close()` and from the modals' `onClose()` and `render()`.

**Tooltips are parked during a drag.** The pointer stays on the grip for the whole gesture, so both the browser's `title` tooltip and Obsidian's `aria-label` one hang over the very rows being aimed at. Neither can be moved with a stacking level: the browser draws its own outside the page, and Obsidian's sits on `--layer-tooltip` (~70), so inside a popover it renders behind it. Both attributes are removed for the duration of the drag and restored afterwards.

## Known issue, not addressed here

Outside of dragging, hovering an `aria-label` element inside one of the plugin's popovers still renders Obsidian's tooltip behind the popover, because the 10000-band sits above Obsidian's entire layer scale. Fixing that means re-basing `--tc-z-*` onto Obsidian's `--layer-*`, which reaches well beyond this change.

## Testing

`npx tsc --noEmit`, `npm run lint` and `npx jest` (228 suites, 3309 tests) all pass.

The recipe DnD tests were dispatching bare `new Event('dragstart')` / `new Event('drop')` — not even `DragEvent`, with no `dataTransfer`. They passed only because the old implementation kept its state in an instance variable, so the drag path was effectively unverified. They now drive the pointer path, with new cases for: no `draggable` attribute, a press under the threshold staying a tap, `pointercancel` leaving the order alone, which edge the accent line appears on, a step refusing to drop on a quality-check row, teardown mid-drag taking the ghost with it, and the tooltip attributes being parked and restored.

Still needs checking on a device: reordering by finger on an iPad, and that the checklist still scrolls normally.
