### PR TITLE
Repair what conversation mode shows

### DIFF
--- a/src/features/ai-task/services/AiResultSummary.ts
+++ b/src/features/ai-task/services/AiResultSummary.ts
@@ -1,0 +1,20 @@
+/**
+ * AI Task - result event summary
+ *
+ * One formatting of a run's terminating `result` event, shared by the log
+ * note and the run pane. The event carries `text` — the CLI's own copy of the
+ * final assistant message — which both surfaces must NOT render as body text:
+ * the same words already arrived as an `assistant-text` event, and printing
+ * them again showed every answer twice in the pane.
+ */
+
+import type { AiResultEvent } from '../types'
+
+/** `success (cost $0.01, 2 turns)` — label plus whatever metadata is present. */
+export function formatAiResultSummary(event: AiResultEvent): string {
+  const label = event.subtype ?? (event.isError ? 'error' : 'success')
+  const details: string[] = []
+  if (event.totalCostUsd !== undefined) details.push(`cost $${event.totalCostUsd}`)
+  if (event.numTurns !== undefined) details.push(`${event.numTurns} turns`)
+  return details.length > 0 ? `${label} (${details.join(', ')})` : label
+}

--- a/src/features/ai-task/services/AiTaskLogWriter.ts
+++ b/src/features/ai-task/services/AiTaskLogWriter.ts
@@ -16,6 +16,7 @@
 import { TFile } from 'obsidian'
 import { listFilesInFolder } from '../../../utils/vaultFiles'
 import type { AiResultEvent, AiRunRecord, AiStreamEvent } from '../types'
+import { formatAiResultSummary } from './AiResultSummary'
 
 /** Maximum stderr lines preserved at the end of a run log note */
 export const STDERR_TAIL_LIMIT = 50
