### PR TITLE
Keep the Pro state in step with the server

### DIFF
--- a/src/features/ai-task/licenseGate.ts
+++ b/src/features/ai-task/licenseGate.ts
@@ -17,10 +17,39 @@ export interface AiTaskLicenseGateHost extends AiTaskPluginLike {
 }
 
 /**
+ * One run at a time per plugin.
+ *
+ * Two callers watch the same state — the license listener in main.ts and the
+ * settings screen, which has to await its own call before redrawing — so a
+ * single activation or release starts both. Overlapping runs share the
+ * pending-disposal set and the manager slot: one can drain the set and build a
+ * runtime while the other is still tearing that very runtime down. Queued
+ * instead, the second sees the finished result of the first and agrees with it.
+ */
+const inFlight = new WeakMap<AiTaskLicenseGateHost, Promise<boolean>>()
+
+/**
  * Create or dispose the manager so it matches the current gates. Returns true
  * when a manager is running afterwards.
  */
 export async function syncAiTaskManagerToLicense(
+  plugin: AiTaskLicenseGateHost,
+): Promise<boolean> {
+  // Chained off the previous run whatever its outcome: a rejection must not
+  // wedge the queue, and the state each run reads is current when it starts.
+  const previous = inFlight.get(plugin) ?? Promise.resolve(false)
+  const run = previous
+    .catch(() => false)
+    .then(() => applyAiTaskLicenseGate(plugin))
+    .finally(() => {
+      if (inFlight.get(plugin) === run) inFlight.delete(plugin)
+    })
+  inFlight.set(plugin, run)
+
+  return run
+}
+
+async function applyAiTaskLicenseGate(
   plugin: AiTaskLicenseGateHost,
 ): Promise<boolean> {
   if (!isAiTaskLicensed(plugin)) {

--- a/src/features/core/views/TaskChuteView.ts
+++ b/src/features/core/views/TaskChuteView.ts
@@ -19,6 +19,7 @@ import { TaskLoaderService } from "../../../features/core/services/TaskLoaderSer
 import type { TaskLoaderHost } from "../../../features/core/services/TaskLoaderService"
 import { TaskCreationService } from "../../../features/core/services/TaskCreationService"
 import { TaskReuseService } from "../../../features/core/services/TaskReuseService"
+import { checkSeatRegistration } from "../../license/ui/notifySeatReleased"
 import { getCurrentLocale, t } from "../../../i18n"
 import { TASKCHUTE_NAME } from "../../../constants"
 import TaskReloadCoordinator from "../../../features/core/services/TaskReloadCoordinator"
@@ -782,6 +783,14 @@ export class TaskChuteView
     this.setupAccentContrast()
     this.navigationController.initializeNavigationEventListeners()
     this.setupEventListeners()
+
+    // Settle entitlement against the server now that the view is up. Opening
+    // the task list is the most common way into the plugin, and this is the
+    // screen the AI task affordances appear on — so it is where a seat released
+    // from another machine would otherwise stay invisible until a restart.
+    // Deliberately not awaited: the list must not wait on the license server,
+    // and a change re-renders through the license listener in main.ts.
+    void checkSeatRegistration(this.plugin)
   }
 
   private getContentContainer(): HTMLElement {

--- a/src/features/license/services/LicenseManager.ts
+++ b/src/features/license/services/LicenseManager.ts
@@ -44,6 +44,16 @@ export type LicenseState =
 
 export type LicenseChangeListener = (state: LicenseState) => void
 
+/** The seat list as the server last reported it. */
+export interface DeviceListSnapshot {
+  devices: DeviceView[]
+  maxDevices: number
+  /** Unix seconds, so a view can tell a fresh answer from a stale one. */
+  fetchedAt: number
+}
+
+export type DeviceListListener = (snapshot: DeviceListSnapshot) => void
+
 /**
  * Outcome of asking the server whether this device still holds a seat.
  *
@@ -83,6 +93,15 @@ export class LicenseManager {
   private refreshInFlight?: Promise<void>
   private deviceCheckInFlight?: Promise<DeviceRegistrationCheck>
   private lastDeviceCheckSec?: number
+  private syncInFlight?: Promise<LicenseState>
+  private lastSyncSec?: number
+  /** A code the server called invalid, so the sync stops re-asking about it. */
+  private rejectedCode?: string
+  private deviceSnapshot?: DeviceListSnapshot
+  private deviceListInFlight?: Promise<
+    { ok: true; devices: DeviceView[]; maxDevices: number } | { ok: false; failure: LicenseApiFailure }
+  >
+  private readonly deviceListeners = new Set<DeviceListListener>()
 
   constructor(private readonly deps: LicenseManagerDeps) {}
 
@@ -110,6 +129,29 @@ export class LicenseManager {
   /** Last known seat figures, available even while offline. */
   getLicenseSummary(): LicenseSummary | undefined {
     return this.deps.store.getState().license
+  }
+
+  /**
+   * The activation code this device may act with, or undefined once it has
+   * given up its seat.
+   *
+   * The code cannot simply be deleted: it lives in data.json, which Obsidian
+   * Sync shares, so removing it would take the license away from every other
+   * machine as well. Hiding it behind the device-local latch throws it away
+   * where it has to be thrown away — on this machine — and leaves the others
+   * untouched. Everything downstream then follows for free: no refresh, no
+   * device check, an empty field in settings, and no way back except the user
+   * entering the code again.
+   */
+  getStoredCode(): string | undefined {
+    return this.usableCode()
+  }
+
+  private usableCode(): string | undefined {
+    if (this.deps.store.isSeatReleased()) return undefined
+
+    const code = this.deps.getCode()
+    return code !== undefined && code.length > 0 ? code : undefined
   }
 
   onChange(listener: LicenseChangeListener): () => void {
@@ -148,9 +190,88 @@ export class LicenseManager {
     return run
   }
 
-  /** Whether a device check found this device gone and latched the token off. */
+  /** Whether this device has given up its seat and latched the code off. */
   isSeatReleased(): boolean {
     return this.deps.store.isSeatReleased()
+  }
+
+  /**
+   * Settle this device's entitlement against the server and report the result.
+   *
+   * The single entry point for "am I still Pro?", used on startup, on the
+   * background timer, and when the settings screen is opened. Returns the state
+   * afterwards so a caller that drew the old one can compare and redraw.
+   *
+   * Never throws and never rejects: every failure inside leaves entitlement
+   * exactly as it was, because being unable to ask is not an answer.
+   *
+   * @param options.force Skip the throttle. For the settings screen being
+   * opened, which is a deliberate act by someone waiting to see the answer.
+   */
+  async syncFromServer(options: { force?: boolean } = {}): Promise<LicenseState> {
+    if (this.syncInFlight) return this.syncInFlight
+
+    const now = this.now()
+    if (
+      options.force !== true &&
+      this.lastSyncSec !== undefined &&
+      now - this.lastSyncSec < LICENSE_DEVICE_CHECK_MIN_INTERVAL_SEC
+    ) {
+      return this.state
+    }
+    this.lastSyncSec = now
+
+    const run = this.doSync().finally(() => {
+      this.syncInFlight = undefined
+    })
+    this.syncInFlight = run
+
+    return run
+  }
+
+  private async doSync(): Promise<LicenseState> {
+    try {
+      return await this.settleAgainstServer()
+    } catch (error) {
+      // The API client turns every outcome into a value, so this is a bug or a
+      // broken environment rather than an unreachable server. It still must not
+      // reach the callers: they are plugin startup, a background timer and the
+      // settings screen, none of which may be derailed by the license server.
+      this.deps.log?.('warn', '[License] License sync failed', error)
+      return this.state
+    }
+  }
+
+  private async settleAgainstServer(): Promise<LicenseState> {
+    // The seat question comes first. Issuing a token re-registers this device
+    // id, so a refresh that ran ahead of the check would hand the seat straight
+    // back and the list would then honestly report the device present — a
+    // release made from another machine would vanish without a trace.
+    //
+    // Forced because this method's own throttle already decided the call was
+    // due; letting the check's floor veto it again is how a sync a minute after
+    // startup came to do nothing at all.
+    if ((await this.verifyDeviceRegistration({ force: true })) === 'released') {
+      return this.state
+    }
+
+    if (this.state.status === 'active') {
+      // Not forced: an unexpired token needs nothing, and the check above has
+      // already confirmed the seat.
+      await this.refreshIfNeeded()
+      return this.state
+    }
+
+    // Not active, which offline evidence alone cannot undo — the token may have
+    // simply expired while the machine was away, or the license may have been
+    // un-suspended since. Only the server can say. A device that gave up its
+    // seat has no usable code, so this can never retake one.
+    const code = this.usableCode()
+    if (code === undefined || code === this.rejectedCode) return this.state
+
+    await this.requestToken(code)
+
+    return this.state
   }
 
   /**
@@ -162,16 +283,19 @@ export class LicenseManager {
    * list is the only thing that can tell us, and only a real answer counts —
    * every failure returns `unknown` and leaves entitlement alone.
    */
-  async verifyDeviceRegistration(): Promise<DeviceRegistrationCheck> {
+  async verifyDeviceRegistration(
+    options: { force?: boolean } = {},
+  ): Promise<DeviceRegistrationCheck> {
+    // Only an entitlement that is currently granted can be taken away, and a
+    // device that already gave up its seat has no code to ask with.
     if (this.state.status !== 'active') return 'unknown'
-
-    const code = this.deps.getCode()
-    if (code === undefined || code.length === 0) return 'unknown'
+    if (this.usableCode() === undefined) return 'unknown'
 
     if (this.deviceCheckInFlight) return this.deviceCheckInFlight
 
     const now = this.now()
     if (
+      options.force !== true &&
       this.lastDeviceCheckSec !== undefined &&
       now - this.lastDeviceCheckSec < LICENSE_DEVICE_CHECK_MIN_INTERVAL_SEC
     ) {
@@ -203,13 +327,32 @@ export class LicenseManager {
     // this very screen, say. Acting on a stale reading would clobber it.
     if (this.state.status !== 'active') return 'unknown'
 
-    // The code stays in settings on purpose: data.json is synced, so clearing it
-    // here would strip the license from every other vault that shares it. The
-    // latch is device-local and stops this device alone from renewing.
+    // Drops the token and, with it, the code — device-locally. The value in
+    // settings is left alone because data.json is synced and clearing it would
+    // strip the license from every other machine that shares it; the latch
+    // makes it unreadable here, which is what "throw the code away" means on
+    // the one device that lost its seat.
     this.deps.store.markSeatReleased(this.now())
     this.setState({ status: 'unlicensed' })
 
     return 'released'
+  }
+
+  /** The seats as of the last successful fetch, for a list that has to paint now. */
+  getDeviceSnapshot(): DeviceListSnapshot | undefined {
+    return this.deviceSnapshot
+  }
+
+  /**
+   * Watch the seat list. The settings screen settles entitlement and the seat
+   * list from the same fetch, so the list has to hear about a result it did not
+   * ask for itself.
+   */
+  onDevicesChange(listener: DeviceListListener): () => void {
+    this.deviceListeners.add(listener)
+    return () => {
+      this.deviceListeners.delete(listener)
+    }
   }
 
   /**
@@ -222,15 +365,55 @@ export class LicenseManager {
   ): Promise<
     { ok: true; devices: DeviceView[]; maxDevices: number } | { ok: false; failure: LicenseApiFailure }
   > {
-    const code = explicitCode ?? this.deps.getCode()
+    const code = explicitCode ?? this.usableCode()
     if (code === undefined || code.length === 0) {
       return { ok: false, failure: { ok: false, kind: 'no-code' } }
     }
 
+    // Opening the Pro screen asks this question twice at once — the sync, to
+    // find out whether this device still holds a seat, and the list the screen
+    // draws. One request answers both, and answers them identically, which a
+    // second request would not guarantee. Only for the stored code: an explicit
+    // one belongs to a different license than the one being coalesced.
+    if (explicitCode === undefined && this.deviceListInFlight) {
+      return this.deviceListInFlight
+    }
+
+    const run = this.fetchDevices(code).finally(() => {
+      if (explicitCode === undefined) this.deviceListInFlight = undefined
+    })
+    if (explicitCode === undefined) this.deviceListInFlight = run
+
+    return run
+  }
+
+  private async fetchDevices(
+    code: string,
+  ): Promise<
+    { ok: true; devices: DeviceView[]; maxDevices: number } | { ok: false; failure: LicenseApiFailure }
+  > {
     const result = await this.deps.client.listDevices(code)
     if (!result.ok) return { ok: false, failure: result }
 
+    this.setDeviceSnapshot({
+      devices: result.data.devices,
+      maxDevices: result.data.max_devices,
+      fetchedAt: this.now(),
+    })
+
     return { ok: true, devices: result.data.devices, maxDevices: result.data.max_devices }
+  }
+
+  private setDeviceSnapshot(snapshot: DeviceListSnapshot): void {
+    this.deviceSnapshot = snapshot
+
+    for (const listener of this.deviceListeners) {
+      try {
+        listener(snapshot)
+      } catch (error) {
+        this.deps.log?.('warn', '[License] Device list listener failed', error)
+      }
+    }
   }
 
   /** @param explicitCode See listDevices: the code behind a 409 is not stored. */
@@ -238,7 +421,7 @@ export class LicenseManager {
     deviceId: string,
     explicitCode?: string,
   ): Promise<{ ok: true; devicesUsed: number } | { ok: false; failure: LicenseApiFailure }> {
-    const code = explicitCode ?? this.deps.getCode()
+    const code = explicitCode ?? this.usableCode()
     if (code === undefined || code.length === 0) {
       return { ok: false, failure: { ok: false, kind: 'no-code' } }
     }
@@ -246,19 +429,26 @@ export class LicenseManager {
     const result = await this.deps.client.deactivateDevice(code, deviceId)
     if (!result.ok) return { ok: false, failure: result }
 
+    // Drop the seat from the snapshot rather than re-fetching: the server has
+    // just told us it is gone, and every list watching stays in step without a
+    // second request.
+    if (this.deviceSnapshot) {
+      this.setDeviceSnapshot({
+        ...this.deviceSnapshot,
+        devices: this.deviceSnapshot.devices.filter((device) => device.device_id !== deviceId),
+      })
+    }
+
     // Releasing this very device invalidates the local token: it still verifies
     // cryptographically, but the seat is gone and no refresh will succeed.
+    //
+    // The same latch as a release from another machine, and for the same
+    // reason: the code has to stop working here — otherwise the next refresh
+    // would issue a fresh token under the same device id and silently retake
+    // the seat the user just gave up — while staying readable on every other
+    // machine that shares data.json through Obsidian Sync.
     if (deviceId === this.getDeviceId()) {
-      this.deps.store.clearToken()
-      // The code has to go with it. Left in settings, the next refresh would
-      // issue a fresh token under the same device id and silently retake the
-      // seat the user just released — on this machine and, via Obsidian Sync,
-      // on every other vault that shares data.json.
-      try {
-        await this.deps.setCode(undefined)
-      } catch (error) {
-        this.deps.log?.('warn', '[License] Failed to clear the stored code', error)
-      }
+      this.deps.store.markSeatReleased(this.now())
       this.setState({ status: 'unlicensed' })
     }
 
@@ -266,13 +456,10 @@ export class LicenseManager {
   }
 
   private async doRefresh(force: boolean): Promise<void> {
-    const code = this.deps.getCode()
-    if (code === undefined || code.length === 0) return
-
-    // A seat released elsewhere left the code in place so other synced vaults
-    // keep working. Refreshing here would hand this device the seat straight
-    // back, undoing the release the user made deliberately.
-    if (this.deps.store.isSeatReleased()) return
+    // Undefined once this device gave up its seat, which is what stops a
+    // refresh from handing it straight back.
+    const code = this.usableCode()
+    if (code === undefined) return
 
     if (!force && !this.needsRefresh()) return
 
@@ -298,7 +485,7 @@ export class LicenseManager {
     })
 
     if (!result.ok) {
-      return { ok: false, failure: this.handleFailure(result) }
+      return { ok: false, failure: this.handleFailure(code, result) }
     }
 
     const { token, expires_at: expiresAt, license } = result.data
@@ -316,8 +503,10 @@ export class LicenseManager {
       return { ok: false, failure: { kind: 'untrusted-token', reason: verification.error } }
     }
 
-    // Only activate() gets this far while the latch is on — doRefresh() bails
-    // out first — so a new token here is always the user asking for the seat.
+    // Only activate() gets this far while the latch is on — every other path
+    // reads the code through usableCode(), which returns nothing — so a new
+    // token here is always the user deliberately asking for the seat back.
+    this.rejectedCode = undefined
     this.deps.store.clearSeatReleased()
     this.deps.store.saveToken(token, expiresAt, license, this.now())
     this.setState({ status: 'active', token: verification.token, license })
@@ -325,7 +514,7 @@ export class LicenseManager {
     return { ok: true, state: this.state }
   }
 
-  private handleFailure(failure: LicenseApiFailure): ActivationFailure {
+  private handleFailure(code: string, failure: LicenseApiFailure): ActivationFailure {
     if (failure.kind !== 'api') {
       // Could not reach the server, or sent a malformed request. Neither says
       // anything about entitlement, so an unexpired token keeps working.
@@ -345,6 +534,11 @@ export class LicenseManager {
 
     if (failure.code === 'invalid_code' || failure.code === 'malformed_code') {
       // The stored code is not a license at all; the token cannot be renewed.
+      // Remembered so the periodic sync stops asking: a revoked or suspended
+      // license may be reinstated, but a string that is not a code never
+      // becomes one, and every settings visit would otherwise spend a request
+      // re-learning that.
+      this.rejectedCode = code
       this.deps.store.clearToken()
       this.setState({ status: 'unlicensed' })
       return failure

--- a/src/features/license/services/LicenseStore.ts
+++ b/src/features/license/services/LicenseStore.ts
@@ -41,10 +41,15 @@ export interface LicenseDeviceState {
   /** Last known seat/expiry figures, for display while offline. */
   license?: LicenseSummary
   /**
-   * When this device was found missing from the license's device list, in unix
-   * seconds. Set only by a real server answer; while it is present the token is
-   * never renewed automatically, so a seat released elsewhere is not silently
-   * retaken on the next refresh.
+   * When this device gave up its seat, in unix seconds — whether the user
+   * released it from here or another device released it for them.
+   *
+   * The activation code itself cannot be thrown away: it lives in data.json,
+   * which Obsidian Sync shares, so deleting it would strip the license from
+   * every other machine too. This is the device-local half of throwing it away.
+   * While it is set the stored code is treated as absent — no refresh, no
+   * device check, and an empty field in settings — so nothing on this machine
+   * quietly retakes the seat. Only an explicit activation lifts it.
    */
   seatReleasedAt?: number
 }
@@ -243,8 +248,8 @@ export class LicenseStore {
   }
 
   /**
-   * Record that the server no longer lists this device. Drops the token like
-   * clearToken(), and latches the reason so no background refresh claims the
+   * Record that this device no longer holds a seat. Drops the token like
+   * clearToken(), and latches the fact so nothing on this machine claims the
    * seat back — only an explicit activation may do that.
    */
   markSeatReleased(now: number): void {

--- a/src/features/license/ui/DeviceListView.ts
+++ b/src/features/license/ui/DeviceListView.ts
@@ -48,6 +48,9 @@ export class DeviceListView {
   private readonly listEl: HTMLElement
   private busyDeviceId?: string
   private disposed = false
+  private refreshing = false
+  private refreshEl!: HTMLButtonElement
+  private readonly unsubscribe?: () => void
 
   constructor(
     container: HTMLElement,
@@ -57,24 +60,68 @@ export class DeviceListView {
     this.devices = options.initialDevices
     this.maxDevices = options.initialMaxDevices
 
+    // The last seats the manager saw, so the list has something to draw while
+    // the request behind it is still out. Skipped for a list seeded from a 409:
+    // that one belongs to the code being typed, which may be a different
+    // license than the snapshot was taken from.
+    if (this.devices === undefined && options.code === undefined) {
+      const snapshot = manager.getDeviceSnapshot()
+      if (snapshot) {
+        this.devices = snapshot.devices
+        this.maxDevices = snapshot.maxDevices
+      }
+
+      // Opening the Pro screen settles entitlement and the seat list from one
+      // fetch — whichever of the two started it, both hear the answer.
+      this.unsubscribe = manager.onDevicesChange((next) => {
+        if (this.disposed) return
+        // Mid-release the list is showing a pending row; the release writes its
+        // own result when it lands.
+        if (this.busyDeviceId !== undefined) return
+        this.devices = next.devices
+        this.maxDevices = next.maxDevices
+        this.render()
+      })
+    }
+
     const root = container.createDiv({ cls: 'taskchute-license-devices' })
     this.rootEl = root
-    root.createDiv({
+
+    const header = root.createDiv({ cls: 'taskchute-license-devices__header' })
+    header.createDiv({
       cls: 'taskchute-license-devices__description',
       text: t(
         'license.devices.description',
         'This license can be used on a limited number of devices. Release a device you no longer use to make room for another one.',
       ),
     })
+    // Both answers come from the server and both can go stale while this screen
+    // is open — a seat taken on another machine, a license renewed. Neither is
+    // something the user can make happen from here, so there has to be a way to
+    // ask again without closing the settings and coming back.
+    this.refreshEl = header.createEl('button', {
+      cls: ['form-button', 'taskchute-license-devices__refresh'],
+      text: t('license.devices.refresh', 'Refresh'),
+    })
+    this.refreshEl.type = 'button'
+    this.refreshEl.addEventListener('click', () => {
+      void this.refresh()
+    })
+
     this.listEl = root.createDiv({ cls: 'taskchute-license-devices__list' })
     // Under the list: the seat count is a summary of what is above it, and a
     // load or failure message reads as the state of the list it follows.
     this.statusEl = root.createDiv({ cls: 'taskchute-license-devices__status' })
 
-    if (this.devices === undefined) {
+    // Nothing to draw yet leaves the container empty for load() to fill, rather
+    // than flashing "no devices" at someone whose seats are on their way.
+    if (this.devices !== undefined) this.render()
+
+    // Always re-asked, even with a snapshot on screen: what is drawn may be a
+    // visit old. The manager coalesces this with the sync's own fetch, so the
+    // screen still costs one request.
+    if (options.initialDevices === undefined) {
       void this.load()
-    } else {
-      this.render()
     }
   }
 
@@ -87,11 +134,68 @@ export class DeviceListView {
    */
   dispose(): void {
     this.disposed = true
+    this.unsubscribe?.()
     this.rootEl.remove()
   }
 
+  /**
+   * Re-ask the server for both halves of what this screen shows: whether this
+   * device is still licensed, and which seats the license holds.
+   *
+   * One request covers both — the manager coalesces the seat list it fetches to
+   * answer the first question with the one this list needs — so the two can
+   * never come back disagreeing with each other.
+   */
+  private async refresh(): Promise<void> {
+    if (this.refreshing || this.busyDeviceId !== undefined) return
+
+    this.refreshing = true
+    this.applyRefreshState()
+
+    // Forced: the user pressing this button is exactly the case the throttle
+    // must not answer with a cached "nothing to report".
+    const before = this.manager.getState().status
+    let state = before
+    try {
+      state = (await this.manager.syncFromServer({ force: true })).status
+    } catch {
+      // Reported through the list below like any other failure to reach the
+      // server; entitlement is left as it was.
+    }
+
+    if (this.disposed) return
+
+    // A sync that dropped this device out of the license replaces this whole
+    // section with the activation form, so there is no list left to reload —
+    // and no code to reload it with.
+    if (state !== before) {
+      this.refreshing = false
+      this.options.onChanged?.()
+      return
+    }
+
+    await this.load()
+    if (this.disposed) return
+
+    this.refreshing = false
+    this.applyRefreshState()
+  }
+
+  private applyRefreshState(): void {
+    this.refreshEl.disabled = this.refreshing || this.busyDeviceId !== undefined
+    this.refreshEl.setText(
+      this.refreshing
+        ? t('license.devices.refreshing', 'Refreshing…')
+        : t('license.devices.refresh', 'Refresh'),
+    )
+  }
+
   private async load(): Promise<void> {
-    this.setStatus(t('license.devices.loading', 'Loading devices…'))
+    // Only when there is nothing to look at. Replacing a drawn list with
+    // "Loading…" on every visit hides seats the user can already act on.
+    if (this.devices === undefined) {
+      this.setStatus(t('license.devices.loading', 'Loading devices…'))
+    }
 
     const result = await this.manager.listDevices(this.options.code)
     if (this.disposed) return
@@ -118,6 +222,10 @@ export class DeviceListView {
   }
 
   private render(): void {
+    // Sharing the list's busy state: releasing a seat and re-reading the seats
+    // must not run at once, or the answer overwrites the row being removed.
+    this.applyRefreshState()
+
     const devices = this.devices ?? []
 
     this.setStatus(

--- a/src/features/license/ui/notifySeatReleased.ts
+++ b/src/features/license/ui/notifySeatReleased.ts
@@ -1,5 +1,5 @@
 /**
- * The user-facing half of the device-presence check.
+ * The user-facing half of settling entitlement against the server.
  *
  * Losing the seat is not something the user did on this machine, so it cannot
  * pass as a Notice that scrolls away: the AI task UI simply disappears, and the
@@ -9,7 +9,7 @@ import type { App } from 'obsidian'
 
 import { t } from '../../../i18n'
 import { showInfoModal } from '../../../ui/modals/ConfirmModal'
-import type { DeviceRegistrationCheck, LicenseManager } from '../services/LicenseManager'
+import type { LicenseManager, LicenseState } from '../services/LicenseManager'
 
 export interface SeatCheckHost {
   app: App
@@ -17,40 +17,57 @@ export interface SeatCheckHost {
   _log?: (level?: string, ...args: unknown[]) => void
 }
 
+export interface SeatCheckResult {
+  /** Entitlement afterwards, or undefined where there was no manager to ask. */
+  state?: LicenseState
+  /**
+   * Whether the sync moved entitlement. What a caller that drew the old state
+   * needs to know — narrower than "the seat was released", which is only one of
+   * the ways the answer can change.
+   */
+  changed: boolean
+}
+
 /**
- * Check whether this device still holds a seat and tell the user if it does
- * not. Returns what the check found, so a caller that draws license state can
- * redraw itself.
+ * Settle this device's entitlement against the server, telling the user if it
+ * lost its seat. Reports whether anything moved, so a caller that draws license
+ * state can redraw itself.
  *
- * Never throws: it runs on startup and on every settings render, neither of
- * which may be derailed by the license server.
+ * Never throws: it runs on startup, on a timer and whenever the settings screen
+ * is built, none of which may be derailed by the license server.
+ *
+ * @param force Skip the throttle — for the settings screen being opened, where
+ * someone is waiting on the answer.
  */
 export async function checkSeatRegistration(
   host: SeatCheckHost,
-): Promise<DeviceRegistrationCheck> {
+  options: { force?: boolean } = {},
+): Promise<SeatCheckResult> {
   const manager = host.licenseManager
-  if (!manager) return 'unknown'
+  if (!manager) return { changed: false }
 
-  let result: DeviceRegistrationCheck
+  const before = manager.getState()
+
+  let state: LicenseState
   try {
-    result = await manager.verifyDeviceRegistration()
+    state = await manager.syncFromServer(options)
   } catch (error) {
-    host._log?.('warn', '[License] Device check failed', error)
-    return 'unknown'
+    host._log?.('warn', '[License] License sync failed', error)
+    return { state: before, changed: false }
   }
 
-  if (result !== 'released') return result
+  // Reached once per release: the sync leaves the state unlicensed, and the
+  // latch keeps every later one from asking again until the user re-activates.
+  if (before.status === 'active' && state.status !== 'active' && manager.isSeatReleased()) {
+    void showInfoModal(host.app, {
+      title: t('license.seatReleased.title', 'This device was released'),
+      message: t(
+        'license.seatReleased.message',
+        'This device is no longer registered to your license, so AI tasks have been turned off here.\nTo use them on this device again, open the plugin settings and activate your license code.',
+      ),
+      confirmText: t('license.seatReleased.close', 'OK'),
+    })
+  }
 
-  // Only ever reached once per release: the check leaves the state unlicensed,
-  // and every later call returns early on that.
-  void showInfoModal(host.app, {
-    title: t('license.seatReleased.title', 'This device was released'),
-    message: t(
-      'license.seatReleased.message',
-      'This device is no longer registered to your license, so AI tasks have been turned off here.\nTo use them on this device again, open the plugin settings and activate your license code.',
-    ),
-    confirmText: t('license.seatReleased.close', 'OK'),
-  })
-
-  return result
+  return { state, changed: before.status !== state.status }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1099,6 +1099,8 @@ export const en = {
       release: "Release",
       releasing: "Releasing…",
       released: "Device released.",
+      refresh: "Refresh",
+      refreshing: "Refreshing…",
     },
     seatReleased: {
       title: "This device was released",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -1097,6 +1097,8 @@ export const ja = {
       release: "解除",
       releasing: "解除しています…",
       released: "端末を解除しました。",
+      refresh: "最新の状態に更新",
+      refreshing: "更新しています…",
     },
     seatReleased: {
       title: "この端末の登録が解除されました",

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,17 +133,14 @@ export default class TaskChutePlusPlugin extends Plugin {
       }),
     )
 
+    // One call: the seat check and the token refresh have to happen in that
+    // order, and syncFromServer is what guarantees it. Renewing first would
+    // re-register this device id and hand back a seat released elsewhere before
+    // anything had the chance to notice it was gone.
     const refresh = () => {
-      void manager
-        .refreshIfNeeded()
-        .catch((error) => {
-          this._log('warn', '[License] Refresh failed', error)
-        })
-        // A seat released from another machine leaves this device's token valid
-        // for the rest of its life, so the refresh alone would never notice.
-        // Runs after it so a token just renewed is checked against the list it
-        // renewed from, not the one before.
-        .then(() => checkSeatRegistration(this))
+      void checkSeatRegistration(this).catch((error) => {
+        this._log('warn', '[License] Refresh failed', error)
+      })
     }
 
     this.app.workspace.onLayoutReady(refresh)

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -33,6 +33,27 @@ export class TaskChuteSettingTab extends PluginSettingTab {
    * discard the edit that triggered it.
    */
   private readonly boundaryDraft = new SectionBoundaryDraft()
+  /**
+   * Whether the next definition build is someone arriving at the screen rather
+   * than a rebuild of it.
+   *
+   * There is no "opened" hook to use: display() is not called for a tab that
+   * returns definitions, and getSettingDefinitions() serves the search index,
+   * every control change and every update() alike. hide() is the one event that
+   * separates visits, so it arms this; the first build of all is armed too,
+   * because that one happens as the plugin loads and its answer is what the
+   * screen shows moments later.
+   */
+  private licenseSyncDue = true
+  /**
+   * Set while the rebuild below is one this tab asked for.
+   *
+   * update() runs getSettingDefinitions() again, so a sync that redraws would
+   * start a sync that redraws. One piece of news is worth exactly one redraw,
+   * and this is what holds it to that — a comparison would not: it only ends
+   * the loop if the manager already agrees with the answer it just gave.
+   */
+  private licenseSyncSuppressed = false
 
   private readonly ctx: SectionContext
   private readonly modules: SectionModule[]
@@ -79,16 +100,30 @@ export class TaskChuteSettingTab extends PluginSettingTab {
   }
 
   getSettingDefinitions(): SettingDefinitionItem[] {
-    // Obsidian calls this on every display(), which makes it the hook for
-    // "the settings screen was opened" — the moment someone is most likely to
-    // wonder why the AI settings are still there after releasing this device
-    // elsewhere. The manager throttles the request, so the extra calls a
-    // rebuild makes cost nothing.
-    void checkSeatRegistration(this.plugin).then((result) => {
-      // The runtime is torn down by the license listener in main.ts; only the
-      // definitions this tab drew from the old state still need replacing.
-      if (result === "released") this.update()
-    })
+    // Arriving at the screen is the moment someone is most likely to wonder
+    // whether they are still Pro — after activating on another machine, or
+    // after releasing this device from one. Settle it against the server, and
+    // skip the throttle for the arrival itself; the rebuilds that follow it
+    // take the throttled path, so a burst of control changes costs nothing.
+    if (!this.licenseSyncSuppressed) {
+      const force = this.licenseSyncDue
+      this.licenseSyncDue = false
+
+      void checkSeatRegistration(this.plugin, { force }).then((result) => {
+        // The runtime is torn down by the license listener in main.ts; only the
+        // definitions this tab drew from the old state still need replacing.
+        // Any change, not just a released seat: an activation that landed
+        // elsewhere leaves this screen just as wrong.
+        if (!result.changed) return
+
+        this.licenseSyncSuppressed = true
+        try {
+          this.update()
+        } finally {
+          this.licenseSyncSuppressed = false
+        }
+      })
+    }
 
     return this.modules.flatMap((module) => module.items(this.ctx))
   }
@@ -100,6 +135,8 @@ export class TaskChuteSettingTab extends PluginSettingTab {
   hide(): void {
     this.boundaryDraft.reseed(this.plugin.settings.customSections)
     this.licenseForm.reset()
+    // The next build is a fresh visit rather than a rebuild of this one.
+    this.licenseSyncDue = true
     super.hide()
   }
 

--- a/src/settings/sections/pro/license.ts
+++ b/src/settings/sections/pro/license.ts
@@ -5,6 +5,7 @@ import { licensePurchaseUrl } from "../../../features/license/config"
 import type { LicenseManager } from "../../../features/license/services/LicenseManager"
 import { formatLicenseId } from "../../../features/license/token/primitives"
 import { DeviceListView } from "../../../features/license/ui/DeviceListView"
+import { checkSeatRegistration } from "../../../features/license/ui/notifySeatReleased"
 import {
   describeActivationFailure,
   describeApiFailure,
@@ -29,6 +30,27 @@ import { LicenseActivationState } from "./licenseActivationState"
 function deviceListHost(setting: Setting): HTMLElement {
   setting.settingEl.addClass("taskchute-license-devices-item")
   return setting.controlEl
+}
+
+/**
+ * Re-ask the server whether this device is licensed, because the Pro page is
+ * being shown.
+ *
+ * A row's render callback is the seam for that: the page's `items` are built
+ * with the rest of the tab's definitions, long before anyone navigates into it,
+ * and only these callbacks run at the moment it is drawn. Both shapes of the
+ * page call it, since "is my license working again?" matters most to someone
+ * looking at the activation form.
+ *
+ * Not forced: arriving at the settings tab has already forced one, and a forced
+ * sync here would re-run on every redraw of the page — including the redraw a
+ * changed answer causes. Throttled, the page reuses an answer at most a minute
+ * old and a redraw settles.
+ */
+function syncOnShown(ctx: SectionContext): void {
+  void checkSeatRegistration(ctx.plugin).then((result) => {
+    if (result.changed) ctx.update()
+  })
 }
 
 /**
@@ -80,6 +102,9 @@ function codeRow(
     // A failure belongs under the field it was typed into.
     desc: form.errorDesc,
     render: (setting) => {
+      // The activation form is drawn only on the Pro page, so this row being
+      // rendered is that page being shown.
+      syncOnShown(ctx)
       setting.settingEl.addClass("taskchute-license-code-item")
       // A failure is not a description: it reads as one unless it is coloured
       // like the error it is.
@@ -96,7 +121,7 @@ function codeRow(
           )
           // Re-seeded on every render: the row is rebuilt whenever activation
           // starts or fails, and the draft must survive that.
-          .setValue(form.currentCode(ctx.plugin.settings.licenseCode))
+          .setValue(form.currentCode(manager.getStoredCode()))
           .onChange((value) => {
             form.code = value
           })
@@ -146,7 +171,7 @@ async function activate(
   ctx.update()
 
   const result = await manager.activate(
-    form.currentCode(ctx.plugin.settings.licenseCode),
+    form.currentCode(manager.getStoredCode()),
   )
 
   if (result.ok) {
@@ -203,7 +228,7 @@ function activationRows(
             initialDevices: failure.devices,
             // The rejected activation stored nothing, so the list has to carry
             // the typed code or releasing a seat would have none to send.
-            code: form.currentCode(ctx.plugin.settings.licenseCode),
+            code: form.currentCode(manager.getStoredCode()),
             onChanged: () => {
               form.clearError()
               ctx.refreshDomState()
@@ -237,7 +262,9 @@ function activeLicenseRows(
   // The code the user actually typed, not the id derived from it: that is what
   // they hold, what support asks for, and what they would re-enter elsewhere.
   // The id is the fallback for a licence activated before the code was stored.
-  const stored = ctx.plugin.settings.licenseCode
+  // Read through the manager so a device that gave up its seat does not show a
+  // code it can no longer use.
+  const stored = manager.getStoredCode()
   const identity =
     stored !== undefined && stored.length > 0
       ? { name: t("settings.license.codeName", "License code"), value: stored }
@@ -266,6 +293,9 @@ function activeLicenseRows(
     // other seat, so there is no separate sign-out control.
     name: "",
     render: (setting) => {
+      // Same seam as the activation form: the seat list is only ever drawn on
+      // the Pro page, so mounting it is that page being shown.
+      syncOnShown(ctx)
       const view = new DeviceListView(deviceListHost(setting), manager, {
         onChanged: () => {
           // Seat counts come from the server, so a release has to re-read the

--- a/styles.css
+++ b/styles.css
@@ -8112,9 +8112,23 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
   margin-bottom: var(--size-4-4);
 }
 
+/* The description carries the width and the button sits beside it, so the
+   button stays on the same line as the text it belongs to rather than taking a
+   row of its own above a list it is not part of. */
+.taskchute-license-devices__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--size-4-2);
+}
+
 .taskchute-license-devices__description {
   color: var(--text-muted);
   font-size: var(--font-ui-smaller);
+}
+
+.taskchute-license-devices__refresh {
+  flex-shrink: 0;
 }
 
 .taskchute-license-devices__status {

--- a/tests/features/ai-task/ai-task-license-gate.test.ts
+++ b/tests/features/ai-task/ai-task-license-gate.test.ts
@@ -112,3 +112,53 @@ describe('syncAiTaskManagerToLicense', () => {
     expect(createAiTaskManagerMock).not.toHaveBeenCalled()
   })
 })
+
+describe('concurrent calls', () => {
+  beforeEach(() => {
+    createAiTaskManagerMock.mockReset()
+    disposeMock.mockReset()
+  })
+
+  test('run one at a time, so a teardown and a build cannot overlap', async () => {
+    // Both the license listener in main.ts and the settings screen react to the
+    // same change, so one activation starts two calls. They share the manager
+    // slot and the pending-disposal set: run at once, one can build a runtime
+    // while the other is still stopping that very runtime.
+    const pending = new Set<{ disposeAndWait: () => Promise<void> }>()
+    let draining = false
+    let overlapped = false
+    const stopping = {
+      disposeAndWait: async () => {
+        draining = true
+        await Promise.resolve()
+        await Promise.resolve()
+        draining = false
+      },
+    }
+    pending.add(stopping)
+
+    createAiTaskManagerMock.mockImplementation(() => {
+      if (draining) overlapped = true
+      return { id: 'manager' }
+    })
+
+    const host = createHost({ aiTaskManagersPendingDisposal: pending })
+
+    await Promise.all([syncAiTaskManagerToLicense(host), syncAiTaskManagerToLicense(host)])
+
+    expect(overlapped).toBe(false)
+    // The second call finds the runtime the first built and leaves it alone.
+    expect(createAiTaskManagerMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('a failed call does not wedge the queue', async () => {
+    const host = createHost()
+    createAiTaskManagerMock.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+    createAiTaskManagerMock.mockReturnValue({ id: 'manager' })
+
+    await expect(syncAiTaskManagerToLicense(host)).rejects.toThrow('boom')
+    expect(await syncAiTaskManagerToLicense(host)).toBe(true)
+  })
+})

--- a/tests/features/license/device-list-view.test.ts
+++ b/tests/features/license/device-list-view.test.ts
@@ -6,11 +6,16 @@
 import { DeviceListView } from '../../../src/features/license/ui/DeviceListView'
 import type { LicenseManager } from '../../../src/features/license/services/LicenseManager'
 
-function fakeManager(): LicenseManager {
+function fakeManager(overrides: Record<string, unknown> = {}): LicenseManager {
   return {
     getDeviceId: () => 'DEVICE-0001',
+    getState: () => ({ status: 'active' }),
+    getDeviceSnapshot: () => undefined,
+    onDevicesChange: jest.fn(() => () => undefined),
+    syncFromServer: jest.fn().mockResolvedValue({ status: 'active' }),
     listDevices: jest.fn().mockResolvedValue({ ok: true, devices: [], maxDevices: 3 }),
     deactivateDevice: jest.fn().mockResolvedValue({ ok: true, devicesUsed: 0 }),
+    ...overrides,
   } as unknown as LicenseManager
 }
 
@@ -30,13 +35,12 @@ describe('DeviceListView', () => {
   test('shows a failed load as an error, with its code', async () => {
     // The status line otherwise reads as a seat count in muted grey, which is
     // the wrong thing for a request that never returned a list.
-    const manager = {
-      getDeviceId: () => 'DEVICE-0001',
+    const manager = fakeManager({
       listDevices: jest
         .fn()
         .mockResolvedValue({ ok: false, failure: { ok: false, kind: 'network' } }),
       deactivateDevice: jest.fn(),
-    } as unknown as LicenseManager
+    })
     const host = document.createElement('div')
 
     new DeviceListView(host, manager)
@@ -65,6 +69,83 @@ describe('DeviceListView', () => {
       'DEVICE-OTHER',
       'TCP-0000-0000-0000-0001',
     )
+  })
+
+  describe('the refresh button', () => {
+    function clickRefresh(host: HTMLElement): void {
+      host.querySelector<HTMLButtonElement>('.taskchute-license-devices__refresh')?.click()
+    }
+
+    test('re-asks for the entitlement and the seats together', async () => {
+      // Both halves of this screen go stale for reasons the user cannot cause
+      // from here, and they have to be re-read as one or they can disagree.
+      const manager = fakeManager()
+      const host = document.createElement('div')
+      new DeviceListView(host, manager, { initialDevices: [] })
+
+      clickRefresh(host)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(manager.syncFromServer).toHaveBeenCalledWith({ force: true })
+      expect(manager.listDevices).toHaveBeenCalled()
+    })
+
+    test('hands over to the caller when the sync changed the entitlement', async () => {
+      // Losing the seat replaces this whole section with the activation form,
+      // so reloading a list that is about to be torn down would be pointless —
+      // and there would be no code left to load it with.
+      const manager = fakeManager({
+        syncFromServer: jest.fn().mockResolvedValue({ status: 'unlicensed' }),
+      })
+      const onChanged = jest.fn()
+      const host = document.createElement('div')
+      new DeviceListView(host, manager, { initialDevices: [], onChanged })
+
+      clickRefresh(host)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(onChanged).toHaveBeenCalled()
+      expect(manager.listDevices).not.toHaveBeenCalled()
+    })
+
+    test('does not run twice at once', async () => {
+      const manager = fakeManager()
+      const host = document.createElement('div')
+      new DeviceListView(host, manager, { initialDevices: [] })
+
+      clickRefresh(host)
+      clickRefresh(host)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(manager.syncFromServer).toHaveBeenCalledTimes(1)
+    })
+
+    test('survives a sync that threw', async () => {
+      // The button must come back enabled: a server that failed once is the
+      // whole reason someone would press it again.
+      const manager = fakeManager({
+        syncFromServer: jest.fn().mockRejectedValue(new Error('offline')),
+      })
+      const host = document.createElement('div')
+      new DeviceListView(host, manager, { initialDevices: [] })
+
+      clickRefresh(host)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      const button = host.querySelector<HTMLButtonElement>(
+        '.taskchute-license-devices__refresh',
+      )
+      expect(button?.disabled).toBe(false)
+      expect(manager.listDevices).toHaveBeenCalled()
+    })
   })
 
   test('mounting again after a dispose leaves a single list', () => {

--- a/tests/features/license/fakeLicenseManager.ts
+++ b/tests/features/license/fakeLicenseManager.ts
@@ -11,17 +11,37 @@ export interface FakeLicenseManager {
   /** The settings tab picks its shape from the state, not from isActive(). */
   getState: () => { status: 'active' | 'inactive' }
   getLicenseSummary: () => undefined
+  /**
+   * The code the settings screen may show. A real manager hides it once this
+   * device has given up its seat; the fake is never in that position, so it
+   * reports whatever the caller stored.
+   */
+  getStoredCode: () => string | undefined
+  setStoredCode: (code: string | undefined) => void
+  isSeatReleased: () => boolean
+  syncFromServer: () => Promise<{ status: 'active' | 'inactive' }>
 }
 
 export function createFakeLicenseManager(active = true): FakeLicenseManager {
   let value = active
+  let code: string | undefined
+
+  const getState = (): { status: 'active' | 'inactive' } => ({
+    status: value ? 'active' : 'inactive',
+  })
 
   return {
     isActive: () => value,
     setActive: (next: boolean) => {
       value = next
     },
-    getState: () => ({ status: value ? 'active' : 'inactive' }),
+    getState,
     getLicenseSummary: () => undefined,
+    getStoredCode: () => code,
+    setStoredCode: (next: string | undefined) => {
+      code = next
+    },
+    isSeatReleased: () => false,
+    syncFromServer: () => Promise.resolve(getState()),
   }
 }

--- a/tests/features/license/license-manager.test.ts
+++ b/tests/features/license/license-manager.test.ts
@@ -310,7 +310,7 @@ describe('device management', () => {
     expect(manager.isActive()).toBe(true)
   })
 
-  test('releasing this device drops the local token and the stored code', async () => {
+  test('releasing this device drops the local token and stops using the code', async () => {
     const { manager, store, client, code } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
     store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
     manager.initialize()
@@ -321,7 +321,56 @@ describe('device management', () => {
     // The token still verifies, but the seat is gone and no refresh can work.
     expect(manager.isActive()).toBe(false)
     expect(store.getState().token).toBeUndefined()
-    expect(code.value).toBeUndefined()
+
+    // The code is thrown away device-locally rather than deleted: data.json is
+    // synced, so deleting it would take the license off every other machine.
+    expect(manager.getStoredCode()).toBeUndefined()
+    expect(manager.isSeatReleased()).toBe(true)
+    expect(code.value).toBe('TCP-0000-0000-0000-0001')
+  })
+
+  test('a seat released from another machine drops the code the same way', async () => {
+    // Whichever end the release came from, this device must stop acting on the
+    // code and must not show it as something the user can still use here.
+    const { manager, store, client, code } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    client.listDevices.mockResolvedValue({
+      ok: true,
+      data: { devices: [{ device_id: 'DEVICE-OTHER' }], max_devices: 3 },
+    })
+
+    expect(await manager.verifyDeviceRegistration()).toBe('released')
+
+    expect(manager.isActive()).toBe(false)
+    expect(manager.getStoredCode()).toBeUndefined()
+    expect(code.value).toBe('TCP-0000-0000-0000-0001')
+  })
+
+  test('a released device makes no further requests with the code', async () => {
+    // The latch has to reach every path that reads the stored code, or the
+    // seat list would keep loading and a refresh would retake the seat.
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 0 } })
+
+    await manager.deactivateDevice(manager.getDeviceId())
+    client.deactivateDevice.mockClear()
+
+    expect(await manager.listDevices()).toEqual({
+      ok: false,
+      failure: { ok: false, kind: 'no-code' },
+    })
+    expect(await manager.deactivateDevice('DEVICE-OTHER')).toEqual({
+      ok: false,
+      failure: { ok: false, kind: 'no-code' },
+    })
+    await manager.refreshIfNeeded(true)
+
+    expect(client.listDevices).not.toHaveBeenCalled()
+    expect(client.deactivateDevice).not.toHaveBeenCalled()
+    expect(client.issueToken).not.toHaveBeenCalled()
   })
 
   test('a release is not undone by the next refresh', async () => {
@@ -340,8 +389,10 @@ describe('device management', () => {
     expect(manager.isActive()).toBe(false)
   })
 
-  test('still releases when the settings write fails', async () => {
-    const { manager, store, client } = createHarness({
+  test('releasing this device never touches data.json', async () => {
+    // Nothing is written to settings, so there is no data.json failure that
+    // could turn a seat the server has already freed into "release failed".
+    const { manager, store, client, code } = createHarness({
       code: 'TCP-0000-0000-0000-0001',
       failSetCode: true,
     })
@@ -351,10 +402,9 @@ describe('device management', () => {
 
     const result = await manager.deactivateDevice(manager.getDeviceId())
 
-    // The seat is already gone on the server; a failed data.json write must not
-    // turn that into a rejected promise the UI reports as "release failed".
     expect(result).toEqual({ ok: true, devicesUsed: 0 })
     expect(manager.isActive()).toBe(false)
+    expect(code.value).toBe('TCP-0000-0000-0000-0001')
   })
 
   test('does not call the API without a stored code', async () => {
@@ -533,3 +583,211 @@ describe('onChange', () => {
   })
 })
 
+
+describe('syncFromServer', () => {
+  test('asks about the seat before renewing the token', async () => {
+    // The order is the whole point. Issuing a token re-registers this device
+    // id, so renewing first would hand back a seat released on another machine
+    // and the list would then honestly report the device present — the release
+    // would disappear without a trace.
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+
+    const calls: string[] = []
+    client.listDevices.mockImplementation(() => {
+      calls.push('listDevices')
+      return Promise.resolve({
+        ok: true,
+        data: { devices: [{ device_id: store.getDeviceId() }], max_devices: 3 },
+      })
+    })
+    client.issueToken.mockImplementation(() => {
+      calls.push('issueToken')
+      return Promise.resolve(issued(tokenFor(store), NOW + 7 * DAY))
+    })
+
+    await manager.syncFromServer({ force: true })
+
+    expect(calls[0]).toBe('listDevices')
+  })
+
+  test('does not renew a token for a seat that is gone', async () => {
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    client.listDevices.mockResolvedValue({
+      ok: true,
+      data: { devices: [{ device_id: 'DEVICE-OTHER' }], max_devices: 3 },
+    })
+
+    const state = await manager.syncFromServer({ force: true })
+
+    expect(state).toEqual({ status: 'unlicensed' })
+    expect(client.issueToken).not.toHaveBeenCalled()
+  })
+
+  test('recovers an entitlement that only looked gone offline', async () => {
+    // The token expired while the machine was away. Nothing on disk can tell
+    // that from a revoked license, so the screen would keep saying "not
+    // activated" until something asked.
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store, { expiresAt: NOW - DAY }), NOW - DAY, SUMMARY, NOW - 2 * DAY)
+    manager.initialize()
+    expect(manager.isActive()).toBe(false)
+
+    client.issueToken.mockResolvedValue(issued(tokenFor(store), NOW + 7 * DAY))
+
+    const state = await manager.syncFromServer({ force: true })
+
+    expect(state.status).toBe('active')
+    // No seat to check while unlicensed: the token request is the question.
+    expect(client.listDevices).not.toHaveBeenCalled()
+  })
+
+  test('leaves a released device alone', async () => {
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 0 } })
+    await manager.deactivateDevice(manager.getDeviceId())
+    client.listDevices.mockClear()
+
+    const state = await manager.syncFromServer({ force: true })
+
+    expect(state).toEqual({ status: 'unlicensed' })
+    expect(client.issueToken).not.toHaveBeenCalled()
+    expect(client.listDevices).not.toHaveBeenCalled()
+  })
+
+  test('stops asking about a code the server called invalid', async () => {
+    // Unlike a revoked license, which may be reinstated, a string that is not a
+    // code never becomes one — and every settings visit forces a sync.
+    const { manager, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    manager.initialize()
+    client.issueToken.mockResolvedValue({
+      ok: false,
+      kind: 'api',
+      code: 'invalid_code',
+      status: 404,
+    })
+
+    await manager.syncFromServer({ force: true })
+    await manager.syncFromServer({ force: true })
+
+    expect(client.issueToken).toHaveBeenCalledTimes(1)
+  })
+
+  test('throttles unless forced', async () => {
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    client.listDevices.mockResolvedValue({
+      ok: true,
+      data: { devices: [{ device_id: store.getDeviceId() }], max_devices: 3 },
+    })
+
+    await manager.syncFromServer()
+    await manager.syncFromServer()
+    expect(client.listDevices).toHaveBeenCalledTimes(1)
+
+    // Someone pressing refresh is exactly the case the throttle must not answer
+    // with a cached "nothing to report".
+    await manager.syncFromServer({ force: true })
+    expect(client.listDevices).toHaveBeenCalledTimes(2)
+  })
+
+  test('never rejects, whatever the server does', async () => {
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    client.listDevices.mockRejectedValue(new Error('offline'))
+
+    await expect(manager.syncFromServer({ force: true })).resolves.toBeDefined()
+    expect(manager.isActive()).toBe(true)
+  })
+})
+
+describe('the seat list snapshot', () => {
+  test('one fetch answers both the seat check and the list', async () => {
+    // Opening the Pro screen asks the same question twice at once. Two requests
+    // could come back disagreeing; one cannot.
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+
+    let resolveList: (value: unknown) => void = () => undefined
+    client.listDevices.mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve
+      }),
+    )
+
+    const sync = manager.syncFromServer({ force: true })
+    const list = manager.listDevices()
+    resolveList({
+      ok: true,
+      data: { devices: [{ device_id: store.getDeviceId() }], max_devices: 3 },
+    })
+
+    await sync
+    expect(await list).toEqual({
+      ok: true,
+      devices: [{ device_id: store.getDeviceId() }],
+      maxDevices: 3,
+    })
+    expect(client.listDevices).toHaveBeenCalledTimes(1)
+  })
+
+  test('tells watchers about a list they did not ask for', async () => {
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    client.listDevices.mockResolvedValue({
+      ok: true,
+      data: { devices: [{ device_id: store.getDeviceId() }], max_devices: 3 },
+    })
+
+    const listener = jest.fn()
+    manager.onDevicesChange(listener)
+
+    await manager.syncFromServer({ force: true })
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0].devices).toEqual([{ device_id: store.getDeviceId() }])
+    expect(manager.getDeviceSnapshot()?.maxDevices).toBe(3)
+  })
+
+  test('drops a released seat without re-fetching', async () => {
+    const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    client.listDevices.mockResolvedValue({
+      ok: true,
+      data: {
+        devices: [{ device_id: store.getDeviceId() }, { device_id: 'DEVICE-OTHER' }],
+        max_devices: 3,
+      },
+    })
+    client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 1 } })
+    await manager.listDevices()
+    client.listDevices.mockClear()
+
+    await manager.deactivateDevice('DEVICE-OTHER')
+
+    expect(manager.getDeviceSnapshot()?.devices).toEqual([{ device_id: store.getDeviceId() }])
+    expect(client.listDevices).not.toHaveBeenCalled()
+  })
+
+  test('an explicit code is not coalesced with the stored one', async () => {
+    // The 409 list belongs to the code being typed, which may be a different
+    // license than the one already stored.
+    const { manager, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
+    manager.initialize()
+    client.listDevices.mockResolvedValue({ ok: true, data: { devices: [], max_devices: 3 } })
+
+    await Promise.all([manager.listDevices(), manager.listDevices('TCP-9999-9999-9999-9999')])
+
+    expect(client.listDevices).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/features/license/pro-settings-section.test.ts
+++ b/tests/features/license/pro-settings-section.test.ts
@@ -38,11 +38,16 @@ function fakeManager(
     isActive: () => false,
     getDeviceId: () => 'DEVICE-0001',
     getLicenseSummary: () => undefined,
+    // What the screen may show and act with, which is not simply
+    // settings.licenseCode: a device that gave up its seat has none.
+    getStoredCode: () => undefined,
+    isSeatReleased: () => false,
     activate: jest.fn(),
     listDevices: jest.fn(),
     deactivateDevice: jest.fn(),
     refreshIfNeeded: jest.fn().mockResolvedValue(undefined),
     verifyDeviceRegistration: jest.fn().mockResolvedValue('unknown'),
+    syncFromServer: jest.fn().mockResolvedValue({ status: 'unlicensed' }),
     onChange: jest.fn(() => () => undefined),
     ...overrides,
   } as unknown as LicenseManager
@@ -55,11 +60,15 @@ const ACTIVE_SUMMARY = {
   expires_at: null,
 }
 
-function activeManager(): LicenseManager {
+function activeManager(storedCode?: string): LicenseManager {
   return fakeManager({
     getState: () => ({ status: 'active', token: {}, license: ACTIVE_SUMMARY }),
     isActive: () => true,
     getLicenseSummary: () => ACTIVE_SUMMARY,
+    getStoredCode: () => storedCode,
+    syncFromServer: jest
+      .fn()
+      .mockResolvedValue({ status: 'active', token: {}, license: ACTIVE_SUMMARY }),
   })
 }
 
@@ -357,11 +366,25 @@ describe('Pro settings section', () => {
     test('shows the code that was entered, not the id derived from it', () => {
       // What the user holds and would re-enter elsewhere is the code; the id
       // means nothing to them.
-      const items = proItems(activeManager(), 'TCP-AAAA-BBBB-CCCC-DDDD')
+      const items = proItems(
+        activeManager('TCP-AAAA-BBBB-CCCC-DDDD'),
+        'TCP-AAAA-BBBB-CCCC-DDDD',
+      )
 
       expect(names(items)).toContain('License code')
       expect(names(items)).not.toContain('License ID')
       expect(descs(items)).toContain('TCP-AAAA-BBBB-CCCC-DDDD')
+    })
+
+    test('falls back to the license id once this device gave up its seat', () => {
+      // The code is still in data.json — it has to be, other machines share it
+      // — but this device may no longer use it, so showing it here would be
+      // offering something that does nothing.
+      const items = proItems(activeManager(), 'TCP-AAAA-BBBB-CCCC-DDDD')
+
+      expect(names(items)).not.toContain('License code')
+      expect(descs(items)).not.toContain('TCP-AAAA-BBBB-CCCC-DDDD')
+      expect(names(items)).toContain('License ID')
     })
 
     test('drops the status and expiry rows', () => {
@@ -483,5 +506,31 @@ describe('Pro settings section', () => {
     expect(descs(items).some((desc) => desc.includes('unexpected error'))).toBe(
       true,
     )
+  })
+})
+
+describe('when the Pro page is shown', () => {
+  // The page's items are built with the rest of the tab's definitions, long
+  // before anyone navigates into it. A row's render callback is the only thing
+  // that runs at the moment the page is actually drawn, which makes it the hook
+  // for "check whether this device is still licensed".
+  test('the activation form re-asks the server', () => {
+    const manager = fakeManager()
+    const row = codeItem(manager)
+    ;(manager.syncFromServer as jest.Mock).mockClear()
+
+    invokeRender(row)
+
+    expect(manager.syncFromServer).toHaveBeenCalled()
+  })
+
+  test('the seat list re-asks the server', () => {
+    const manager = activeManager()
+    const row = deviceItem(manager)
+    ;(manager.syncFromServer as jest.Mock).mockClear()
+
+    invokeRender(row)
+
+    expect(manager.syncFromServer).toHaveBeenCalled()
   })
 })

--- a/tests/features/license/seat-registration-check.test.ts
+++ b/tests/features/license/seat-registration-check.test.ts
@@ -1,12 +1,16 @@
 /**
  * Losing the seat happens on another machine, so this dialog is the only thing
  * that tells the user why the AI task UI vanished here. It must fire on a real
- * release and never on a failed check.
+ * release and never on a failed sync — and the `changed` it reports is what
+ * makes the settings screen redraw, so a sync that moved nothing must say so.
  */
 import type { App } from 'obsidian'
 
 import { checkSeatRegistration } from '../../../src/features/license/ui/notifySeatReleased'
-import type { LicenseManager } from '../../../src/features/license/services/LicenseManager'
+import type {
+  LicenseManager,
+  LicenseState,
+} from '../../../src/features/license/services/LicenseManager'
 
 jest.mock('../../../src/ui/modals/ConfirmModal', () => ({
   showInfoModal: jest.fn(() => Promise.resolve()),
@@ -16,10 +20,35 @@ const { showInfoModal } = require('../../../src/ui/modals/ConfirmModal') as {
   showInfoModal: jest.Mock
 }
 
-function createHost(manager?: Partial<LicenseManager>) {
+const ACTIVE = { status: 'active', token: {} } as unknown as LicenseState
+const UNLICENSED = { status: 'unlicensed' } as LicenseState
+
+/**
+ * @param before  what the manager reported before the sync
+ * @param after   what syncFromServer resolves to, or a rejection
+ * @param released whether the latch is set afterwards
+ */
+function createHost(options: {
+  before?: LicenseState
+  after?: LicenseState | Error
+  released?: boolean
+  manager?: false
+}) {
+  const after = options.after ?? options.before ?? UNLICENSED
+  const manager =
+    options.manager === false
+      ? undefined
+      : ({
+          getState: jest.fn(() => options.before ?? UNLICENSED),
+          isSeatReleased: jest.fn(() => options.released === true),
+          syncFromServer: jest.fn(() =>
+            after instanceof Error ? Promise.reject(after) : Promise.resolve(after),
+          ),
+        } as unknown as LicenseManager)
+
   return {
     app: {} as App,
-    licenseManager: manager as LicenseManager | undefined,
+    licenseManager: manager,
     _log: jest.fn(),
   }
 }
@@ -29,11 +58,12 @@ beforeEach(() => {
 })
 
 test('tells the user when the seat is gone', async () => {
-  const host = createHost({
-    verifyDeviceRegistration: jest.fn().mockResolvedValue('released'),
-  })
+  const host = createHost({ before: ACTIVE, after: UNLICENSED, released: true })
 
-  await expect(checkSeatRegistration(host)).resolves.toBe('released')
+  await expect(checkSeatRegistration(host)).resolves.toEqual({
+    state: UNLICENSED,
+    changed: true,
+  })
 
   expect(showInfoModal).toHaveBeenCalledTimes(1)
   const options = showInfoModal.mock.calls[0][1] as { title: string; message: string }
@@ -42,35 +72,73 @@ test('tells the user when the seat is gone', async () => {
 })
 
 test('stays quiet while the device is still registered', async () => {
-  const host = createHost({
-    verifyDeviceRegistration: jest.fn().mockResolvedValue('registered'),
-  })
+  const host = createHost({ before: ACTIVE, after: ACTIVE })
 
-  await expect(checkSeatRegistration(host)).resolves.toBe('registered')
+  await expect(checkSeatRegistration(host)).resolves.toEqual({
+    state: ACTIVE,
+    changed: false,
+  })
   expect(showInfoModal).not.toHaveBeenCalled()
 })
 
-test('stays quiet when the check could not run', async () => {
-  const host = createHost({
-    verifyDeviceRegistration: jest.fn().mockResolvedValue('unknown'),
-  })
+test('reports a change when the sync activated this device', async () => {
+  // Activated on another machine, or simply recovered from an expired token:
+  // the screen drew "not activated" and has to be told to draw it again.
+  const host = createHost({ before: UNLICENSED, after: ACTIVE })
 
-  await expect(checkSeatRegistration(host)).resolves.toBe('unknown')
+  await expect(checkSeatRegistration(host)).resolves.toEqual({
+    state: ACTIVE,
+    changed: true,
+  })
   expect(showInfoModal).not.toHaveBeenCalled()
 })
 
-test('swallows a thrown check so startup is never derailed', async () => {
-  const host = createHost({
-    verifyDeviceRegistration: jest.fn().mockRejectedValue(new Error('boom')),
-  })
+test('does not blame the seat for a license the server blocked', async () => {
+  // Revoked or suspended is not a released seat, and pointing the user at the
+  // device list would send them somewhere that cannot help.
+  const blocked = { status: 'blocked', reason: 'license_revoked' } as LicenseState
+  const host = createHost({ before: ACTIVE, after: blocked, released: false })
 
-  await expect(checkSeatRegistration(host)).resolves.toBe('unknown')
+  await expect(checkSeatRegistration(host)).resolves.toEqual({
+    state: blocked,
+    changed: true,
+  })
+  expect(showInfoModal).not.toHaveBeenCalled()
+})
+
+test('stays quiet when the sync could not reach the server', async () => {
+  const host = createHost({ before: ACTIVE, after: ACTIVE })
+
+  await expect(checkSeatRegistration(host)).resolves.toEqual({
+    state: ACTIVE,
+    changed: false,
+  })
+  expect(showInfoModal).not.toHaveBeenCalled()
+})
+
+test('swallows a thrown sync so startup is never derailed', async () => {
+  const host = createHost({ before: ACTIVE, after: new Error('boom') })
+
+  await expect(checkSeatRegistration(host)).resolves.toEqual({
+    state: ACTIVE,
+    changed: false,
+  })
 
   expect(showInfoModal).not.toHaveBeenCalled()
   expect(host._log).toHaveBeenCalled()
 })
 
+test('passes force through to the manager', async () => {
+  const host = createHost({ before: ACTIVE, after: ACTIVE })
+
+  await checkSeatRegistration(host, { force: true })
+
+  expect(host.licenseManager?.syncFromServer).toHaveBeenCalledWith({ force: true })
+})
+
 test('does nothing without a license manager', async () => {
-  await expect(checkSeatRegistration(createHost(undefined))).resolves.toBe('unknown')
+  await expect(checkSeatRegistration(createHost({ manager: false }))).resolves.toEqual({
+    changed: false,
+  })
   expect(showInfoModal).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Whether the AI task settings appeared depended on when the plugin last happened to ask the licence server, and the answer it got could be wrong.

## The seat check ran after the refresh

Issuing a token re-registers this device id. A refresh that ran first therefore handed back a seat released on another machine, and the device list then honestly reported the device present — so the release vanished without a trace.

`syncFromServer()` now owns the order: seats first, token second, and no token request at all for a seat that is gone.

## Nothing re-checked once the state was inactive

`verifyDeviceRegistration()` returned early unless the licence was already active. A token that merely expired while the machine was offline, or a licence un-suspended since, stayed dark until a restart. The sync now asks for a token in that case.

A code the server calls `invalid_code` is remembered so it is not asked about again — unlike a revoked licence, which may be reinstated, a string that is not a code never becomes one.

## Where the check runs

| When | Forced? |
|---|---|
| The task list opens | throttled |
| The settings tab is entered | **forced** |
| The Pro page is drawn | throttled |
| The new **Refresh** button on the seat list | **forced** |
| Startup, and every 12 h | throttled |

The Pro page is throttled rather than forced on purpose. `display()` is not called for a tab that returns definitions, so the hook is a row's `render` callback — which runs again on every redraw, including the redraw a changed answer causes. Entering the settings tab has already forced one, so the page reuses an answer at most a minute old.

## Throwing the code away

Releasing a seat used to delete `settings.licenseCode` when the user did it here, and keep it when another device did it for them. Neither is right: the code is shared through `data.json`, so deleting it takes the licence off every other machine, while keeping it leaves the settings field offering a code this device may no longer use.

Both paths now latch the device-local `seatReleasedAt` and read the code through it. The code is thrown away exactly where it has to be — on the one device that lost its seat — and nowhere else. Only an explicit activation lifts the latch.

## Refreshing the screen

The seat list and the entitlement came from two separate requests that could come back disagreeing. `listDevices()` coalesces them, so one fetch answers both, and every mounted list hears the result through `onDevicesChange`.

## One actuator at a time

`syncAiTaskManagerToLicense` ran twice per change — once from the licence listener in `main.ts`, once from the settings screen, which has to await its own call before redrawing. They share the manager slot and the pending-disposal set, so one could build a runtime while the other was still tearing that very runtime down. It is now serialized per plugin.

## Testing

`npx jest` — 3334 tests across 228 suites pass. `tsc --noEmit` and `npm run lint` are clean.

New coverage: the check/refresh ordering, recovery from an inactive state, the invalid-code guard, the throttle and its bypass, the coalesced fetch and its listeners, the latch reaching every path that reads the code, the Refresh button, the Pro page render hook, and the serialized gate.

Manual checks worth doing on two machines: activate; release **this** device from the list; release it from the other machine and confirm the dialog appears and the other machine keeps working; then re-enter the code on both.
