### PR TITLE
Translate the UI strings that bypassed the dictionary

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -7,6 +7,7 @@ import { createCommandRegistrar } from "../commands/registerTaskCommands"
 import type { CommandRegistrar } from "../types/Commands"
 import { RibbonManager } from "./ribbon/RibbonManager"
 import { LocaleCoordinator } from "./locale/LocaleCoordinator"
+import { initializeLocaleManager } from "../i18n"
 import { ensureRequiredFolders, initializeServices } from "./serviceFactory"
 import { DEFAULT_SETTINGS } from "../settings"
 import type { TaskChuteSettings } from "../types"
@@ -160,6 +161,13 @@ export async function bootstrapPlugin(
   } catch (error) {
     plugin._log?.("warn", "[TaskChute] Failed to initialize license manager:", error)
   }
+
+  // Also before the settings tab, and for the same reason: that first read
+  // resolves every label through t(), so the locale has to be settled or the
+  // whole pane is captured in English no matter what Obsidian's language is.
+  // LocaleCoordinator re-runs this below once the listeners it notifies exist;
+  // repeating it with the same override is a no-op.
+  initializeLocaleManager(plugin.settings.languageOverride ?? "auto")
 
   try {
     plugin.addSettingTab(new TaskChuteSettingTab(plugin.app, plugin))

--- a/src/features/ai-task/services/ElectronDirectoryPicker.ts
+++ b/src/features/ai-task/services/ElectronDirectoryPicker.ts
@@ -55,7 +55,7 @@ export class ElectronDirectoryPicker {
   async selectDirectory(defaultPath?: string): Promise<string | null> {
     return this.open(
       ['openDirectory', 'createDirectory'],
-      t('taskChuteView.aiTask.picker.selectDirectory', 'ワーキングディレクトリを選択'),
+      t('taskChuteView.aiTask.picker.selectDirectory', 'Select working directory'),
       defaultPath,
     )
   }
@@ -66,7 +66,7 @@ export class ElectronDirectoryPicker {
   }): Promise<string | null> {
     return this.open(
       ['openFile'],
-      options?.title ?? t('taskChuteView.aiTask.picker.selectFile', 'ファイルを選択'),
+      options?.title ?? t('taskChuteView.aiTask.picker.selectFile', 'Select file'),
       options?.defaultPath,
     )
   }

--- a/src/features/calendar/services/GoogleCalendarService.ts
+++ b/src/features/calendar/services/GoogleCalendarService.ts
@@ -52,12 +52,12 @@ export class GoogleCalendarService {
       options.overrideDateKey,
     )
     if (!dateKey) {
-      throw new Error(t("taskChuteView.calendar.export.errors.dateUnavailable", "日付を特定できませんでした"))
+      throw new Error(t("taskChuteView.calendar.export.errors.dateUnavailable", "Could not determine the date"))
     }
 
     const startTime = this.resolveStartTime(inst, options.overrideStartTime)
     if (!startTime) {
-      throw new Error(t("taskChuteView.calendar.export.errors.startTimeUnavailable", "開始時刻を決められませんでした"))
+      throw new Error(t("taskChuteView.calendar.export.errors.startTimeUnavailable", "Could not determine the start time"))
     }
 
     const recurrence = this.buildRecurrenceRule(inst)
@@ -162,7 +162,7 @@ export class GoogleCalendarService {
       if (!isTimeString(overrideStartTime)) {
         throw new Error(t(
           "taskChuteView.calendar.export.errors.startTimeFormat",
-          "開始時刻はHH:mm形式で入力してください",
+          "Enter the start time in 24-hour hh:mm format",
         ))
       }
       return overrideStartTime
@@ -204,7 +204,7 @@ export class GoogleCalendarService {
       if (!Number.isFinite(overrideDurationMinutes) || overrideDurationMinutes <= 0) {
         throw new Error(t(
           "taskChuteView.calendar.export.errors.durationInvalid",
-          "所要時間は1分以上の数値を入力してください",
+          "Enter a duration of at least 1 minute",
         ))
       }
       return Math.round(overrideDurationMinutes)

--- a/src/features/calendar/ui/CalendarExportModal.ts
+++ b/src/features/calendar/ui/CalendarExportModal.ts
@@ -51,7 +51,7 @@ export class CalendarExportModal extends Modal {
 
     // 標準タイトルをそのまま利用
     this.titleEl.setText(
-      this.opts.tv("calendar.export.title", "Googleカレンダーに登録"),
+      this.opts.tv("calendar.export.title", "Register to Google Calendar"),
     )
 
     this.noteBody = await this.loadNoteBody()
@@ -59,11 +59,11 @@ export class CalendarExportModal extends Modal {
     const displayTitle = this.opts.getDisplayTitle(this.opts.instance)
 
     new Setting(contentEl)
-      .setName(this.opts.tv("calendar.export.task", "タスク"))
+      .setName(this.opts.tv("calendar.export.task", "Task"))
       .setDesc(displayTitle)
 
     const dateSetting = new Setting(contentEl)
-      .setName(this.opts.tv("calendar.export.date", "日付"))
+      .setName(this.opts.tv("calendar.export.date", "Date"))
 
     if (this.opts.isRoutine) {
       this.dateEl = dateSetting.descEl
@@ -84,13 +84,13 @@ export class CalendarExportModal extends Modal {
 
     if (this.opts.isRoutine) {
       const recurrenceSetting = new Setting(contentEl)
-        .setName(this.opts.tv("calendar.export.recurrence", "繰り返し"))
-        .setDesc(this.opts.tv("calendar.export.recurrenceNone", "単発イベントとして登録します"))
+        .setName(this.opts.tv("calendar.export.recurrence", "Recurrence"))
+        .setDesc(this.opts.tv("calendar.export.recurrenceNone", "Register as a one-time event"))
       this.recurrenceEl = recurrenceSetting.descEl
     }
 
     new Setting(contentEl)
-      .setName(this.opts.tv("calendar.export.startTime", "開始時刻"))
+      .setName(this.opts.tv("calendar.export.startTime", "Start time"))
       .addText((text) => {
         text.setPlaceholder("09:00")
         text.onChange(() => {
@@ -100,7 +100,7 @@ export class CalendarExportModal extends Modal {
       })
 
     new Setting(contentEl)
-      .setName(this.opts.tv("calendar.export.duration", "所要時間（分）"))
+      .setName(this.opts.tv("calendar.export.duration", "Duration (minutes)"))
       .addText((text) => {
         text.inputEl.type = "number"
         text.inputEl.min = "1"
@@ -112,13 +112,13 @@ export class CalendarExportModal extends Modal {
       })
 
     new Setting(contentEl)
-      .setName(this.opts.tv("calendar.export.details", "説明プレビュー"))
+      .setName(this.opts.tv("calendar.export.details", "Description preview"))
       .addTextArea((area) => {
         area.inputEl.rows = 6
         area.setPlaceholder(
           this.opts.tv(
             "calendar.export.detailsPlaceholder",
-            "Obsidianのパスや本文がここに表示されます"
+            "Obsidian path and note body will appear here"
           ),
         )
         area.setDisabled(true)
@@ -129,12 +129,12 @@ export class CalendarExportModal extends Modal {
 
     createModalFooter(contentEl, [
       {
-        text: this.opts.tv("common.cancel", "キャンセル"),
+        text: this.opts.tv("common.cancel", "Cancel"),
         role: "cancel",
         onClick: () => this.close(),
       },
       {
-        text: this.opts.tv("calendar.export.open", "カレンダーを開く"),
+        text: this.opts.tv("calendar.export.open", "Open calendar"),
         role: "primary",
         onClick: () => {
           void this.handleOpen()
@@ -240,7 +240,7 @@ export class CalendarExportModal extends Modal {
       new Notice(
         this.opts.tv(
           "calendar.export.cannotOpen",
-          "プレビューを作成できません。開始時刻と所要時間を確認してください。"
+          "Cannot create preview. Check start time and duration."
         ),
       )
       return
@@ -271,7 +271,7 @@ export class CalendarExportModal extends Modal {
     new Notice(
       this.opts.tv(
         "calendar.export.opened",
-        "ブラウザでGoogleカレンダーを開きました"
+        "Opened Google Calendar in your browser"
       ),
     )
   }
@@ -287,13 +287,13 @@ export class CalendarExportModal extends Modal {
     if (!preview.recurrenceRule) {
       return this.opts.tv(
         "calendar.export.recurrenceNone",
-        "単発イベントとして登録します"
+        "Register as a one-time event"
       )
     }
 
     const rule = preview.recurrenceRule
     if (rule.startsWith("FREQ=DAILY")) {
-      return this.opts.tv("calendar.export.recurrenceDaily", "毎日繰り返します")
+      return this.opts.tv("calendar.export.recurrenceDaily", "Repeats daily")
     }
     if (rule.startsWith("FREQ=WEEKLY")) {
       const match = rule.match(/BYDAY=([^;]+)/)
@@ -301,25 +301,25 @@ export class CalendarExportModal extends Modal {
       const labels = days.map((d) => this.dayCodeToLabel(d)).join(", ")
       return this.opts.tv(
         "calendar.export.recurrenceWeekly",
-        "毎週: {days}",
+        "Repeats weekly: {days}",
         { days: labels || "不明" },
       )
     }
     if (rule.startsWith("FREQ=MONTHLY")) {
-      return this.opts.tv("calendar.export.recurrenceMonthly", "毎月のルーチンとして登録します")
+      return this.opts.tv("calendar.export.recurrenceMonthly", "Registers as a monthly routine")
     }
-    return this.opts.tv("calendar.export.recurrenceOther", "繰り返しイベントとして登録します")
+    return this.opts.tv("calendar.export.recurrenceOther", "Registers as a recurring event")
   }
 
   private dayCodeToLabel(code: string): string {
     const map: Record<string, string> = {
-      SU: this.opts.tv("labels.weekdays.sundayShort", "日"),
-      MO: this.opts.tv("labels.weekdays.mondayShort", "月"),
-      TU: this.opts.tv("labels.weekdays.tuesdayShort", "火"),
-      WE: this.opts.tv("labels.weekdays.wednesdayShort", "水"),
-      TH: this.opts.tv("labels.weekdays.thursdayShort", "木"),
-      FR: this.opts.tv("labels.weekdays.fridayShort", "金"),
-      SA: this.opts.tv("labels.weekdays.saturdayShort", "土"),
+      SU: this.opts.tv("labels.weekdays.sundayShort", "Sun"),
+      MO: this.opts.tv("labels.weekdays.mondayShort", "Mon"),
+      TU: this.opts.tv("labels.weekdays.tuesdayShort", "Tue"),
+      WE: this.opts.tv("labels.weekdays.wednesdayShort", "Wed"),
+      TH: this.opts.tv("labels.weekdays.thursdayShort", "Thu"),
+      FR: this.opts.tv("labels.weekdays.fridayShort", "Fri"),
+      SA: this.opts.tv("labels.weekdays.saturdayShort", "Sat"),
     }
     return map[code] ?? code
   }

--- a/src/features/core/services/TaskLoaderService.ts
+++ b/src/features/core/services/TaskLoaderService.ts
@@ -314,7 +314,7 @@ export async function loadTasksForContext(context: TaskLoaderHost): Promise<void
     context.renderTaskList()
   } catch (error) {
     console.error('Failed to load tasks', error)
-    new Notice(t('taskChuteView.notices.taskLoadFailed', 'タスクの読み込みに失敗しました'))
+    new Notice(t('taskChuteView.notices.taskLoadFailed', 'Failed to load tasks'))
   }
 }
 

--- a/src/features/core/views/TaskChuteView.ts
+++ b/src/features/core/views/TaskChuteView.ts
@@ -3520,7 +3520,7 @@ export class TaskChuteView
       } else {
         const file = inst.task.file
         if (!file) {
-          new Notice(this.tv('errors.taskFileNotFound', 'Task file not found'))
+          new Notice(this.tv('notices.taskFileMissing', 'Task file not found'))
           return
         }
 

--- a/src/features/core/views/TaskChuteView.ts
+++ b/src/features/core/views/TaskChuteView.ts
@@ -2569,7 +2569,7 @@ export class TaskChuteView
       new Notice(
         this.tv(
           "calendar.export.disabled",
-          "Googleカレンダー連携は設定で有効化してください",
+          "Enable Google Calendar integration in settings",
         ),
       )
       return
@@ -2592,13 +2592,13 @@ export class TaskChuteView
       )
       const url = this.googleCalendarService.buildEventUrl(event)
       this.googleCalendarService.open(url)
-      new Notice(this.tv("calendar.export.opened", "ブラウザでGoogleカレンダーを開きました"))
+      new Notice(this.tv("calendar.export.opened", "Opened Google Calendar in your browser"))
     } catch (error) {
       console.error("[TaskChuteView] Failed to open calendar export for created task", error)
       new Notice(
         this.tv(
           "calendar.export.cannotOpen",
-          "プレビューを作成できません。開始時刻と所要時間を確認してください。",
+          "Cannot create preview. Check start time and duration.",
         ),
       )
     }
@@ -4039,7 +4039,7 @@ export class TaskChuteView
       new Notice(
         this.tv(
           "calendar.export.disabled",
-          "Googleカレンダー連携は設定で有効化してください",
+          "Enable Google Calendar integration in settings",
         ),
       )
       return

--- a/src/features/log/services/BackupRestoreService.ts
+++ b/src/features/log/services/BackupRestoreService.ts
@@ -477,7 +477,7 @@ export class BackupRestoreService {
 
     // Build executions list with time info
     const executions: TaskExecutionPreview[] = sortedEntries.map((entry) => ({
-      taskName: entry.taskTitle ?? entry.taskName ?? t('logView.restore.unknownTaskName', '(不明)'),
+      taskName: entry.taskTitle ?? entry.taskName ?? t('logView.restore.unknownTaskName', '(Unknown)'),
       startTime: entry.startTime ?? '-',
       endTime: entry.stopTime ?? '-',
     }))

--- a/src/features/log/views/LogView.ts
+++ b/src/features/log/views/LogView.ts
@@ -124,7 +124,7 @@ export class LogView {
 
     const loading = this.container.createDiv( {
       cls: 'heatmap-loading',
-      text: this.tv('header.loading', 'データを読み込み中...'),
+      text: this.tv('header.loading', 'Loading data...'),
     })
 
     try {
@@ -140,7 +140,7 @@ export class LogView {
       console.error('Failed to render heatmap', error)
       loading.remove()
       new Notice(
-        this.tv('notices.loadFailure', `${this.currentYear}年のデータ読み込みに失敗しました`, {
+        this.tv('notices.loadFailure', "Failed to load data for {year}", {
           year: this.currentYear,
         }),
       )
@@ -151,7 +151,7 @@ export class LogView {
   private createHeader(): void {
     const header = this.container.createDiv( { cls: 'taskchute-log-header' })
     header.createEl('h2', {
-      text: this.tv('header.title', 'タスク実行ログ'),
+      text: this.tv('header.title', 'Task execution log'),
       cls: 'log-title',
     });
 
@@ -162,7 +162,7 @@ export class LogView {
     for (let year = currentYear + 1; year >= 2020; year -= 1) {
       const option = yearSelector.createEl('option', {
         value: String(year),
-        text: this.tv('labels.yearOption', `${year}年`, { year }),
+        text: this.tv('labels.yearOption', "{year}", { year }),
       })
       if (year === this.currentYear) {
         option.selected = true
@@ -171,9 +171,9 @@ export class LogView {
 
     const restoreButton = controls.createEl('button', {
       cls: 'restore-button',
-      text: this.tv('header.restoreButton', '🔄 データを復元'),
+      text: this.tv('header.restoreButton', '🔄 Restore data'),
       attr: {
-        title: this.tv('header.restoreTooltip', 'バックアップからログデータを復元'),
+        title: this.tv('header.restoreTooltip', 'Restore log data from backup'),
       },
     })
 
@@ -186,7 +186,7 @@ export class LogView {
         const target = event.currentTarget as HTMLSelectElement
         this.currentYear = Number.parseInt(target.value, 10)
         await this.reloadCurrentYear(
-          this.tv('header.loading', 'データを読み込み中...'),
+          this.tv('header.loading', 'Loading data...'),
           false,
         )
       })()
@@ -228,7 +228,7 @@ export class LogView {
       this.renderHeatmap()
       if (showSuccessNotice) {
         new Notice(
-          this.tv('notices.reloadSuccess', `${this.currentYear}年のデータを更新しました`, {
+          this.tv('notices.reloadSuccess', "Updated data for {year}", {
             year: this.currentYear,
           }),
         )
@@ -237,7 +237,7 @@ export class LogView {
       console.error('Failed to reload heatmap', error)
       loading.remove()
       new Notice(
-        this.tv('notices.reloadFailure', `${this.currentYear}年のデータ読み込みに失敗しました`, {
+        this.tv('notices.reloadFailure', "Failed to load data for {year}", {
           year: this.currentYear,
         }),
       )
@@ -306,7 +306,7 @@ export class LogView {
     const gridSection = layout.createDiv( { cls: 'heatmap-grid-section' });
     gridSection.createDiv( {
       cls: 'heatmap-error',
-      text: this.tv('notices.yearUnavailable', `${year}年のデータは利用できません`, {
+      text: this.tv('notices.yearUnavailable', "No data available for {year}", {
         year,
       }),
     });
@@ -315,7 +315,7 @@ export class LogView {
 
     grid.querySelectorAll<HTMLElement>('.heatmap-cell').forEach((cell) => {
       delete cell.dataset.level;
-      cell.dataset.tooltip = this.tv('labels.tooltipNoData', 'データなし');
+      cell.dataset.tooltip = this.tv('labels.tooltipNoData', 'No data');
     });
 
     // Legend outside of scroll area, centered
@@ -375,7 +375,7 @@ export class LogView {
           'aria-label',
           this.tv(
             'labels.openTaskListAria',
-            `${this.getAccessibleLabel(dateString)}を表示`,
+            "Open task list for {date}",
             { date: this.getAccessibleLabel(dateString) },
           ),
         );
@@ -536,13 +536,13 @@ export class LogView {
       case 'placeholder':
         this.dayDetailContainer.createDiv( {
           cls: 'heatmap-detail-placeholder',
-          text: this.tv('labels.selectDate', '日付を選択してください'),
+          text: this.tv('labels.selectDate', 'Select a date'),
         });
         break;
       case 'loading':
         this.dayDetailContainer.createDiv( {
           cls: 'heatmap-detail-loading',
-          text: this.tv('labels.loadingDate', `${state.dateKey} のデータを読み込み中...`, {
+          text: this.tv('labels.loadingDate', "Loading data for {date}...", {
             date: state.dateKey,
           }),
         });
@@ -550,13 +550,13 @@ export class LogView {
       case 'future':
         this.dayDetailContainer.createDiv( {
           cls: 'heatmap-detail-placeholder',
-          text: this.tv('labels.futureDate', '未来の日付です。記録はまだありません。'),
+          text: this.tv('labels.futureDate', 'This is a future date. No records yet.'),
         });
         break;
       case 'error':
         this.dayDetailContainer.createDiv( {
           cls: 'heatmap-detail-error',
-          text: this.tv('notices.loadFailedGeneric', 'データの読み込みに失敗しました。'),
+          text: this.tv('notices.loadFailedGeneric', 'Failed to load data.'),
         });
         break;
       case 'success':
@@ -565,7 +565,7 @@ export class LogView {
       default:
         this.dayDetailContainer.createDiv( {
           cls: 'heatmap-detail-placeholder',
-          text: this.tv('labels.selectDatePrompt', '日付を選択してください'),
+          text: this.tv('labels.selectDatePrompt', 'Select a date'),
         });
     }
   }
@@ -585,11 +585,11 @@ export class LogView {
 
     const openButton = heading.createEl('button', {
       cls: 'heatmap-detail-open-button',
-      text: this.tv('labels.openTaskList', '↗︎ 開く'),
+      text: this.tv('labels.openTaskList', 'Open ↗'),
       attr: {
         'aria-label': this.tv(
           'labels.openTaskListAria',
-          `${this.getAccessibleLabel(detail.date)}のタスク一覧を開く`,
+          "Open task list for {date}",
           { date: this.getAccessibleLabel(detail.date) },
         ),
       },
@@ -604,18 +604,18 @@ export class LogView {
 
     this.createSummaryItem(
       summary,
-      this.tv('labels.totalTasks', '総タスク'),
+      this.tv('labels.totalTasks', 'Total tasks'),
       String(detail.summary.totalTasks),
     );
     this.createSummaryItem(
       summary,
-      this.tv('labels.completedTasks', '完了'),
+      this.tv('labels.completedTasks', 'Completed'),
       String(detail.summary.completedTasks),
     );
     if (detail.executions.length === 0) {
       this.dayDetailContainer.createDiv( {
         cls: 'heatmap-detail-empty',
-        text: this.tv('labels.noEntries', 'この日に記録された実行ログはありません。'),
+        text: this.tv('labels.noEntries', 'No execution logs recorded for this day.'),
       });
       return;
     }
@@ -627,14 +627,14 @@ export class LogView {
     const headerRow = thead.createEl('tr');
     const columns: Array<{ label: string; cls?: string }> = [
       {
-        label: this.tv('labels.tableHeaders.taskNameWithCount', `タスク名 (${detail.executions.length})`, {
+        label: this.tv('labels.tableHeaders.taskNameWithCount', "Task name ({count})", {
           count: detail.executions.length,
         }),
       },
-      { label: this.tv('labels.tableHeaders.executionTime', '実行時間') },
-      { label: this.tv('labels.tableHeaders.focus', '集中度'), cls: 'heatmap-col-focus' },
-      { label: this.tv('labels.tableHeaders.energy', '元気度'), cls: 'heatmap-col-energy' },
-      { label: this.tv('labels.tableHeaders.comment', 'コメント') },
+      { label: this.tv('labels.tableHeaders.executionTime', 'Execution time') },
+      { label: this.tv('labels.tableHeaders.focus', 'Focus'), cls: 'heatmap-col-focus' },
+      { label: this.tv('labels.tableHeaders.energy', 'Energy'), cls: 'heatmap-col-energy' },
+      { label: this.tv('labels.tableHeaders.comment', 'Comment') },
     ];
     columns.forEach((col) => {
       headerRow.createEl('th', { text: col.label, cls: col.cls, attr: { scope: 'col' } });
@@ -712,7 +712,7 @@ export class LogView {
 
   private formatMinutesValue(totalMinutes: number): string {
     if (!Number.isFinite(totalMinutes) || totalMinutes <= 0) {
-      return this.tv('durations.zeroMinutes', '0分');
+      return this.tv('durations.zeroMinutes', '0 minutes');
     }
     const minutes = Math.round(totalMinutes);
     const hours = Math.floor(minutes / 60);
@@ -742,7 +742,7 @@ export class LogView {
 
   private formatDuration(durationSec: number | undefined): string {
     if (!durationSec || durationSec <= 0) {
-      return this.tv('durations.lessThanMinute', '1分未満');
+      return this.tv('durations.lessThanMinute', 'Under 1 minute');
     }
     const minutes = Math.max(1, Math.round(durationSec / 60));
     const hours = Math.floor(minutes / 60);
@@ -819,7 +819,7 @@ export class LogView {
     });
 
     if (!stats || stats.totalTasks === 0) {
-      return this.tv('summaries.noTasks', `${formatted}\nタスクなし`, {
+      return this.tv('summaries.noTasks', "{formatted}\nNo tasks", {
         formatted,
       });
     }
@@ -827,7 +827,7 @@ export class LogView {
     const rate = Math.round((stats.completionRate ?? 0) * 100);
     return this.tv(
       'summaries.stats',
-      `${formatted}\n総タスク: ${stats.totalTasks}\n完了: ${stats.completedTasks}\n先送り: ${stats.procrastinatedTasks}\n完了率: ${rate}%`,
+      "{formatted}\nTotal tasks: {total}\nCompleted: {completed}\nDeferred: {deferred}\nCompletion rate: {rate}%",
       {
         formatted,
         total: stats.totalTasks,
@@ -840,16 +840,16 @@ export class LogView {
 
   private formatHoursMinutes(hours: number, minutes: number): string {
     if (minutes > 0) {
-      return this.tv('durations.hoursAndMinutes', `${hours}時間${minutes}分`, {
+      return this.tv('durations.hoursAndMinutes', "{hours}h {minutes}m", {
         hours,
         minutes,
       });
     }
-    return this.tv('durations.hoursOnly', `${hours}時間`, { hours });
+    return this.tv('durations.hoursOnly', "{hours}h", { hours });
   }
 
   private formatMinutesOnly(minutes: number): string {
-    return this.tv('durations.minutesOnly', `${minutes}分`, { minutes });
+    return this.tv('durations.minutesOnly', "{minutes}m", { minutes });
   }
 
   private addCellEventListeners(cell: HTMLElement, dateKey: string): void {
@@ -977,7 +977,7 @@ export class LogView {
       {
         onRestore: async (monthKey: string, backupPath: string) => {
           await restoreService.restoreFromBackup(monthKey, backupPath)
-          new Notice(this.tv('restore.success', 'ログデータを復元しました'))
+          new Notice(this.tv('restore.success', 'Log data restored successfully'))
         },
         getPreview: async (backupPath: string, targetDate?: string) => {
           return restoreService.getBackupPreview(backupPath, targetDate)

--- a/src/features/log/views/LogView.ts
+++ b/src/features/log/views/LogView.ts
@@ -271,12 +271,12 @@ export class LogView {
 
     // Legend outside of scroll area, centered
     const legend = layout.createDiv( { cls: 'heatmap-legend' });
-    legend.createSpan( { cls: 'legend-label', text: 'Less' });
+    legend.createSpan( { cls: 'legend-label', text: this.tv('labels.heatmapLegendLess', 'Less') });
     const legendScale = legend.createDiv( { cls: 'legend-scale' });
     for (let level = 0; level <= 4; level++) {
       legendScale.createDiv( { cls: 'legend-cell', attr: { 'data-level': String(level) } });
     }
-    legend.createSpan( { cls: 'legend-label', text: 'More' });
+    legend.createSpan( { cls: 'legend-label', text: this.tv('labels.heatmapLegendMore', 'More') });
 
     this.dayDetailContainer = layout.createDiv( {
       cls: 'heatmap-detail-section',
@@ -320,12 +320,12 @@ export class LogView {
 
     // Legend outside of scroll area, centered
     const legend = layout.createDiv( { cls: 'heatmap-legend' });
-    legend.createSpan( { cls: 'legend-label', text: 'Less' });
+    legend.createSpan( { cls: 'legend-label', text: this.tv('labels.heatmapLegendLess', 'Less') });
     const legendScale = legend.createDiv( { cls: 'legend-scale' });
     for (let level = 0; level <= 4; level++) {
       legendScale.createDiv( { cls: 'legend-cell', attr: { 'data-level': String(level) } });
     }
-    legend.createSpan( { cls: 'legend-label', text: 'More' });
+    legend.createSpan( { cls: 'legend-label', text: this.tv('labels.heatmapLegendMore', 'More') });
 
     this.dayDetailContainer = layout.createDiv( {
       cls: 'heatmap-detail-section',

--- a/src/features/recipe/modals/RecipeManagerModal.ts
+++ b/src/features/recipe/modals/RecipeManagerModal.ts
@@ -94,7 +94,7 @@ export default class RecipeManagerModal extends Modal {
       this.render()
     } catch (error) {
       console.error('[RecipeManagerModal] Failed to load recipes', error)
-      new Notice(t('recipes.manager.notices.loadFailed', 'レシピ管理画面の読み込みに失敗しました'))
+      new Notice(t('recipes.manager.notices.loadFailed', 'Failed to load recipe manager'))
     }
   }
 
@@ -115,13 +115,13 @@ export default class RecipeManagerModal extends Modal {
 
   private renderList(): void {
     if (!this.contentEl) return
-    this.renderHeader(t('recipes.manager.listTitle', 'レシピ一覧'))
+    this.renderHeader(t('recipes.manager.listTitle', 'Recipes'))
 
     if (this.recipes.length > 0) {
       const toolbar = this.contentEl.createDiv( { cls: 'recipe-list-toolbar' })
       const search = toolbar.createEl('input', {
         cls: 'form-input recipe-search-input',
-        attr: { type: 'search', placeholder: t('recipes.manager.searchPlaceholder', 'レシピを検索') },
+        attr: { type: 'search', placeholder: t('recipes.manager.searchPlaceholder', 'Search recipes') },
       })
       search.value = this.searchQuery
       search.addEventListener('input', () => {
@@ -130,7 +130,7 @@ export default class RecipeManagerModal extends Modal {
       })
       const createButton = toolbar.createEl('button', {
         cls: 'form-button create',
-        text: t('recipes.manager.createButton', '新規'),
+        text: t('recipes.manager.createButton', 'New'),
         attr: { type: 'button' },
       })
       createButton.addEventListener('click', () => {
@@ -166,7 +166,7 @@ export default class RecipeManagerModal extends Modal {
       return
     }
     if (recipes.length === 0) {
-      list.createDiv( { cls: 'recipe-empty-state', text: t('recipes.manager.noMatches', '一致するレシピがありません') })
+      list.createDiv( { cls: 'recipe-empty-state', text: t('recipes.manager.noMatches', 'No matching recipes') })
       return
     }
     recipes.forEach((recipe) => {
@@ -184,8 +184,8 @@ export default class RecipeManagerModal extends Modal {
       cls: 'recipe-source-open-button',
       attr: {
         type: 'button',
-        title: t('recipes.manager.openSource', 'レシピ原本を開く'),
-        'aria-label': t('recipes.manager.openSource', 'レシピ原本を開く'),
+        title: t('recipes.manager.openSource', 'Open recipe source'),
+        'aria-label': t('recipes.manager.openSource', 'Open recipe source'),
       },
     })
     this.appendOpenSourceIcon(openSourceButton)
@@ -196,7 +196,7 @@ export default class RecipeManagerModal extends Modal {
     })
     main.createDiv( {
       cls: 'recipe-card-meta',
-      text: t('recipes.manager.cardMeta', '{steps} 手順・{quality} 品質基準 / 使用中: {usages} タスク', {
+      text: t('recipes.manager.cardMeta', '{steps} steps · {quality} quality checks / used by {usages} tasks', {
         steps: recipe.steps.length,
         quality: recipe.qualityChecks?.length ?? 0,
         usages: usages.length,
@@ -206,12 +206,12 @@ export default class RecipeManagerModal extends Modal {
       || recipe.steps.slice(0, 3).map((step) => step.text).join(' / ')
     main.createDiv({
       cls: 'recipe-card-preview',
-      text: preview || t('recipes.manager.emptyPreview', 'レシピ内容なし'),
+      text: preview || t('recipes.manager.emptyPreview', 'No recipe content'),
     })
     const actions = card.createDiv( { cls: 'recipe-card-actions' })
     const editButton = actions.createEl('button', {
       cls: 'form-button cancel recipe-card-edit-button',
-      text: t('recipes.manager.editButton', '編集'),
+      text: t('recipes.manager.editButton', 'Edit'),
       attr: { type: 'button' },
     })
     editButton.addEventListener('click', () => {
@@ -224,8 +224,8 @@ export default class RecipeManagerModal extends Modal {
       cls: 'recipe-card-delete-button',
       attr: {
         type: 'button',
-        title: t('recipes.manager.deleteRecipe', 'レシピを削除'),
-        'aria-label': t('recipes.manager.deleteRecipe', 'レシピを削除'),
+        title: t('recipes.manager.deleteRecipe', 'Delete recipe'),
+        'aria-label': t('recipes.manager.deleteRecipe', 'Delete recipe'),
       },
     })
     this.appendTrashIcon(deleteButton)
@@ -241,7 +241,7 @@ export default class RecipeManagerModal extends Modal {
     const recipe = this.editing
 
     this.renderHeader(
-      recipe ? t('recipes.manager.editTitle', 'レシピ編集') : t('recipes.manager.createTitle', 'レシピ新規作成'),
+      recipe ? t('recipes.manager.editTitle', 'Edit recipe') : t('recipes.manager.createTitle', 'Create recipe'),
     )
 
     const form = this.contentEl.createEl('form', { cls: 'task-form recipe-edit-form' })
@@ -257,14 +257,14 @@ export default class RecipeManagerModal extends Modal {
     let saveButton: HTMLButtonElement | undefined
     createModalFooter(form, [
       {
-        text: t('common.cancel', 'キャンセル'),
+        text: t('common.cancel', 'Cancel'),
         role: 'cancel',
         onClick: () => {
           void this.requestLeaveEdit()
         },
       },
       {
-        text: t('recipes.manager.saveButton', '保存'),
+        text: t('recipes.manager.saveButton', 'Save'),
         role: 'primary',
         type: 'submit',
         ref: (button) => {
@@ -305,10 +305,10 @@ export default class RecipeManagerModal extends Modal {
 
   private confirmDiscardChanges(): Promise<boolean> {
     return showConfirmModal(this.app, {
-      title: t('recipes.manager.discardTitle', '未保存の変更'),
-      message: t('recipes.manager.discardMessage', '未保存の変更を破棄しますか？'),
-      confirmText: t('recipes.manager.discardButton', '破棄'),
-      cancelText: t('common.cancel', 'キャンセル'),
+      title: t('recipes.manager.discardTitle', 'Unsaved changes'),
+      message: t('recipes.manager.discardMessage', 'Discard your unsaved changes?'),
+      confirmText: t('recipes.manager.discardButton', 'Discard'),
+      cancelText: t('common.cancel', 'Cancel'),
       destructive: true,
     })
   }
@@ -374,35 +374,35 @@ export default class RecipeManagerModal extends Modal {
       this.forceClose()
     } catch (error) {
       console.error('[RecipeManagerModal] Failed to open recipe source', error)
-      new Notice(t('recipes.manager.notices.openSourceFailed', 'レシピ原本を開けませんでした'))
+      new Notice(t('recipes.manager.notices.openSourceFailed', 'Failed to open recipe source'))
     }
   }
 
   private async saveCurrentRecipe(path: string | undefined, value: RecipeEditorValue): Promise<void> {
     try {
       await this.service.saveRecipe({ path, ...value })
-      new Notice(t('recipes.manager.notices.saved', 'レシピを保存しました'))
+      new Notice(t('recipes.manager.notices.saved', 'Recipe saved'))
       this.directEditFromRecipePath = false
       this.mode = 'list'
       this.editing = null
       await this.reload()
     } catch (error) {
       console.error('[RecipeManagerModal] Failed to save recipe', error)
-      new Notice(error instanceof Error ? error.message : t('recipes.manager.notices.saveFailed', 'レシピの保存に失敗しました'))
+      new Notice(error instanceof Error ? error.message : t('recipes.manager.notices.saveFailed', 'Failed to save recipe'))
     }
   }
 
   private async deleteCurrentRecipe(recipe: Recipe): Promise<void> {
     try {
       await this.service.deleteRecipe(recipe.path)
-      new Notice(t('recipes.manager.notices.deleted', 'レシピを削除しました'))
+      new Notice(t('recipes.manager.notices.deleted', 'Recipe deleted'))
       this.mode = 'list'
       this.editing = null
       await this.notifyRecipesChanged()
       await this.reload()
     } catch (error) {
       console.error('[RecipeManagerModal] Failed to delete recipe', error)
-      new Notice(t('recipes.manager.notices.deleteFailed', 'レシピの削除に失敗しました'))
+      new Notice(t('recipes.manager.notices.deleteFailed', 'Failed to delete recipe'))
     }
   }
 
@@ -416,16 +416,16 @@ export default class RecipeManagerModal extends Modal {
 
   private async confirmDeleteRecipe(recipe: Recipe): Promise<void> {
     const confirmed = await showConfirmModal(this.app, {
-      title: t('routineManager.confirm.heading', '確認'),
-      message: t('recipes.manager.deleteConfirmTitle', '「{title}」を削除しますか？', {
+      title: t('routineManager.confirm.heading', 'Confirm'),
+      message: t('recipes.manager.deleteConfirmTitle', 'Delete "{title}"?', {
         title: recipe.title,
       }),
       description: t(
         'recipes.manager.deleteConfirmMessage',
-        '紐付いているタスクからも解除されます。',
+        'Linked tasks will also be unassigned.',
       ),
-      confirmText: t('common.delete', '削除'),
-      cancelText: t('common.cancel', 'キャンセル'),
+      confirmText: t('common.delete', 'Delete'),
+      cancelText: t('common.cancel', 'Cancel'),
       destructive: true,
     })
     if (!confirmed) return

--- a/src/features/recipe/modals/RecipeSelectModal.ts
+++ b/src/features/recipe/modals/RecipeSelectModal.ts
@@ -109,13 +109,13 @@ export class RecipeSelectModal extends Modal {
 
   private renderSelect(): void {
     if (!this.contentEl) return
-    this.renderHeader(t('recipes.select.title', 'レシピを設定'))
+    this.renderHeader(t('recipes.select.title', 'Set recipe'))
 
     if (this.recipes.length > 0) {
       const titleGroup = this.contentEl.createDiv( { cls: 'form-group recipe-select-name-group' })
       titleGroup.createEl('label', {
         cls: 'form-label',
-        text: t('recipes.select.nameLabel', 'レシピ名:'),
+        text: t('recipes.select.nameLabel', 'Recipe name:'),
         attr: { for: this.searchInputId },
       })
       this.searchInput = this.contentEl.createEl('input', {
@@ -128,7 +128,7 @@ export class RecipeSelectModal extends Modal {
           'aria-autocomplete': 'list',
           'aria-expanded': 'false',
           'aria-controls': this.suggestionsId,
-          placeholder: t('recipes.manager.searchPlaceholder', 'レシピを検索'),
+          placeholder: t('recipes.manager.searchPlaceholder', 'Search recipes'),
         },
       })
       titleGroup.appendChild(this.searchInput)
@@ -147,7 +147,7 @@ export class RecipeSelectModal extends Modal {
       this.renderInlineCreateFields()
       const createButton = this.contentEl.createEl('button', {
         cls: 'form-button cancel recipe-select-create-new-button',
-        text: t('recipes.select.createNew', '新しいレシピを作る'),
+        text: t('recipes.select.createNew', 'Create a new recipe'),
         attr: { type: 'button' },
       })
       createButton.addEventListener('click', () => this.enterCreateMode())
@@ -224,7 +224,7 @@ export class RecipeSelectModal extends Modal {
 
   private renderCreate(): void {
     if (!this.contentEl) return
-    this.renderHeader(t('recipes.manager.createTitle', 'レシピ新規作成'))
+    this.renderHeader(t('recipes.manager.createTitle', 'Create recipe'))
 
     const form = this.contentEl.createEl('form', { cls: 'task-form recipe-edit-form' })
     this.createEditor = new RecipeEditorForm(form, { title: this.createInitialTitle })
@@ -232,14 +232,14 @@ export class RecipeSelectModal extends Modal {
     let saveButton: HTMLButtonElement | undefined
     createModalFooter(form, [
       {
-        text: t('common.cancel', 'キャンセル'),
+        text: t('common.cancel', 'Cancel'),
         role: 'cancel',
         onClick: () => {
           void this.requestLeaveCreate()
         },
       },
       {
-        text: t('recipes.manager.saveButton', '保存'),
+        text: t('recipes.manager.saveButton', 'Save'),
         role: 'primary',
         type: 'submit',
         ref: (button) => {
@@ -269,7 +269,7 @@ export class RecipeSelectModal extends Modal {
       ...(this.options.instance.task.recipePath
         ? [
             {
-              text: t('recipes.select.clear', 'レシピを解除'),
+              text: t('recipes.select.clear', 'Remove recipe'),
               role: 'secondary' as const,
               cls: 'recipe-select-clear-button',
               ref: (button: HTMLButtonElement) => {
@@ -285,9 +285,9 @@ export class RecipeSelectModal extends Modal {
             },
           ]
         : []),
-      { text: t('common.cancel', 'キャンセル'), role: 'cancel', onClick: () => this.close() },
+      { text: t('common.cancel', 'Cancel'), role: 'cancel', onClick: () => this.close() },
       {
-        text: t('recipes.manager.saveButton', '保存'),
+        text: t('recipes.manager.saveButton', 'Save'),
         role: 'primary',
         cls: 'recipe-select-save-button',
         ref: (button) => {
@@ -449,10 +449,10 @@ export class RecipeSelectModal extends Modal {
 
   private confirmDiscardChanges(): Promise<boolean> {
     return showConfirmModal(this.app, {
-      title: t('recipes.manager.discardTitle', '未保存の変更'),
-      message: t('recipes.manager.discardMessage', '未保存の変更を破棄しますか？'),
-      confirmText: t('recipes.manager.discardButton', '破棄'),
-      cancelText: t('common.cancel', 'キャンセル'),
+      title: t('recipes.manager.discardTitle', 'Unsaved changes'),
+      message: t('recipes.manager.discardMessage', 'Discard your unsaved changes?'),
+      confirmText: t('recipes.manager.discardButton', 'Discard'),
+      cancelText: t('common.cancel', 'Cancel'),
       destructive: true,
     })
   }
@@ -481,7 +481,7 @@ export class RecipeSelectModal extends Modal {
       this.render()
     } catch (error) {
       console.error('[RecipeSelectModal] Failed to load recipes', error)
-      new Notice(t('recipes.select.notices.loadFailed', 'レシピ一覧の読み込みに失敗しました'))
+      new Notice(t('recipes.select.notices.loadFailed', 'Failed to load recipes'))
       this.forceClose()
     }
   }
@@ -491,7 +491,7 @@ export class RecipeSelectModal extends Modal {
       await this.options.service.assignRecipeToTask(this.options.instance.task.path, recipe.path)
     } catch (error) {
       console.error('[RecipeSelectModal] Failed to assign recipe', error)
-      new Notice(t('recipes.select.notices.assignFailed', 'レシピの設定に失敗しました'))
+      new Notice(t('recipes.select.notices.assignFailed', 'Failed to set recipe'))
       return false
     }
 
@@ -509,7 +509,7 @@ export class RecipeSelectModal extends Modal {
       await this.options.service.unassignRecipeFromTask(this.options.instance.task.path)
     } catch (error) {
       console.error('[RecipeSelectModal] Failed to unassign recipe', error)
-      new Notice(t('recipes.select.notices.unassignFailed', 'レシピの解除に失敗しました'))
+      new Notice(t('recipes.select.notices.unassignFailed', 'Failed to remove recipe'))
       return
     }
 
@@ -534,7 +534,7 @@ export class RecipeSelectModal extends Modal {
       this.render()
     } catch (error) {
       console.error('[RecipeSelectModal] Failed to create recipe', error)
-      new Notice(error instanceof Error ? error.message : t('recipes.select.notices.createFailed', 'レシピの作成に失敗しました'))
+      new Notice(error instanceof Error ? error.message : t('recipes.select.notices.createFailed', 'Failed to create recipe'))
     }
   }
 }

--- a/src/features/recipe/services/RecipeService.ts
+++ b/src/features/recipe/services/RecipeService.ts
@@ -254,7 +254,7 @@ export class RecipeService {
       frontmatter.recipe = createRecipeReferenceLink(normalizedRecipePath)
       return frontmatter
     })
-    new Notice(t('recipes.select.notices.assigned', 'レシピを設定しました'))
+    new Notice(t('recipes.select.notices.assigned', 'Recipe set'))
   }
 
   async unassignRecipeFromTask(taskPath: string): Promise<void> {
@@ -265,7 +265,7 @@ export class RecipeService {
     await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
       delete frontmatter.recipe
     })
-    new Notice(t('recipes.select.notices.unassigned', 'レシピを解除しました'))
+    new Notice(t('recipes.select.notices.unassigned', 'Recipe removed'))
   }
 
   private async unlinkRecipeFromTasks(recipePath: string): Promise<void> {

--- a/src/features/recipe/ui/RecipeEditorForm.ts
+++ b/src/features/recipe/ui/RecipeEditorForm.ts
@@ -76,7 +76,7 @@ export class RecipeEditorForm {
       const titleGroup = container.createDiv({ cls: 'form-group' })
       titleGroup.createEl('label', {
         cls: 'form-label',
-        text: t('recipes.manager.nameLabel', 'レシピ名'),
+        text: t('recipes.manager.nameLabel', 'Recipe name'),
         attr: { for: `${this.fieldIdPrefix}-title` },
       })
       this.titleInput = titleGroup.createEl('input', {
@@ -85,7 +85,7 @@ export class RecipeEditorForm {
           type: 'text',
           id: `${this.fieldIdPrefix}-title`,
           autocomplete: 'off',
-          placeholder: t('recipes.manager.namePlaceholder', 'タスクを迷わず実行できる名前'),
+          placeholder: t('recipes.manager.namePlaceholder', 'A name that makes the task easy to start'),
         },
       })
       this.titleInput.value = this.initialValue.title
@@ -95,19 +95,19 @@ export class RecipeEditorForm {
     const goalGroup = container.createDiv({ cls: 'form-group recipe-goal-group' })
     goalGroup.createEl('label', {
       cls: 'form-label',
-      text: t('recipes.manager.goalLabel', '完了基準'),
+      text: t('recipes.manager.goalLabel', 'Definition of done'),
       attr: { for: `${this.fieldIdPrefix}-goal` },
     })
     goalGroup.createDiv({
       cls: 'recipe-field-description',
-      text: t('recipes.manager.goalDescription', 'どうなったら、このタスクを完了にできるかを記述します。'),
+      text: t('recipes.manager.goalDescription', 'Describe what must be true before this task is complete.'),
     })
     this.goalInput = goalGroup.createEl('textarea', {
       cls: 'form-input recipe-goal-input',
       attr: {
         rows: '3',
         id: `${this.fieldIdPrefix}-goal`,
-        placeholder: t('recipes.manager.goalPlaceholder', '例: 公開前レビューを通過し、URLを共有できている'),
+        placeholder: t('recipes.manager.goalPlaceholder', 'For example, the review is approved and the published URL is shared'),
       },
     })
     this.goalInput.value = this.initialValue.goal
@@ -116,11 +116,11 @@ export class RecipeEditorForm {
     const stepsGroup = container.createDiv({ cls: 'form-group recipe-checklist-group recipe-steps-group' })
     stepsGroup.createEl('label', {
       cls: 'form-label',
-      text: t('recipes.manager.stepsLabel', '手順'),
+      text: t('recipes.manager.stepsLabel', 'Steps'),
     })
     stepsGroup.createDiv({
       cls: 'recipe-field-description',
-      text: t('recipes.manager.stepsDescription', '実行する順番に並べます。実行時にチェックできます。'),
+      text: t('recipes.manager.stepsDescription', 'Put the procedure in execution order. Check items while working.'),
     })
     this.stepsList = stepsGroup.createDiv({ cls: 'recipe-steps-list' })
     this.renderChecklist('steps')
@@ -129,11 +129,11 @@ export class RecipeEditorForm {
     const qualityGroup = container.createDiv({ cls: 'form-group recipe-checklist-group recipe-quality-group' })
     qualityGroup.createEl('label', {
       cls: 'form-label',
-      text: t('recipes.manager.qualityChecksLabel', '品質基準'),
+      text: t('recipes.manager.qualityChecksLabel', 'Quality checks'),
     })
     qualityGroup.createDiv({
       cls: 'recipe-field-description',
-      text: t('recipes.manager.qualityChecksDescription', '完了前に満たしているか確認する品質チェックです。'),
+      text: t('recipes.manager.qualityChecksDescription', 'Checks that must pass before completion.'),
     })
     this.qualityList = qualityGroup.createDiv({ cls: 'recipe-quality-checks-list' })
     this.renderChecklist('quality')
@@ -142,19 +142,19 @@ export class RecipeEditorForm {
     const constraintsGroup = container.createDiv({ cls: 'form-group recipe-constraints-group' })
     constraintsGroup.createEl('label', {
       cls: 'form-label',
-      text: t('recipes.manager.constraintsLabel', '制約・ルール'),
+      text: t('recipes.manager.constraintsLabel', 'Constraints and rules'),
       attr: { for: `${this.fieldIdPrefix}-constraints` },
     })
     constraintsGroup.createDiv({
       cls: 'recipe-field-description',
-      text: t('recipes.manager.constraintsDescription', '必ず守るルールを1行に1つ入力します。'),
+      text: t('recipes.manager.constraintsDescription', 'Enter one rule per line. These rules must always be followed.'),
     })
     this.constraintsInput = constraintsGroup.createEl('textarea', {
       cls: 'form-input recipe-constraints-input',
       attr: {
         rows: '4',
         id: `${this.fieldIdPrefix}-constraints`,
-        placeholder: t('recipes.manager.constraintsPlaceholder', '例: 顧客データを外部サービスへ送信しない'),
+        placeholder: t('recipes.manager.constraintsPlaceholder', 'For example, do not send customer data to external services'),
       },
     })
     this.constraintsInput.value = this.initialValue.constraints.join('\n')
@@ -182,7 +182,7 @@ export class RecipeEditorForm {
     let invalidTarget: HTMLElement | null = null
     this.clearInvalidState()
     if (!value.title) {
-      message = t('recipes.manager.validation.nameRequired', 'レシピ名を入力してください。')
+      message = t('recipes.manager.validation.nameRequired', 'Enter a recipe name.')
       invalidTarget = this.titleInput
     } else if (
       !value.goal
@@ -192,7 +192,7 @@ export class RecipeEditorForm {
     ) {
       message = t(
         'recipes.manager.validation.contentRequired',
-        '完了基準・手順・品質基準・制約のいずれかを入力してください。',
+        'Enter a definition of done, step, quality check, or constraint.',
       )
       invalidTarget = this.goalInput
     }
@@ -263,8 +263,8 @@ export class RecipeEditorForm {
         cls: `recipe-list-drag-handle ${handleClass}`,
         attr: {
           type: 'button',
-          title: t('recipes.manager.reorderStep', 'ドラッグして並び替え'),
-          'aria-label': t('recipes.manager.reorderStep', 'ドラッグして並び替え'),
+          title: t('recipes.manager.reorderStep', 'Drag to reorder'),
+          'aria-label': t('recipes.manager.reorderStep', 'Drag to reorder'),
           'aria-keyshortcuts': 'Alt+ArrowUp Alt+ArrowDown',
         },
       })
@@ -289,11 +289,11 @@ export class RecipeEditorForm {
         attr: {
           type: 'text',
           'aria-label': isQuality
-            ? t('recipes.manager.qualityCheckPlaceholder', '品質基準')
-            : t('recipes.manager.stepPlaceholder', '手順'),
+            ? t('recipes.manager.qualityCheckPlaceholder', 'Quality check')
+            : t('recipes.manager.stepPlaceholder', 'Step'),
           placeholder: isQuality
-            ? t('recipes.manager.qualityCheckPlaceholder', '品質基準')
-            : t('recipes.manager.stepPlaceholder', '手順'),
+            ? t('recipes.manager.qualityCheckPlaceholder', 'Quality check')
+            : t('recipes.manager.stepPlaceholder', 'Step'),
         },
       })
       input.value = value.text
@@ -307,11 +307,11 @@ export class RecipeEditorForm {
         attr: {
           type: 'button',
           title: isQuality
-            ? t('recipes.manager.removeQualityCheck', '品質基準を削除')
-            : t('recipes.manager.removeStep', '手順を削除'),
+            ? t('recipes.manager.removeQualityCheck', 'Remove quality check')
+            : t('recipes.manager.removeStep', 'Remove step'),
           'aria-label': isQuality
-            ? t('recipes.manager.removeQualityCheck', '品質基準を削除')
-            : t('recipes.manager.removeStep', '手順を削除'),
+            ? t('recipes.manager.removeQualityCheck', 'Remove quality check')
+            : t('recipes.manager.removeStep', 'Remove step'),
         },
       })
       applyIcon(remove, 'x')
@@ -330,8 +330,8 @@ export class RecipeEditorForm {
     const button = container.createEl('button', {
       cls: `form-button cancel recipe-add-step-button ${isQuality ? 'recipe-add-quality-check-button' : ''}`,
       text: isQuality
-        ? t('recipes.manager.addQualityCheck', '+ 品質基準を追加')
-        : t('recipes.manager.addStep', '+ 手順を追加'),
+        ? t('recipes.manager.addQualityCheck', '+ add quality check')
+        : t('recipes.manager.addStep', '+ add step'),
       attr: { type: 'button' },
     })
     button.addEventListener('click', () => {

--- a/src/features/recipe/ui/RecipeEmptyState.ts
+++ b/src/features/recipe/ui/RecipeEmptyState.ts
@@ -11,15 +11,15 @@ export function renderRecipeEmptyState(container: HTMLElement, options: RecipeEm
   const empty = container.createDiv( { cls: 'recipe-empty-create-state' })
   empty.createDiv( {
     cls: 'recipe-empty-create-title',
-    text: options.title ?? t('recipes.empty.title', 'レシピがありません。'),
+    text: options.title ?? t('recipes.empty.title', 'No recipes yet.'),
   })
   empty.createDiv( {
     cls: 'recipe-empty-create-message',
-    text: options.message ?? t('recipes.empty.message', 'このモーダルで作成しますか？'),
+    text: options.message ?? t('recipes.empty.message', 'Create one in this modal?'),
   })
   const createButton = empty.createEl('button', {
     cls: 'form-button create recipe-empty-create-button',
-    text: options.buttonText ?? t('recipes.empty.createButton', 'レシピを作成'),
+    text: options.buttonText ?? t('recipes.empty.createButton', 'Create recipe'),
     attr: { type: 'button' },
   })
   createButton.addEventListener('click', options.onCreate)

--- a/src/features/recipe/ui/RecipeRunPopover.ts
+++ b/src/features/recipe/ui/RecipeRunPopover.ts
@@ -85,7 +85,7 @@ export class RecipeRunPopover {
     } catch (error) {
       if (token !== this.showToken) return
       console.error('[RecipeRunPopover] Failed to load recipe', error)
-      new Notice(t('recipes.run.notices.loadFailed', 'レシピを読み込めませんでした'))
+      new Notice(t('recipes.run.notices.loadFailed', 'Failed to load recipe'))
       return
     }
     if (token !== this.showToken) return
@@ -147,8 +147,8 @@ export class RecipeRunPopover {
         cls: 'recipe-run-edit-button',
         attr: {
           type: 'button',
-          title: t('recipes.run.editRecipe', 'レシピを編集'),
-          'aria-label': t('recipes.run.editRecipe', 'レシピを編集'),
+          title: t('recipes.run.editRecipe', 'Edit recipe'),
+          'aria-label': t('recipes.run.editRecipe', 'Edit recipe'),
         },
       })
       this.appendEditIcon(editButton)
@@ -163,7 +163,7 @@ export class RecipeRunPopover {
         const goalSection = popover.createDiv({ cls: 'recipe-run-context recipe-run-goal' })
         goalSection.createDiv({
           cls: 'recipe-run-context-title',
-          text: t('recipes.run.goalLabel', '完了基準'),
+          text: t('recipes.run.goalLabel', 'Definition of done'),
         })
         goalSection.createDiv({ cls: 'recipe-run-context-text', text: recipe.goal.trim() })
       }
@@ -180,8 +180,8 @@ export class RecipeRunPopover {
         sectionHeader.createDiv({
           cls: 'recipe-run-section-title',
           text: kind === 'steps'
-            ? t('recipes.run.stepsLabel', '手順')
-            : t('recipes.run.qualityChecksLabel', '品質基準'),
+            ? t('recipes.run.stepsLabel', 'Steps')
+            : t('recipes.run.qualityChecksLabel', 'Quality checks'),
         })
         sectionHeader.createSpan({
           cls: 'recipe-run-section-summary',
@@ -227,8 +227,8 @@ export class RecipeRunPopover {
           list.createDiv({
             cls: 'recipe-empty-state',
             text: kind === 'steps'
-              ? t('recipes.run.emptySteps', '手順がありません')
-              : t('recipes.run.emptyQualityChecks', '品質基準がありません'),
+              ? t('recipes.run.emptySteps', 'No steps')
+              : t('recipes.run.emptyQualityChecks', 'No quality checks'),
           })
         }
         displayItems.forEach((item, index) => {
@@ -241,8 +241,8 @@ export class RecipeRunPopover {
             cls: 'recipe-step-drag-handle',
             attr: {
               type: 'button',
-              title: t('recipes.run.reorderStep', 'ドラッグして並び替え'),
-              'aria-label': t('recipes.run.reorderStep', 'ドラッグして並び替え'),
+              title: t('recipes.run.reorderStep', 'Drag to reorder'),
+              'aria-label': t('recipes.run.reorderStep', 'Drag to reorder'),
               'aria-keyshortcuts': 'Alt+ArrowUp Alt+ArrowDown',
             },
           })
@@ -317,7 +317,7 @@ export class RecipeRunPopover {
       if (recipe.steps.length === 0 && (recipe.qualityChecks?.length ?? 0) === 0) {
         popover.createDiv({
           cls: 'recipe-empty-state',
-          text: t('recipes.run.emptyChecklists', 'チェックリストがありません'),
+          text: t('recipes.run.emptyChecklists', 'No checklists'),
         })
       }
 
@@ -325,7 +325,7 @@ export class RecipeRunPopover {
         const constraintsSection = popover.createDiv({ cls: 'recipe-run-context recipe-run-constraints' })
         constraintsSection.createDiv({
           cls: 'recipe-run-context-title',
-          text: t('recipes.run.constraintsLabel', '制約・ルール'),
+          text: t('recipes.run.constraintsLabel', 'Constraints and rules'),
         })
         const constraintsList = constraintsSection.createEl('ul', { cls: 'recipe-run-constraints-list' })
         recipe.constraints.forEach((constraint) => {

--- a/src/features/reminder/ui/ReminderIconRenderer.ts
+++ b/src/features/reminder/ui/ReminderIconRenderer.ts
@@ -60,12 +60,11 @@ export class ReminderIconRenderer {
 
   /**
    * Build tooltip text showing reminder time.
-   * Shows "HH:mm にリマインダー" format.
    */
   private buildTooltipText(reminderTime: string): string {
     return this.options.tv(
       'tooltips.reminderAtTime',
-      `${reminderTime} にリマインダー`,
+      "Reminder at {time}",
       { time: reminderTime }
     );
   }

--- a/src/features/routine/controllers/RoutineController.ts
+++ b/src/features/routine/controllers/RoutineController.ts
@@ -296,7 +296,7 @@ export default class RoutineController {
       const option = monthdayOptions.createEl('label', { cls: 'routine-monthday-option' })
       const checkbox = option.createEl('input', { type: 'checkbox', value: String(day) })
       option.createSpan( {
-        text: this.tv('labels.routineMonthdayNth', '{day}日', { day }),
+        text: this.tv('labels.routineMonthdayNth', 'Day {day}', { day }),
         cls: 'routine-monthday-option__label',
       })
       monthdayCheckboxes.push(checkbox)
@@ -1302,7 +1302,7 @@ export default class RoutineController {
     const labels = monthdays.map((day) =>
       day === 'last'
         ? this.tv('labels.routineMonthdayLast', 'Last day')
-        : this.tv('labels.routineMonthdayNth', '{day}日', { day }),
+        : this.tv('labels.routineMonthdayNth', 'Day {day}', { day }),
     )
     return labels.join(joiner)
   }

--- a/src/features/routine/controllers/RoutineController.ts
+++ b/src/features/routine/controllers/RoutineController.ts
@@ -812,9 +812,7 @@ export default class RoutineController {
   ): HTMLInputElement {
     const wrapper = container.createDiv( { cls: 'form-input-icon-wrapper' })
     const localeCode = getCurrentLocale() === 'ja' ? 'ja-JP' : 'en-US'
-    const placeholder = getCurrentLocale() === 'ja'
-      ? this.tv('forms.datePlaceholderJa', '年/月/日')
-      : this.tv('forms.datePlaceholderEn', 'YYYY-MM-DD')
+    const placeholder = this.tv('forms.datePlaceholder', 'YYYY-MM-DD')
     const displayInput = wrapper.createEl('input', {
       type: 'text',
       cls: 'form-input--date form-input--bare',

--- a/src/features/routine/modals/RoutineEditModal.ts
+++ b/src/features/routine/modals/RoutineEditModal.ts
@@ -969,9 +969,7 @@ export default class RoutineEditModal extends Modal {
   ): HTMLInputElement {
     const wrapper = container.createDiv( { cls: "form-input-icon-wrapper" })
     const localeCode = getCurrentLocale() === "ja" ? "ja-JP" : "en-US"
-    const placeholder = getCurrentLocale() === "ja"
-      ? this.tv("fields.datePlaceholderJa", "年/月/日")
-      : this.tv("fields.datePlaceholderEn", "YYYY-MM-DD")
+    const placeholder = this.tv("fields.datePlaceholder", "YYYY-MM-DD")
     const displayInput = wrapper.createEl("input", {
       type: "text",
       cls: "form-input--date form-input--bare",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -113,6 +113,8 @@ export const en = {
         "Windows .cmd/.bat/.ps1 shims cannot be used as manual CLI paths. Leave this empty for auto-detection or select the actual executable/package entrypoint.",
       retentionName: "Run log retention (days)",
       retentionDesc: "Run log notes older than this many days are deleted automatically.",
+      previousRuntimeShutdownFailed:
+        "The previous AI runtime could not be stopped safely. AI tasks remain disabled; please try again.",
     },
     taskCreation: {
       heading: "Task creation",
@@ -462,6 +464,18 @@ export const en = {
       taskRemovedFromTodayWithTitle: 'Removed "{title}" from the list.',
       taskMoveCleared: 'Cleared destination for "{title}"',
       routineDetached: "Detached from routine",
+      routineScheduleUpdated: "Routine schedule updated",
+    },
+    errors: {
+      unknown: "Unknown error",
+      reminderUpdateFailed: "Failed to update reminder",
+    },
+    messages: {
+      reminderCleared: "Reminder cleared",
+      reminderSet: "Reminder set for {time}",
+    },
+    recipes: {
+      openRecipe: "Open recipe",
     },
     restoreModal: {
       heading: "Restore deleted tasks for {date}",
@@ -494,6 +508,7 @@ export const en = {
       routineAssigned: "Routine task",
       routineSet: "Set as routine",
       toggleRoutine: "Toggle enabled state",
+      reminderAtTime: "Reminder at {time}",
     },
     moveCalendar: {
       prevMonth: "Previous month",
@@ -634,6 +649,7 @@ export const en = {
       enabled: "Enabled:",
       startDateLabel: "Start date:",
       endDateLabel: "End date:",
+      datePlaceholder: DATE_FORMAT_DISPLAY,
       startDateFormat: "Start date must use {format} format.",
       endDateFormat: "End date must use {format} format.",
       endBeforeStart: "End date must be on or after the start date.",
@@ -763,6 +779,7 @@ export const en = {
       routineMonthdayNth: 'Day {day}',
       routineMonthdayLast: 'Last day',
       routineMonthdayUnset: 'No date set',
+      untitledTask: 'Untitled task',
     },
     validator: {
       invalidChars: "Task name contains invalid characters: {chars}",
@@ -1197,10 +1214,12 @@ export const en = {
       enabledLabel: 'Enabled:',
       startDateLabel: 'Start date:',
       endDateLabel: 'End date:',
+      datePlaceholder: DATE_FORMAT_DISPLAY,
       weekdaysLabel: 'Weekdays (multi-select):',
       monthWeekLabel: 'Week:',
       monthWeeksLabel: 'Weeks (multi-select):',
       monthWeekdaysLabel: 'Weekdays (multi-select):',
+      monthlySettings: 'Monthly settings:',
       monthlyDateSettings: 'Monthly date settings:',
       monthDaysLabel: 'Dates (multi-select):',
       saveButton: 'Save',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -715,6 +715,7 @@ export const en = {
       minute: "M",
       cancel: "Cancel",
       save: "Save",
+      reset: "Reset",
     },
     calendar: {
       export: {
@@ -886,6 +887,8 @@ export const en = {
     labels: {
       yearOption: "{year}",
       tooltipNoData: "No data",
+      heatmapLegendLess: "Less",
+      heatmapLegendMore: "More",
       openTaskList: "Open ↗",
       openTaskListAria: "Open task list for {date}",
       totalTasks: "Total tasks",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -711,6 +711,7 @@ export const ja = {
       minute: "分",
       cancel: "キャンセル",
       save: "保存",
+      reset: "リセット",
     },
     calendar: {
       export: {
@@ -884,6 +885,8 @@ export const ja = {
     labels: {
       yearOption: "{year}年",
       tooltipNoData: "データなし",
+      heatmapLegendLess: "少ない",
+      heatmapLegendMore: "多い",
       openTaskList: "↗︎ 開く",
       openTaskListAria: "{date}のタスク一覧を開く",
       totalTasks: "総タスク",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -109,6 +109,8 @@ export const ja = {
         "Windowsの.cmd/.bat/.ps1 shimは手動CLIパスに使用できません。空欄で自動検出するか、実体の実行ファイル／パッケージentrypointを指定してください。",
       retentionName: "実行ログの保持期間（日）",
       retentionDesc: "この日数より古い実行ログノートは自動的に削除されます。",
+      previousRuntimeShutdownFailed:
+        "前回のAIランタイムを安全に停止できませんでした。AIタスクは無効のままです。もう一度お試しください。",
     },
     taskCreation: {
       heading: "タスク作成",
@@ -458,6 +460,18 @@ export const ja = {
       taskRemovedFromTodayWithTitle: "「{title}」を一覧から削除しました。",
       taskMoveCleared: "タスク「{title}」の移動先を解除しました",
       routineDetached: "ルーチンを外しました",
+      routineScheduleUpdated: "ルーチンの予定を更新しました",
+    },
+    errors: {
+      unknown: "不明なエラー",
+      reminderUpdateFailed: "リマインダーの更新に失敗しました",
+    },
+    messages: {
+      reminderCleared: "リマインダーを解除しました",
+      reminderSet: "{time} にリマインダーを設定しました",
+    },
+    recipes: {
+      openRecipe: "レシピを開く",
     },
     restoreModal: {
       heading: "{date} の削除済みタスクを復元",
@@ -490,6 +504,7 @@ export const ja = {
       routineAssigned: "ルーチンタスク",
       routineSet: "ルーチンタスクに設定",
       toggleRoutine: "有効/無効を切り替え",
+      reminderAtTime: "{time} にリマインダー",
     },
     moveCalendar: {
       prevMonth: "前の月へ",
@@ -630,6 +645,7 @@ export const ja = {
       enabled: "有効:",
       startDateLabel: "開始日:",
       endDateLabel: "終了日:",
+      datePlaceholder: "年/月/日",
       startDateFormat: "開始日は {format} 形式で指定してください",
       endDateFormat: "終了日は {format} 形式で指定してください",
       endBeforeStart: "終了日は開始日以降で指定してください",
@@ -759,6 +775,7 @@ export const ja = {
       routineMonthdayNth: "{day}日",
       routineMonthdayLast: "最終日",
       routineMonthdayUnset: "日付未指定",
+      untitledTask: "無題のタスク",
     },
     validator: {
       invalidChars: "使用できない文字が含まれています: {chars}",
@@ -1195,10 +1212,12 @@ export const ja = {
       enabledLabel: '有効:',
       startDateLabel: '開始日:',
       endDateLabel: '終了日:',
+      datePlaceholder: '年/月/日',
       weekdaysLabel: '曜日（複数選択可）:',
       monthWeekLabel: '第:',
       monthWeeksLabel: '週（複数選択可）:',
       monthWeekdaysLabel: '曜日（複数選択可）:',
+      monthlySettings: '月次設定:',
       monthlyDateSettings: '月次（日付）設定:',
       monthDaysLabel: '日付（複数選択可）:',
       saveButton: '保存',

--- a/src/ui/navigation/NavigationController.ts
+++ b/src/ui/navigation/NavigationController.ts
@@ -88,14 +88,14 @@ export default class NavigationController {
 
   private renderNavigationItems(navMenu: HTMLElement): void {
     const items: NavigationItem[] = [
-      { key: 'routine', label: this.view.tv('navigation.routine', 'ルーチン'), icon: '🔄' },
-      { key: 'review', label: this.view.tv('navigation.review', 'デビュー'), icon: '📋' },
-      { key: 'log', label: this.view.tv('navigation.log', 'ログ'), icon: '📊' },
+      { key: 'routine', label: this.view.tv('navigation.routine', 'Routine'), icon: '🔄' },
+      { key: 'review', label: this.view.tv('navigation.review', 'Review'), icon: '📋' },
+      { key: 'log', label: this.view.tv('navigation.log', 'Log'), icon: '📊' },
       ...(this.isRecipeFeatureEnabled()
-        ? [{ key: 'recipes' as const, label: this.view.tv('navigation.recipes', 'レシピ'), icon: '📄' }]
+        ? [{ key: 'recipes' as const, label: this.view.tv('navigation.recipes', 'Recipes'), icon: '📄' }]
         : []),
-      { key: 'projects', label: this.view.tv('navigation.projects', 'プロジェクト'), icon: '📁' },
-      { key: 'settings', label: this.view.tv('navigation.settings', '設定'), icon: '⚙️' },
+      { key: 'projects', label: this.view.tv('navigation.projects', 'Projects'), icon: '📁' },
+      { key: 'settings', label: this.view.tv('navigation.settings', 'Settings'), icon: '⚙️' },
     ]
 
     items.forEach((item) => {

--- a/src/ui/navigation/NavigationRoutineRenderer.ts
+++ b/src/ui/navigation/NavigationRoutineRenderer.ts
@@ -113,7 +113,7 @@ export default class NavigationRoutineRenderer {
             weekSet.push(converted)
           }
         }
-        const weekLabel = this.formatWeekList(weekSet) ?? this.host.tv('labels.routineWeekLabel', 'Week {week}', { week: 1 })
+        const weekLabel = this.formatWeekList(weekSet) ?? this.host.tv('labels.routineWeekNth', 'Week {week}', { week: 1 })
 
         const weekdaySet = this.normalizeWeekdayArray(
           task.routine_weekdays ?? (typeof task.routine_weekday === 'number' ? [task.routine_weekday] : undefined),
@@ -221,7 +221,7 @@ export default class NavigationRoutineRenderer {
     const labels = weeks.map((week) =>
       week === 'last'
         ? this.host.tv('labels.routineWeekLast', 'Last')
-        : this.host.tv('labels.routineWeekLabel', 'Week {week}', { week }),
+        : this.host.tv('labels.routineWeekNth', 'Week {week}', { week }),
     )
     return labels.join(joiner)
   }

--- a/src/ui/task/TaskCreationController.ts
+++ b/src/ui/task/TaskCreationController.ts
@@ -858,7 +858,7 @@ export default class TaskCreationController {
       this.host.recipeService
     ) {
       const recipeField = buildField(
-        this.host.tv("addTask.aiRecipeLabel", "レシピ（任意）"),
+        this.host.tv("addTask.aiRecipeLabel", "Recipe (optional)"),
       )
       recipeSelect = doc.win.createEl("select")
       recipeSelect.className = "form-input ai-task-recipe-select"
@@ -866,7 +866,7 @@ export default class TaskCreationController {
       noneOption.value = ""
       noneOption.textContent = this.host.tv(
         "addTask.aiRecipeNone",
-        "レシピなし",
+        "No recipe",
       )
       recipeSelect.appendChild(noneOption)
       let pendingInitialOption: HTMLOptionElement | null = null
@@ -883,7 +883,7 @@ export default class TaskCreationController {
       disclosure.className = "ai-task-field-description"
       disclosure.textContent = this.host.tv(
         "addTask.aiRecipeDisclosure",
-        "選択したレシピの完了基準・手順・品質基準・制約は、実行時にClaude Code/Codexへ送信されます。秘密情報を含めないでください。",
+        "The selected recipe's definition of done, steps, quality checks, and constraints are sent to the selected CLI at run time; don't include secrets.",
       )
       recipeField.appendChild(disclosure)
 
@@ -892,7 +892,7 @@ export default class TaskCreationController {
       const detailsSummary = doc.win.createEl("summary")
       detailsSummary.textContent = this.host.tv(
         "addTask.aiRecipePreview",
-        "内容を確認",
+        "Review recipe content",
       )
       recipeDetails.appendChild(detailsSummary)
       const detailsBody = doc.win.createEl("pre")
@@ -907,16 +907,16 @@ export default class TaskCreationController {
         detailsBody.textContent = recipe
           ? [
               recipe.goal
-                ? `${this.host.tv("recipes.manager.goalLabel", "完了基準")}\n${recipe.goal}`
+                ? `${this.host.tv("recipes.manager.goalLabel", "Definition of done")}\n${recipe.goal}`
                 : "",
               recipe.steps.length > 0
-                ? `${this.host.tv("recipes.manager.stepsLabel", "手順チェックリスト")}\n${recipe.steps.map((item) => `- ${item.text}`).join("\n")}`
+                ? `${this.host.tv("recipes.manager.stepsLabel", "Steps")}\n${recipe.steps.map((item) => `- ${item.text}`).join("\n")}`
                 : "",
               recipe.qualityChecks.length > 0
-                ? `${this.host.tv("recipes.manager.qualityChecksLabel", "品質基準チェックリスト")}\n${recipe.qualityChecks.map((item) => `- ${item.text}`).join("\n")}`
+                ? `${this.host.tv("recipes.manager.qualityChecksLabel", "Quality checks")}\n${recipe.qualityChecks.map((item) => `- ${item.text}`).join("\n")}`
                 : "",
               recipe.constraints.length > 0
-                ? `${this.host.tv("recipes.manager.constraintsLabel", "制約・ルール")}\n${recipe.constraints.map((item) => `- ${item.text}`).join("\n")}`
+                ? `${this.host.tv("recipes.manager.constraintsLabel", "Constraints and rules")}\n${recipe.constraints.map((item) => `- ${item.text}`).join("\n")}`
                 : "",
             ].filter(Boolean).join("\n\n")
           : ""
@@ -933,11 +933,11 @@ export default class TaskCreationController {
           option.value = recipe.path
           const summaryParts = [
             recipe.goal.trim().length > 0
-              ? this.host.tv("addTask.aiRecipeHasGoal", "ゴールあり")
+              ? this.host.tv("addTask.aiRecipeHasGoal", "Has definition of done")
               : null,
-            `${this.host.tv("recipes.manager.stepsLabel", "手順")} ${recipe.steps.length}`,
-            `${this.host.tv("recipes.manager.qualityChecksLabel", "品質")} ${recipe.qualityChecks.length}`,
-            `${this.host.tv("recipes.manager.constraintsLabel", "制約")} ${recipe.constraints.length}`,
+            `${this.host.tv("recipes.manager.stepsLabel", "Steps")} ${recipe.steps.length}`,
+            `${this.host.tv("recipes.manager.qualityChecksLabel", "Quality checks")} ${recipe.qualityChecks.length}`,
+            `${this.host.tv("recipes.manager.constraintsLabel", "Constraints and rules")} ${recipe.constraints.length}`,
           ].filter((value): value is string => value !== null)
           option.textContent = `${recipe.title} — ${summaryParts.join(" / ")}`
           recipeSelect.appendChild(option)
@@ -948,7 +948,7 @@ export default class TaskCreationController {
         ) {
           const broken = doc.win.createEl("option")
           broken.value = initialRecipePath
-          broken.textContent = `${initialRecipePath} (${this.host.tv("addTask.aiRecipeMissing", "見つかりません")})`
+          broken.textContent = `${initialRecipePath} (${this.host.tv("addTask.aiRecipeMissing", "Not found")})`
           recipeSelect.appendChild(broken)
         }
         recipeSelect.value = initialRecipePath ?? ""

--- a/src/ui/task/TaskSettingsTooltipController.ts
+++ b/src/ui/task/TaskSettingsTooltipController.ts
@@ -159,8 +159,8 @@ export default class TaskSettingsTooltipController {
       ? this.host.hasRecipeAssigned(inst)
       : Boolean(inst.task.recipePath)
     const label = hasRecipe
-      ? this.host.tv('buttons.manageRecipe', '🍽 レシピを変更・解除')
-      : this.host.tv('buttons.setRecipe', '🍽 レシピを設定')
+      ? this.host.tv('buttons.manageRecipe', '🍽 Change or remove recipe')
+      : this.host.tv('buttons.setRecipe', '🍽 Set recipe')
     const item = tooltip.createDiv( {
       cls: 'tooltip-item',
       text: label,
@@ -203,11 +203,11 @@ export default class TaskSettingsTooltipController {
 
     let label: string
     if (hasReminder) {
-      label = this.host.tv('buttons.reminderSet', `⏰ リマインダー (${reminderTime})`, {
+      label = this.host.tv('buttons.reminderSet', "⏰ Reminder ({time})", {
         time: reminderTime,
       })
     } else {
-      label = this.host.tv('buttons.setReminder', '⏰ リマインダーを設定')
+      label = this.host.tv('buttons.setReminder', '⏰ Set reminder')
     }
 
     const item = tooltip.createDiv( {

--- a/src/ui/time/MobileTimePicker.ts
+++ b/src/ui/time/MobileTimePicker.ts
@@ -321,7 +321,7 @@ export class MobileTimePicker implements TimePicker {
       const selectedMinutes = this.selectedHour * 60 + this.selectedMinute
       if (selectedMinutes > nowMinutes) {
         const message = this.options.tv
-          ? this.options.tv('forms.timeNotFuture', '未来の時刻は設定できません')
+          ? this.options.tv('forms.timeNotFuture', 'Time cannot be in the future')
           : 'Time cannot be in the future'
         new Notice(message)
         return

--- a/src/ui/time/MobileTimePicker.ts
+++ b/src/ui/time/MobileTimePicker.ts
@@ -119,7 +119,10 @@ export class MobileTimePicker implements TimePicker {
       'taskchute-mobile-time-picker-btn-reset',
     )
     applyIcon(resetBtn, 'rotate-ccw')
-    resetBtn.setAttribute('aria-label', 'Reset')
+    resetBtn.setAttribute(
+      'aria-label',
+      options.tv ? options.tv('forms.reset', 'Reset') : 'Reset',
+    )
     resetBtn.addEventListener('click', this.handleReset)
     buttonsContainer.appendChild(resetBtn)
 

--- a/src/ui/time/TimeEditPopup.ts
+++ b/src/ui/time/TimeEditPopup.ts
@@ -31,7 +31,10 @@ export default class TimeEditPopup implements TimePicker {
     saveBtn.type = 'button'
     saveBtn.classList.add('taskchute-time-popup-btn', 'taskchute-time-popup-btn-save')
     applyIcon(saveBtn, 'check')
-    saveBtn.setAttribute('aria-label', 'Save')
+    saveBtn.setAttribute(
+      'aria-label',
+      options.tv ? options.tv('forms.save', 'Save') : 'Save',
+    )
     container.appendChild(saveBtn)
 
     // Cancel button
@@ -39,7 +42,10 @@ export default class TimeEditPopup implements TimePicker {
     cancelBtn.type = 'button'
     cancelBtn.classList.add('taskchute-time-popup-btn', 'taskchute-time-popup-btn-cancel')
     applyIcon(cancelBtn, 'x')
-    cancelBtn.setAttribute('aria-label', 'Cancel')
+    cancelBtn.setAttribute(
+      'aria-label',
+      options.tv ? options.tv('forms.cancel', 'Cancel') : 'Cancel',
+    )
     container.appendChild(cancelBtn)
 
     // Reset button (clear time)
@@ -47,7 +53,10 @@ export default class TimeEditPopup implements TimePicker {
     resetBtn.type = 'button'
     resetBtn.classList.add('taskchute-time-popup-btn', 'taskchute-time-popup-btn-reset')
     applyIcon(resetBtn, 'rotate-ccw')
-    resetBtn.setAttribute('aria-label', 'Reset')
+    resetBtn.setAttribute(
+      'aria-label',
+      options.tv ? options.tv('forms.reset', 'Reset') : 'Reset',
+    )
     container.appendChild(resetBtn)
 
     // Position below anchor

--- a/tests/navigation/navigation-controller.test.ts
+++ b/tests/navigation/navigation-controller.test.ts
@@ -1,7 +1,8 @@
 import NavigationController from '../../src/ui/navigation/NavigationController';
+import { t } from '../../src/i18n';
 
 type NavigationViewStub = {
-  tv: (key: string, fallback: string) => string;
+  tv: (key: string, fallback: string, vars?: Record<string, string | number>) => string;
   app: {
     setting: {
       open: jest.Mock<void, []>;
@@ -71,7 +72,9 @@ describe('NavigationController', () => {
     );
 
     const view: NavigationViewStub = {
-      tv: jest.fn((_, fallback) => fallback),
+      tv: jest.fn((key: string, fallback: string, vars?: Record<string, string | number>) =>
+        t(`taskChuteView.${key}`, fallback, vars),
+      ),
       app: {
         setting: {
           open: jest.fn(),
@@ -141,11 +144,11 @@ describe('NavigationController', () => {
       'settings',
     ]);
     expect(Array.from(container.querySelectorAll('.navigation-nav-label')).map((item) => item.textContent)).toEqual([
-      'ルーチン',
-      'デビュー',
-      'ログ',
-      'プロジェクト',
-      '設定',
+      'Routine',
+      'Review',
+      'Log',
+      'Projects',
+      'Settings',
     ]);
 
     navItems[0].dispatchEvent(new Event('click'));
@@ -168,7 +171,7 @@ describe('NavigationController', () => {
       'projects',
       'settings',
     ]);
-    expect(Array.from(container.querySelectorAll('.navigation-nav-label')).map((item) => item.textContent)).toContain('レシピ');
+    expect(Array.from(container.querySelectorAll('.navigation-nav-label')).map((item) => item.textContent)).toContain('Recipes');
   });
 
   test('initializeNavigationEventListeners connects overlay handler', () => {

--- a/tests/reminder/reminder-icon.test.ts
+++ b/tests/reminder/reminder-icon.test.ts
@@ -6,6 +6,7 @@ import {
   ReminderIconRendererOptions,
 } from '../../src/features/reminder/ui/ReminderIconRenderer';
 import type { TaskInstance } from '../../src/types';
+import { t } from '../../src/i18n';
 
 // Mock Obsidian's createEl and createSvg
 const mockCreateEl = function (
@@ -70,7 +71,8 @@ describe('ReminderIconRenderer', () => {
     container.createSvg = createSvgStub;
 
     options = {
-      tv: jest.fn((key: string, fallback: string) => fallback),
+      tv: jest.fn((key: string, fallback: string, vars?: Record<string, string | number>) =>
+        t(`taskChuteView.${key}`, fallback, vars),),
     };
     renderer = new ReminderIconRenderer(options);
   });

--- a/tests/reminder/reminder-menu-item.test.ts
+++ b/tests/reminder/reminder-menu-item.test.ts
@@ -6,6 +6,7 @@ import TaskSettingsTooltipController, {
   TaskSettingsTooltipHost,
 } from '../../src/ui/task/TaskSettingsTooltipController';
 import type { TaskInstance } from '../../src/types';
+import { t } from '../../src/i18n';
 
 // Mock Obsidian's createEl method on HTMLElement
 const mockCreateEl = function (
@@ -48,7 +49,8 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
     document.body.innerHTML = '';
 
     mockHost = {
-      tv: jest.fn((key: string, fallback: string) => fallback),
+      tv: jest.fn((key: string, fallback: string, vars?: Record<string, string | number>) =>
+        t(`taskChuteView.${key}`, fallback, vars),),
       resetTaskToIdle: jest.fn(),
       showScheduledTimeEditModal: jest.fn(),
       showTaskMoveDatePicker: jest.fn(),
@@ -106,8 +108,7 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
       const items = tooltip?.querySelectorAll('.tooltip-item');
       const reminderItem = Array.from(items || []).find(
         (item) =>
-          item.textContent?.includes('リマインダー') ||
-          item.textContent?.includes('Reminder')
+          /reminder/i.test(item.textContent ?? '')
       );
       expect(reminderItem).toBeDefined();
     });
@@ -131,8 +132,7 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
       const items = tooltip?.querySelectorAll('.tooltip-item');
       const reminderItem = Array.from(items || []).find(
         (item) =>
-          item.textContent?.includes('リマインダー') ||
-          item.textContent?.includes('Reminder')
+          /reminder/i.test(item.textContent ?? '')
       );
 
       (reminderItem as HTMLElement)?.click();
@@ -147,8 +147,7 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
       const items = tooltip?.querySelectorAll('.tooltip-item');
       const reminderItem = Array.from(items || []).find(
         (item) =>
-          item.textContent?.includes('リマインダー') ||
-          item.textContent?.includes('Reminder')
+          /reminder/i.test(item.textContent ?? '')
       );
 
       (reminderItem as HTMLElement)?.click();
@@ -165,8 +164,7 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
       const items = tooltip?.querySelectorAll('.tooltip-item');
       const reminderItem = Array.from(items || []).find(
         (item) =>
-          item.textContent?.includes('リマインダー') ||
-          item.textContent?.includes('Reminder')
+          /reminder/i.test(item.textContent ?? '')
       );
 
       // Should not have "clear" text when no reminder is set
@@ -182,8 +180,7 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
       const items = tooltip?.querySelectorAll('.tooltip-item');
       const reminderItem = Array.from(items || []).find(
         (item) =>
-          item.textContent?.includes('リマインダー') ||
-          item.textContent?.includes('Reminder')
+          /reminder/i.test(item.textContent ?? '')
       );
 
       // Should indicate current setting with time
@@ -198,8 +195,7 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
       const items = tooltip?.querySelectorAll('.tooltip-item');
       const reminderItem = Array.from(items || []).find(
         (item) =>
-          item.textContent?.includes('リマインダー') ||
-          item.textContent?.includes('Reminder')
+          /reminder/i.test(item.textContent ?? '')
       );
 
       expect(reminderItem?.textContent).toContain('09:55');
@@ -213,8 +209,7 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
       const items = tooltip?.querySelectorAll('.tooltip-item');
       const reminderItem = Array.from(items || []).find(
         (item) =>
-          item.textContent?.includes('リマインダー') ||
-          item.textContent?.includes('Reminder')
+          /reminder/i.test(item.textContent ?? '')
       );
 
       // Should show "set" text, not a time
@@ -230,8 +225,7 @@ describe('TaskSettingsTooltipController reminder menu item', () => {
       const items = tooltip?.querySelectorAll('.tooltip-item');
       const reminderItem = Array.from(items || []).find(
         (item) =>
-          item.textContent?.includes('リマインダー') ||
-          item.textContent?.includes('Reminder')
+          /reminder/i.test(item.textContent ?? '')
       );
 
       expect(reminderItem?.textContent).toMatch(/設定|Set/i);

--- a/tests/ui/routine/routine-controller.test.ts
+++ b/tests/ui/routine/routine-controller.test.ts
@@ -5,7 +5,7 @@ import RoutineController, {
 } from '../../../src/features/routine/controllers/RoutineController'
 import type { RoutineTaskShape } from '../../../src/types/routine'
 import type { TaskChutePluginLike } from '../../../src/types'
-import { initializeLocaleManager, setLocaleOverride } from '../../../src/i18n'
+import { initializeLocaleManager, setLocaleOverride, t } from '../../../src/i18n'
 
 const setActiveDocument = (doc: Document): void => {
   ;(globalThis as typeof globalThis & { activeDocument: Document }).activeDocument = doc
@@ -63,10 +63,9 @@ describe('RoutineController', () => {
     const host: RoutineControllerHost = {
       app,
       plugin,
-      tv: (key, fallback, vars) => {
-        if (!vars) return fallback
-        return fallback.replace(/\{(\w+)\}/g, (_, k) => String(vars[k] ?? `{${k}}`))
-      },
+      // Mirror TaskChuteView.tv so locale-dependent labels resolve through the
+      // real dictionary instead of always falling back to the English default.
+      tv: (key, fallback, vars) => t(`taskChuteView.${key}`, fallback, vars),
       getWeekdayNames: () => [...baseWeekdays],
       reloadTasksAndRestore: jest.fn(async () => {}),
       getCurrentDate: () => new Date('2025-10-09T00:00:00Z'),

--- a/tests/ui/task/task-creation-controller-ai.test.ts
+++ b/tests/ui/task/task-creation-controller-ai.test.ts
@@ -678,7 +678,7 @@ describe('AI mode UI', () => {
     )
     expect(select).not.toBeNull()
     expect(select?.options[1]?.textContent).toContain('Publish')
-    expect(modal.textContent).toContain('秘密情報を含めないでください')
+    expect(modal.textContent).toContain("don't include secrets")
     if (!select) throw new Error('recipe select missing')
     select.value = recipe.path
     select.dispatchEvent(new Event('change', { bubbles: true }))

--- a/tests/ui/task/task-settings-tooltip-controller.test.ts
+++ b/tests/ui/task/task-settings-tooltip-controller.test.ts
@@ -6,6 +6,7 @@ import TaskTimeController, {
 } from '../../../src/ui/time/TaskTimeController'
 import type { TaskData, TaskInstance } from '../../../src/types'
 import { Notice } from 'obsidian'
+import { t } from '../../../src/i18n'
 import { SectionConfigService } from '../../../src/services/SectionConfigService'
 
 /** Test overrides may supply a partial task; the runtime shape stays as written. */
@@ -70,7 +71,7 @@ describe('TaskSettingsTooltipController', () => {
   })
 
   const createHost = (overrides: Partial<TaskSettingsTooltipHost> = {}): TaskSettingsTooltipHost => ({
-    tv: (_key, fallback) => fallback,
+    tv: (key, fallback, vars) => t(`taskChuteView.${key}`, fallback, vars),
     resetTaskToIdle: jest.fn().mockResolvedValue(undefined),
     showScheduledTimeEditModal: jest.fn().mockResolvedValue(undefined),
     showTaskMoveDatePicker: jest.fn(),
@@ -116,7 +117,7 @@ const createTimeController = () => {
   const saveRunningTasksState = jest.fn().mockResolvedValue(undefined)
   const removeTaskLog = jest.fn().mockResolvedValue(undefined)
   const host: TaskTimeControllerHost = {
-    tv: (_key, fallback) => fallback,
+    tv: (key, fallback, vars) => t(`taskChuteView.${key}`, fallback, vars),
     app: {
       vault: {
         getAbstractFileByPath: jest.fn(() => null),
@@ -377,7 +378,7 @@ const createTimeController = () => {
       controller.show(instance, anchor)
 
       const tooltip = document.querySelector('.task-settings-tooltip') as HTMLElement
-      expect(tooltip.textContent).not.toContain('レシピ')
+      expect(tooltip.textContent).not.toMatch(/recipe/i)
     })
 
     test('shows set recipe when linked recipe is no longer available', () => {
@@ -399,9 +400,9 @@ const createTimeController = () => {
 
       controller.show(instance, anchor)
 
-      expect(queryTooltipItem('レシピを設定')).toBeTruthy()
+      expect(queryTooltipItem('Set recipe')).toBeTruthy()
       const tooltip = document.querySelector('.task-settings-tooltip') as HTMLElement
-      expect(tooltip.textContent).not.toContain('レシピを変更')
+      expect(tooltip.textContent).not.toContain('Change or remove recipe')
     })
 
     test('shows change recipe when linked recipe is available', () => {
@@ -423,7 +424,7 @@ const createTimeController = () => {
 
       controller.show(instance, anchor)
 
-      expect(queryTooltipItem('レシピを変更')).toBeTruthy()
+      expect(queryTooltipItem('Change or remove recipe')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
## Why

Some parts of the UI were suspected to be untranslated, but grepping for Japanese literals is mostly false positives — comments, frontmatter keys, Markdown headings, and code that already branches on the locale correctly.

So instead of hunting for text, I enumerated the holes in the i18n mechanism itself: keys resolved against the real `en.ts`/`ja.ts` trees (loaded through esbuild), with every `t()` / `tv()` call site matched across line breaks and resolved through all five `tv` namespaces. That found three distinct problems.

| | Before | After |
|---|---|---|
| Keys missing from both dictionaries | 18 | 0 |
| UI strings never passed through the dictionary | 8 | 0 |
| Fallback arguments written in Japanese | 190 | 0 |

## What changed

**Missing keys (18).** These call sites named keys that exist in neither dictionary, so the English fallback argument was shown to Japanese users too — a real, visible gap. Notable ones: the reminder set/cleared notices, the "task file not found" error, the recipe icon tooltip, the routine schedule notice, and the untitled-task label.

Two of them had invented near-duplicate key names for text the dictionary already had, so those now reuse `notices.taskFileMissing` and `labels.routineWeekNth`.

The routine date placeholder branched on the locale to choose between `datePlaceholderJa` and `datePlaceholderEn`. That is the dictionary's job, so it collapses to one `datePlaceholder` key.

**Hardcoded strings (8).** The heatmap legend wrote `Less` / `More` straight into `createSpan`, and the time popup and mobile time picker set their aria-labels from literals. Those stayed English in the Japanese UI. They now go through `tv()`.

Three literals are deliberately left alone: `/path/to/workspace` (a default that the call site already overrides via `tv()`), `hh:mm`, and `Review - ` — format and value samples, not prose.

**Japanese fallbacks (190).** Harmless while the key exists, but a rename or typo would leak Japanese into the English UI. Each fallback is now the key's English value from `en.ts`. Sixteen of them hand-built the string with a template literal despite already passing the variables, so those use the dictionary's `{name}` placeholders instead.

## Tests

Several test stubs defined `tv` as `(key, fallback) => fallback`, which bypassed both the dictionary and the variable substitution. That let them pass while asserting Japanese fallback text — one was even pinning a `デビュー` typo in the navigation labels, and the routine placeholder tests were really exercising the source's locale branch rather than the translation. Those stubs now mirror `TaskChuteView.tv` and go through the real translator, and the assertions expect the English that the `en` locale actually renders.

`npm run typecheck`, `npm run lint`, and `npm run test:unit` (225 suites / 3227 tests) all pass.

## Verifying by hand

With Obsidian set to English: the heatmap legend, the time-popup button aria-labels, and the routine monthly-settings label and date placeholder.

Back in Japanese: the same spots, plus the newly added keys — the reminder set/cleared notices, the task-file-not-found error, the recipe icon tooltip, and the untitled-task label.

## The settings pane was English regardless of all this

Found while checking the above in a Japanese Obsidian: the plugin's own views were translated, but the entire settings pane stayed English.

The locale detection was fine. The problem was ordering in `bootstrap.ts`. A comment already sitting a few lines above `addSettingTab` says it: registering a tab makes Obsidian read its definitions right away to build the search index. That read resolves every label through `t()` — and the locale manager was initialized about thirty lines further down. So the settings pane was captured in English at registration, while everything rendered later followed Obsidian's language correctly.

`initializeLocaleManager` now runs before `addSettingTab`. `LocaleCoordinator` still calls it below once the listeners it notifies exist; `setLocale` returns early when the locale is unchanged, so the repeat costs nothing.

Verified by hand in a Japanese vault: the settings pane is now Japanese.