@@ -141,12 +142,7 @@ function composeInitLine(event: Extract<AiStreamEvent, { kind: 'init' }>): strin
 }
 
 function composeResultLine(event: AiResultEvent): string {
-  const label = event.subtype ?? (event.isError ? 'error' : 'success')
-  const details: string[] = []
-  if (event.totalCostUsd !== undefined) details.push(`cost $${event.totalCostUsd}`)
-  if (event.numTurns !== undefined) details.push(`${event.numTurns} turns`)
-  const suffix = details.length > 0 ? ` (${details.join(', ')})` : ''
-  return `- [result] ${label}${suffix}`
+  return `- [result] ${formatAiResultSummary(event)}`
 }
 
 function composeTranscript(events: AiStreamEvent[]): string[] {

--- a/src/features/ai-task/services/NodeProcessGateway.ts
+++ b/src/features/ai-task/services/NodeProcessGateway.ts
@@ -22,6 +22,7 @@ import { Platform } from 'obsidian'
 
 import { stableTimeoutSource } from '../../../utils/stableTimer'
 import { parseDescendantSnapshot } from './process/parseDescendantSnapshot'
+import { isPtyPlatformSupported } from './ptyPlatform'
 
 // Ambient declarations for the Electron renderer runtime (no @types/node in
 // the src build). These shadow nothing at runtime; they only inform tsc.
@@ -1407,8 +1408,7 @@ export class NodeProcessGateway implements ProcessGateway, WorkspaceFileGateway 
   }
 
   isPtySupported(): boolean {
-    const platform = this.getPlatform()
-    return platform === 'darwin' || platform === 'linux'
+    return isPtyPlatformSupported(this.getPlatform())
   }
 
   buildPtyCommand(request: PtyCommandRequest): PtyCommand {

--- a/src/features/ai-task/services/ptyPlatform.ts
+++ b/src/features/ai-task/services/ptyPlatform.ts
@@ -1,0 +1,30 @@
+/**
+ * AI Task - PTY platform predicate
+ *
+ * The single place that answers "can this OS host an embedded terminal?".
+ * Terminal mode wraps the CLI in the POSIX `script(1)` utility to obtain a
+ * real tty; Windows ships no equivalent an external command can drive, so
+ * runs there always fall back to the conversation pipeline.
+ *
+ * Deliberately a standalone module with no imports: NodeProcessGateway owns
+ * the runtime behaviour but pulls in Node builtins, while the settings tab
+ * needs the same answer on every platform (including mobile, where requiring
+ * a Node builtin is forbidden — see "gate every Node builtin behind
+ * Platform.isDesktop").
+ */
+
+import { Platform } from 'obsidian'
+
+export function isPtyPlatformSupported(platform: string): boolean {
+  return platform === 'darwin' || platform === 'linux'
+}
+
+/**
+ * The same answer for callers that hold no `process` — the settings tab runs
+ * on mobile too, where reading `process.platform` is not allowed. Kept beside
+ * the string predicate so the supported set is stated once.
+ */
+export function isTerminalModeSupportedHere(): boolean {
+  if (!Platform.isDesktop) return false
+  return Platform.isMacOS === true || Platform.isLinux === true
+}

--- a/src/features/ai-task/services/streams/StreamJsonParser.ts
+++ b/src/features/ai-task/services/streams/StreamJsonParser.ts
@@ -160,6 +160,23 @@ function rawEvent(line: string): AiStreamEvent[] {
   return [{ kind: 'raw', text: capTextTail(line) }]
 }
 
+/**
+ * A line whose envelope parsed but whose `type` (and `subtype`) this parser
+ * does not render. Only the discriminators survive: dumping the whole line
+ * floods the pane and the log note with payloads that carry nothing readable
+ * (Claude's `system` subtypes such as `api_retry` are the common case), while
+ * the type name is enough to tell what was skipped.
+ */
+function unhandledLabel(label: string): AiStreamEvent[] {
+  return [{ kind: 'raw', text: `[unhandled] ${label}` }]
+}
+
+function unhandledEvent(payload: UnknownRecord): AiStreamEvent[] {
+  const type = capField(asString(payload['type'])) ?? 'unknown'
+  const subtype = capField(asString(payload['subtype']))
+  return unhandledLabel(subtype === undefined ? type : `${type}/${subtype}`)
+}
+
 function tryParseRecord(line: string): UnknownRecord | null {
   try {
     const parsed: unknown = JSON.parse(line)
@@ -173,11 +190,18 @@ function tryParseRecord(line: string): UnknownRecord | null {
 // Claude Code: `claude -p PROMPT --output-format stream-json --verbose`
 // ---------------------------------------------------------------------------
 
-function parseClaudeAssistant(payload: UnknownRecord): AiStreamEvent[] {
+/**
+ * `null` means the envelope is malformed (no `message.content` array), so the
+ * caller degrades to a full `raw` dump. An empty array means the message was
+ * well formed and simply held nothing this parser renders — Claude emits an
+ * assistant message carrying only a `thinking` block every turn, and dumping
+ * those raw buried the pane under signed base64.
+ */
+function parseClaudeAssistant(payload: UnknownRecord): AiStreamEvent[] | null {
   const message = payload['message']
-  if (!isRecord(message)) return []
+  if (!isRecord(message)) return null
   const content = message['content']
-  if (!Array.isArray(content)) return []
+  if (!Array.isArray(content)) return null
 
   const accumulator: LineEventAccumulator = { events: [], omittedCount: 0 }
   for (const block of content) {
@@ -216,11 +240,12 @@ function extractToolResultText(content: unknown): string | undefined {
   return parts.length > 0 ? parts.join('\n') : undefined
 }
 
-function parseClaudeUser(payload: UnknownRecord): AiStreamEvent[] {
+/** Same null-vs-empty contract as parseClaudeAssistant. */
+function parseClaudeUser(payload: UnknownRecord): AiStreamEvent[] | null {
   const message = payload['message']
-  if (!isRecord(message)) return []
+  if (!isRecord(message)) return null
   const content = message['content']
-  if (!Array.isArray(content)) return []
+  if (!Array.isArray(content)) return null
 
   const accumulator: LineEventAccumulator = { events: [], omittedCount: 0 }
   for (const block of content) {
@@ -236,7 +261,10 @@ function parseClaudeUser(payload: UnknownRecord): AiStreamEvent[] {
 
 /**
  * Parse one line of Claude Code stream-json output.
- * Returns [] for blank lines; falls back to a raw event otherwise.
+ * Returns [] for blank lines and for well-formed messages that carry nothing
+ * to render. A line that does not parse as JSON degrades to a full `raw`
+ * dump; a recognized envelope this parser does not handle degrades to the
+ * short `[unhandled] type/subtype` marker instead.
  */
 export function parseClaudeLine(line: string): AiStreamEvent[] {
   if (line.trim().length === 0) return []
@@ -254,12 +282,10 @@ export function parseClaudeLine(line: string): AiStreamEvent[] {
     ]
   }
   if (type === 'assistant') {
-    const events = parseClaudeAssistant(payload)
-    return events.length > 0 ? events : rawEvent(line)
+    return parseClaudeAssistant(payload) ?? rawEvent(line)
   }
   if (type === 'user') {
-    const events = parseClaudeUser(payload)
-    return events.length > 0 ? events : rawEvent(line)
+    return parseClaudeUser(payload) ?? rawEvent(line)
   }
   if (type === 'result') {
     return [
@@ -273,7 +299,7 @@ export function parseClaudeLine(line: string): AiStreamEvent[] {
       },
     ]
   }
-  return rawEvent(line)
+  return unhandledEvent(payload)
 }
 
 // ---------------------------------------------------------------------------
@@ -314,7 +340,7 @@ function parseCodexCompletedItem(
     }
     return events
   }
-  return rawEvent(line)
+  return unhandledLabel(`item.completed/${capField(itemType) ?? 'unknown'}`)
 }
 
 /**
@@ -383,5 +409,5 @@ export function parseCodexLine(line: string): AiStreamEvent[] {
       },
     ]
   }
-  return rawEvent(line)
+  return unhandledEvent(payload)
 }

--- a/src/features/ai-task/ui/AiRunPaneController.ts
+++ b/src/features/ai-task/ui/AiRunPaneController.ts
@@ -103,6 +103,7 @@ import {
   type AiRunChangeType,
   type AiShellSessionOptions,
 } from '../services/AiTaskManager'
+import { formatAiResultSummary } from '../services/AiResultSummary'
 import { AiBinaryNotFoundError } from '../services/BinaryLocator'
 import {
   formatWorkspacePathForTerminal,
@@ -2610,8 +2611,16 @@ export class AiRunPaneController {
         return this.formatToolUse(event.toolName, event.input)
       case 'tool-result':
         return event.text ?? ''
-      case 'result':
-        return event.text ?? event.subtype ?? 'result'
+      case 'result': {
+        // `event.text` is the CLI's copy of the final assistant message, which
+        // already arrived as an assistant-text event; rendering it here showed
+        // every answer twice. Errors are the exception: nothing else carries
+        // their body.
+        const summary = formatAiResultSummary(event)
+        return event.isError === true && event.text !== undefined
+          ? `${summary}\n${event.text}`
+          : summary
+      }
       case 'stderr':
         return event.text
       case 'raw':

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -98,7 +98,9 @@ export const en = {
         "Run tasks with the Claude or Codex CLI inside the AI run pane (desktop only).",
       runModeName: "Run mode",
       runModeDesc:
-        "Terminal embeds the interactive CLI session on macOS and Linux; conversation mode streams parsed events and supports follow-up input on every desktop platform. Windows automatically uses it because the plugin does not bundle a native pseudoterminal runtime.",
+        "Terminal embeds the interactive CLI session. Conversation mode streams parsed events and supports follow-up input instead.",
+      runModeFixedDesc:
+        "Conversation mode. This platform has no pseudoterminal the plugin can drive, so runs stream parsed events and take follow-up input instead of embedding the interactive CLI.",
       runModeTerminal: "Terminal (interactive)",
       runModeHeadless: "Conversation (cross-platform)",
       claudePathName: "Claude CLI path (advanced fallback)",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -94,7 +94,9 @@ export const ja = {
         "AI CLI（Claude Code / Codex）でタスクを実行し、AI実行ペインに表示します（デスクトップ専用）。",
       runModeName: "実行モード",
       runModeDesc:
-        "ターミナルはmacOS / Linuxで対話型CLIを埋め込みます。会話モードは全デスクトップOSで解析済みイベントとフォローアップ入力に対応します。ネイティブConPTYを同梱していないため、Windowsでは自動的に会話モードを使用します。",
+        "ターミナルは対話型CLIをそのまま埋め込みます。会話モードは解析済みイベントを流し、フォローアップ入力を受け付けます。",
+      runModeFixedDesc:
+        "会話モードで実行します。このプラットフォームには本プラグインから扱える疑似端末がないため、対話型CLIを埋め込む代わりに、解析済みイベントの表示とフォローアップ入力で動作します。",
       runModeTerminal: "ターミナル（対話型）",
       runModeHeadless: "会話モード（全OS対応）",
       claudePathName: "Claude Code CLIパス（詳細・予備）",

--- a/src/settings/sections/pro/aiTask.ts
+++ b/src/settings/sections/pro/aiTask.ts
@@ -1,7 +1,8 @@
 import { Notice } from "obsidian"
-import type { Setting, SettingDefinitionRender } from "obsidian"
+import type { Setting, SettingDefinition, SettingDefinitionRender } from "obsidian"
 import { t } from "../../../i18n"
 import { ElectronDirectoryPicker } from "../../../features/ai-task/services/ElectronDirectoryPicker"
+import { isTerminalModeSupportedHere } from "../../../features/ai-task/services/ptyPlatform"
 import type { TaskChuteSettings } from "../../../types"
 import { DEFAULT_SETTINGS } from "../../defaults"
 import { clampedNumber, choice } from "../../controlHandlers"
@@ -152,6 +153,48 @@ function cliPathRow(
 }
 
 /**
+ * The run-mode row, or the note that replaces it.
+ *
+ * Terminal mode needs a pseudoterminal the plugin can drive through an
+ * external command, which exists only on macOS and Linux; elsewhere
+ * `resolveRunMode()` degrades every run to the conversation pipeline no matter
+ * what this setting holds. Offering the choice there showed "Terminal
+ * (interactive)" to Windows users whose runs were never going to be terminal
+ * runs, so the row becomes a plain explanation instead. The stored value is
+ * left untouched: carrying the vault to a Mac restores the original choice.
+ */
+function runModeRow(): SettingDefinition<keyof TaskChuteSettings> {
+  if (!isTerminalModeSupportedHere()) {
+    return {
+      name: t("settings.aiTask.runModeName", "Run mode"),
+      desc: t(
+        "settings.aiTask.runModeFixedDesc",
+        "Conversation mode. This platform has no pseudoterminal the plugin can drive, so runs stream parsed events and take follow-up input instead of embedding the interactive CLI.",
+      ),
+    }
+  }
+  return {
+    name: t("settings.aiTask.runModeName", "Run mode"),
+    desc: t(
+      "settings.aiTask.runModeDesc",
+      "Terminal embeds the interactive CLI session. Conversation mode streams parsed events and supports follow-up input instead.",
+    ),
+    control: {
+      type: "dropdown",
+      key: "aiTaskRunMode",
+      defaultValue: "terminal",
+      options: {
+        terminal: t("settings.aiTask.runModeTerminal", "Terminal (interactive)"),
+        headless: t(
+          "settings.aiTask.runModeHeadless",
+          "Conversation (cross-platform)",
+        ),
+      },
+    },
+  }
+}
+
+/**
  * Everything a Pro license unlocks. Only reached from the Pro page, which has
  * already checked entitlement.
  */
@@ -176,28 +219,7 @@ export function aiTaskSection(guard: AiTaskToggleGuard): SectionModule {
               defaultValue: false,
             },
           },
-          {
-            name: t("settings.aiTask.runModeName", "Run mode"),
-            desc: t(
-              "settings.aiTask.runModeDesc",
-              "Terminal embeds the interactive CLI session on macOS and Linux; conversation mode streams parsed events and supports follow-up input on every desktop platform. Windows automatically uses it because the plugin does not bundle a native pseudoterminal runtime.",
-            ),
-            control: {
-              type: "dropdown",
-              key: "aiTaskRunMode",
-              defaultValue: "terminal",
-              options: {
-                terminal: t(
-                  "settings.aiTask.runModeTerminal",
-                  "Terminal (interactive)",
-                ),
-                headless: t(
-                  "settings.aiTask.runModeHeadless",
-                  "Conversation (cross-platform)",
-                ),
-              },
-            },
-          },
+          runModeRow(),
           ...paths.map((path) => cliPathRow(ctx, path)),
           {
             name: t("settings.aiTask.retentionName", "Run log retention (days)"),

--- a/tests/features/ai-task/ai-run-pane-controller.test.ts
+++ b/tests/features/ai-task/ai-run-pane-controller.test.ts
@@ -160,6 +160,55 @@ describe('AiRunPaneController', () => {
     ).toBe(true)
   })
 
+  /**
+   * The CLI's terminating `result` message repeats the final assistant text.
+   * Rendering it as body text printed every answer twice in the pane, so the
+   * row now shows the same summary the log note carries.
+   */
+  test('summarizes a result event instead of repeating the answer', () => {
+    controller.mount(container)
+    const run = createRun()
+    manager.emit(run)
+
+    run.events.push({ kind: 'assistant-text', text: 'The answer is 42.' })
+    run.events.push({
+      kind: 'result',
+      subtype: 'success',
+      isError: false,
+      totalCostUsd: 0.01,
+      numTurns: 2,
+      text: 'The answer is 42.',
+    })
+    manager.emit(run)
+    flushEventFrame()
+
+    const events = container.querySelectorAll('.ai-run-pane__event')
+    expect(events).toHaveLength(2)
+    expect(events[0].textContent).toBe('The answer is 42.')
+    expect(events[1].textContent).toBe('success (cost $0.01, 2 turns)')
+  })
+
+  test('keeps the body of an error result, which nothing else carries', () => {
+    controller.mount(container)
+    const run = createRun()
+    manager.emit(run)
+
+    run.events.push({
+      kind: 'result',
+      subtype: 'error_during_execution',
+      isError: true,
+      text: 'the CLI ran out of credits',
+    })
+    manager.emit(run)
+    flushEventFrame()
+
+    const events = container.querySelectorAll('.ai-run-pane__event')
+    expect(events).toHaveLength(1)
+    expect(events[0].textContent).toBe(
+      'error_during_execution\nthe CLI ran out of credits',
+    )
+  })
+
   test('appends only new events on repeated notifications', () => {
     controller.mount(container)
     const run = createRun()

--- a/tests/features/ai-task/ai-task-settings-section.test.ts
+++ b/tests/features/ai-task/ai-task-settings-section.test.ts
@@ -146,9 +146,20 @@ const CODEX_PATH_NAME = 'Codex CLI path (advanced fallback)'
 describe('TaskChute AI task settings section', () => {
   const createAiTaskManagerMock = createAiTaskManager as jest.Mock
 
+  // The run-mode row only offers a choice where a pseudoterminal exists, so
+  // every test that is not about that branch runs as macOS.
+  beforeEach(() => {
+    Platform.isMacOS = true
+    Platform.isLinux = false
+    Platform.isWin = false
+  })
+
   afterEach(() => {
     jest.clearAllMocks()
     mockApp.workspace.getLeavesOfType.mockReturnValue([])
+    delete (Platform as Partial<typeof Platform>).isMacOS
+    delete (Platform as Partial<typeof Platform>).isLinux
+    delete (Platform as Partial<typeof Platform>).isWin
   })
 
   test('is disabled by default with a 30-day retention', () => {
@@ -165,6 +176,31 @@ describe('TaskChute AI task settings section', () => {
     expect(findByKey(items, 'aiTaskLogRetentionDays')?.control.type).toBe(
       'number',
     )
+  })
+
+  /**
+   * resolveRunMode() degrades every run to the conversation pipeline where no
+   * pseudoterminal exists, so offering "Terminal (interactive)" there named a
+   * mode the platform could never enter. The row becomes an explanation, and
+   * the stored value is left alone so moving the vault to a Mac restores it.
+   */
+  test('replaces the run mode choice with a note where no pseudoterminal exists', () => {
+    Platform.isMacOS = false
+    Platform.isLinux = false
+    Platform.isWin = true
+
+    const { tab, plugin } = createTab()
+    plugin.settings.aiTaskRunMode = 'terminal'
+
+    const items = tab.getSettingDefinitions()
+    expect(findByKey(items, 'aiTaskRunMode')).toBeUndefined()
+
+    const row = findByName(items, 'Run mode')
+    expect(row).toBeDefined()
+    expect(row?.control).toBeUndefined()
+    expect(row?.desc).toContain('Conversation mode')
+    // Left untouched: the choice survives a move to a supported platform.
+    expect(plugin.settings.aiTaskRunMode).toBe('terminal')
   })
 
   /**

--- a/tests/features/ai-task/pty-platform.test.ts
+++ b/tests/features/ai-task/pty-platform.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The one predicate that decides whether terminal mode is on the table.
+ *
+ * Two entry points answer it — the gateway holds `process.platform`, the
+ * settings tab holds only Obsidian's Platform — and they must never disagree,
+ * because the settings tab uses its answer to decide whether to offer a mode
+ * that AiTaskManager would silently refuse.
+ */
+import { Platform } from 'obsidian'
+import {
+  isPtyPlatformSupported,
+  isTerminalModeSupportedHere,
+} from '../../../src/features/ai-task/services/ptyPlatform'
+
+describe('isPtyPlatformSupported', () => {
+  test('accepts the platforms that ship script(1)', () => {
+    expect(isPtyPlatformSupported('darwin')).toBe(true)
+    expect(isPtyPlatformSupported('linux')).toBe(true)
+  })
+
+  test('rejects Windows and anything unrecognized', () => {
+    expect(isPtyPlatformSupported('win32')).toBe(false)
+    expect(isPtyPlatformSupported('freebsd')).toBe(false)
+    expect(isPtyPlatformSupported('')).toBe(false)
+  })
+})
+
+describe('isTerminalModeSupportedHere', () => {
+  const original = {
+    isDesktop: Platform.isDesktop,
+    isMacOS: Platform.isMacOS,
+    isLinux: Platform.isLinux,
+  }
+
+  afterEach(() => {
+    Platform.isDesktop = original.isDesktop
+    Platform.isMacOS = original.isMacOS
+    Platform.isLinux = original.isLinux
+  })
+
+  test('agrees with the string predicate on every desktop platform', () => {
+    Platform.isDesktop = true
+
+    Platform.isMacOS = true
+    Platform.isLinux = false
+    expect(isTerminalModeSupportedHere()).toBe(isPtyPlatformSupported('darwin'))
+
+    Platform.isMacOS = false
+    Platform.isLinux = true
+    expect(isTerminalModeSupportedHere()).toBe(isPtyPlatformSupported('linux'))
+
+    Platform.isLinux = false
+    expect(isTerminalModeSupportedHere()).toBe(isPtyPlatformSupported('win32'))
+  })
+
+  test('refuses mobile even when the OS family would qualify', () => {
+    Platform.isDesktop = false
+    Platform.isMacOS = true
+    Platform.isLinux = false
+    expect(isTerminalModeSupportedHere()).toBe(false)
+  })
+})

--- a/tests/features/ai-task/stream-json-parser.test.ts
+++ b/tests/features/ai-task/stream-json-parser.test.ts
@@ -37,9 +37,16 @@ describe('parseClaudeLine', () => {
     ])
   })
 
-  test('treats system events with other subtypes as raw', () => {
-    const line = JSON.stringify({ type: 'system', subtype: 'compact' })
-    expect(parseClaudeLine(line)).toEqual([{ kind: 'raw', text: line }])
+  test('reduces system events with other subtypes to a short marker', () => {
+    const line = JSON.stringify({
+      type: 'system',
+      subtype: 'api_retry',
+      attempt: 1,
+      error: 'overloaded',
+    })
+    expect(parseClaudeLine(line)).toEqual([
+      { kind: 'raw', text: '[unhandled] system/api_retry' },
+    ])
   })
 
   test('parses assistant text blocks', () => {
@@ -78,20 +85,43 @@ describe('parseClaudeLine', () => {
     ])
   })
 
-  test('treats an assistant event without recognizable content as raw', () => {
+  test('treats an assistant event with a malformed message as raw', () => {
     const noMessage = JSON.stringify({ type: 'assistant' })
     expect(parseClaudeLine(noMessage)).toEqual([{ kind: 'raw', text: noMessage }])
 
     const nullMessage = JSON.stringify({ type: 'assistant', message: null })
     expect(parseClaudeLine(nullMessage)).toEqual([{ kind: 'raw', text: nullMessage }])
 
-    const unknownBlocks = JSON.stringify({
+    const contentNotArray = JSON.stringify({
       type: 'assistant',
-      message: { content: [{ type: 'thinking', thinking: 'hmm' }] },
+      message: { content: 'oops' },
     })
-    expect(parseClaudeLine(unknownBlocks)).toEqual([
-      { kind: 'raw', text: unknownBlocks },
+    expect(parseClaudeLine(contentNotArray)).toEqual([
+      { kind: 'raw', text: contentNotArray },
     ])
+  })
+
+  // Claude emits one of these every turn. Dumping the line raw buried the run
+  // pane under the block's signed base64 payload.
+  test('emits nothing for an assistant message holding only thinking blocks', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'thinking', thinking: '', signature: 'EuoCCqgBCBEYAipAy8Em' },
+        ],
+      },
+      session_id: '34f4fad3-b521-434d-98c3-d25e4f974c67',
+    })
+    expect(parseClaudeLine(line)).toEqual([])
+  })
+
+  test('emits nothing for a user message carrying no tool_result blocks', () => {
+    const line = JSON.stringify({
+      type: 'user',
+      message: { content: [{ type: 'text', text: 'echoed prompt' }] },
+    })
+    expect(parseClaudeLine(line)).toEqual([])
   })
 
   test('parses user tool_result blocks with string content', () => {
@@ -167,9 +197,11 @@ describe('parseClaudeLine', () => {
     ])
   })
 
-  test('returns raw for unknown event types', () => {
+  test('reduces unknown event types to a short marker', () => {
     const line = JSON.stringify({ type: 'stream_event', payload: 1 })
-    expect(parseClaudeLine(line)).toEqual([{ kind: 'raw', text: line }])
+    expect(parseClaudeLine(line)).toEqual([
+      { kind: 'raw', text: '[unhandled] stream_event' },
+    ])
   })
 
   test('never throws on hostile shapes', () => {
@@ -278,12 +310,14 @@ describe('parseCodexLine', () => {
     ])
   })
 
-  test('falls back to raw for completed items of unknown type', () => {
+  test('reduces completed items of unknown type to a short marker', () => {
     const line = JSON.stringify({
       type: 'item.completed',
       item: { item_type: 'todo_list', items: [] },
     })
-    expect(parseCodexLine(line)).toEqual([{ kind: 'raw', text: line }])
+    expect(parseCodexLine(line)).toEqual([
+      { kind: 'raw', text: '[unhandled] item.completed/todo_list' },
+    ])
   })
 
   test('parses turn.completed as a success result', () => {
@@ -313,9 +347,11 @@ describe('parseCodexLine', () => {
     ])
   })
 
-  test('returns raw for unknown event types', () => {
+  test('reduces unknown event types to a short marker', () => {
     const line = JSON.stringify({ id: '1', msg: { type: 'agent_message' } })
-    expect(parseCodexLine(line)).toEqual([{ kind: 'raw', text: line }])
+    expect(parseCodexLine(line)).toEqual([
+      { kind: 'raw', text: '[unhandled] unknown' },
+    ])
   })
 
   test('never throws on hostile shapes', () => {
@@ -472,11 +508,8 @@ describe('event text capping', () => {
     expect(event.text.length).toBeLessThanOrEqual(EVENT_TEXT_LIMIT + 64)
   })
 
-  test('caps raw fallback events for unrecognized giant lines', () => {
-    const line = JSON.stringify({
-      type: 'mystery',
-      payload: 'p'.repeat(EVENT_TEXT_LIMIT * 2),
-    })
+  test('caps raw fallback events for giant unparseable lines', () => {
+    const line = `not json ${'p'.repeat(EVENT_TEXT_LIMIT * 2)}`
     const claudeEvents = parseClaudeLine(line)
     expect(claudeEvents).toHaveLength(1)
     const claudeEvent = claudeEvents[0]
@@ -489,6 +522,30 @@ describe('event text capping', () => {
     const codexEvent = codexEvents[0]
     if (codexEvent.kind !== 'raw') throw new Error('expected raw')
     expect(codexEvent.text.length).toBeLessThanOrEqual(EVENT_TEXT_LIMIT + 64)
+  })
+
+  // The marker never carries the payload, so an oversized unknown line is
+  // bounded by construction rather than by the text cap.
+  test('keeps the unhandled marker short for giant unknown lines', () => {
+    const line = JSON.stringify({
+      type: 'mystery',
+      payload: 'p'.repeat(EVENT_TEXT_LIMIT * 2),
+    })
+    expect(parseClaudeLine(line)).toEqual([
+      { kind: 'raw', text: '[unhandled] mystery' },
+    ])
+    expect(parseCodexLine(line)).toEqual([
+      { kind: 'raw', text: '[unhandled] mystery' },
+    ])
+  })
+
+  test('caps an absurd type name inside the unhandled marker', () => {
+    const line = JSON.stringify({ type: 't'.repeat(EVENT_TEXT_LIMIT) })
+    const events = parseClaudeLine(line)
+    expect(events).toHaveLength(1)
+    const event = events[0]
+    if (event.kind !== 'raw') throw new Error('expected raw')
+    expect(event.text.length).toBeLessThanOrEqual(EVENT_FIELD_LIMIT + 32)
   })
 
   test('leaves text at exactly EVENT_TEXT_LIMIT untouched', () => {
@@ -564,7 +621,7 @@ describe('session id extraction', () => {
     ])
     const unknownJson = JSON.stringify({ type: 'session.snapshot', data: 1 })
     expect(parseCodexLine(unknownJson)).toEqual([
-      { kind: 'raw', text: unknownJson },
+      { kind: 'raw', text: '[unhandled] session.snapshot' },
     ])
   })
 })


### PR DESCRIPTION
## Why

Windows has no pseudoterminal the plugin can drive, so `resolveRunMode()` degrades every run there to conversation mode. That mode had never been exercised on a real Windows machine, and two display bugs plus one missing explanation made a perfectly working run look broken.

Neither bug is Windows-specific — both reproduce on macOS by switching **Run mode** to *Conversation*.

## What changed

**Answers no longer appear twice.** Claude's terminating `result` message repeats the final assistant text, and the pane rendered it as body text right after the identical `assistant-text` event. The log note already reduced that event to a summary line, so the formatting moves to `AiResultSummary` and both surfaces share it. An error result keeps its body — nothing else carries it.

**Raw JSON no longer floods the pane.** The parser dumped any line it did not recognize in full, and Claude emits an assistant message holding only a `thinking` block on most turns, each carrying a long signed base64 payload. `parseClaudeAssistant` and `parseClaudeUser` now distinguish *malformed* from *nothing to render*: only the former still degrades to a full dump. Unrecognized envelopes shrink to an `[unhandled] type/subtype` marker on both the Claude and the Codex side, which keeps the diagnostic without the payload.

**The run mode setting stops lying.** The settings tab offered "Terminal (interactive)" on platforms where every run is degraded anyway, which is why the setting looked ignored. There the row becomes a plain explanation instead. The stored value is untouched, so carrying the vault to a Mac restores the original choice. The platform predicate moves to `ptyPlatform` so the gateway and the settings tab — which must not touch a Node builtin — give the same answer.

## Testing

- `npm run lint` — clean
- `npm run test:unit` — 226 suites, 3263 tests
- `npm run test:integration` — 3 suites, 82 tests
- `npm run review:obsidian` — 0 errors, 0 warnings (the 8 capability disclosures are pre-existing)
- `npm run build` — succeeds

New coverage: a `thinking`-only assistant message and a `tool_result`-free user message emit nothing; malformed `message`/`content` still degrades to a full raw dump; the unhandled marker stays short for giant lines; the pane summarizes a result and keeps an error body; the run mode row collapses to a note where no pseudoterminal exists; and both platform predicates agree on every OS.

## Follow-ups (not in this PR)

- Verify on real Windows hardware: one answer, no raw JSON, no run mode dropdown.
- Claude is launched with `-p` and no `--permission-mode`. The documented default for `-p` is Manual, and conversation mode has no channel to answer a permission prompt, so operations needing approval may stall. Worth confirming on Windows and filing separately.
- Approving tools and interrupting mid-run still require a persistent `--input-format stream-json` session. Deliberately out of scope.