### PR TITLE
Quiet the metadata rows in the conversation pane

### DIFF
--- a/src/features/ai-task/ui/AiRunPaneController.ts
+++ b/src/features/ai-task/ui/AiRunPaneController.ts
@@ -2577,9 +2577,20 @@ export class AiRunPaneController {
     if (pinned) this.scrollToBottom(view.body)
   }
 
+  /**
+   * One node per event, ALWAYS — renderEvents' in-place elision patch pairs
+   * each appended event with exactly one node. An event with nothing to say
+   * therefore becomes an empty node that the stylesheet collapses, never a
+   * skipped one.
+   */
   private appendEventElement(body: HTMLElement, event: AiStreamEvent): HTMLElement {
+    const isError =
+      (event.kind === 'result' || event.kind === 'tool-result') &&
+      event.isError === true
     return body.createDiv({
-      cls: `ai-run-pane__event ai-run-pane__event--${event.kind}`,
+      cls:
+        `ai-run-pane__event ai-run-pane__event--${event.kind}` +
+        (isError ? ' is-error' : ''),
       text: this.formatEventText(event),
     })
   }
@@ -2597,12 +2608,11 @@ export class AiRunPaneController {
 
   private formatEventText(event: AiStreamEvent): string {
     switch (event.kind) {
-      case 'init': {
-        const details = [event.model, event.sessionId]
-          .filter((part): part is string => typeof part === 'string' && part.length > 0)
-          .join(' · ')
-        return details.length > 0 ? details : 'init'
-      }
+      case 'init':
+        // The session id belongs to resume plumbing, not to a reader, and a
+        // follow-up restarts the CLI so it repeated on every turn — codex,
+        // which sends no model, printed a bare UUID and nothing else.
+        return event.model ?? ''
       case 'assistant-text':
         return event.text
       case 'user-text':
@@ -2617,9 +2627,15 @@ export class AiRunPaneController {
         // every answer twice. Errors are the exception: nothing else carries
         // their body.
         const summary = formatAiResultSummary(event)
-        return event.isError === true && event.text !== undefined
-          ? `${summary}\n${event.text}`
-          : summary
+        if (event.isError === true) {
+          return event.text === undefined ? summary : `${summary}\n${event.text}`
+        }
+        // A successful turn is worth a row only when it reports something the
+        // run pane does not already show. Codex sends neither figure, so its
+        // `turn.completed` was a bare protocol word between every exchange.
+        const hasFigures =
+          event.totalCostUsd !== undefined || event.numTurns !== undefined
+        return hasFigures ? summary : ''
       }
       case 'stderr':
         return event.text

--- a/styles.css
+++ b/styles.css
@@ -7777,6 +7777,16 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
   color: var(--text-normal);
 }
 
+/*
+ * Every event gets a node so the pane's incremental append stays 1:1 with the
+ * event buffer; the ones carrying nothing readable (a session-id-only init, a
+ * codex turn.completed, an empty tool result) are folded away here rather than
+ * left as 2px gaps.
+ */
+.ai-run-pane__event:empty {
+  display: none;
+}
+
 .ai-run-pane__event--init {
   color: var(--text-muted);
   font-style: italic;
@@ -7791,7 +7801,12 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
 }
 
 .ai-run-pane__event--result {
-  font-weight: 600;
+  color: var(--text-muted);
+}
+
+/* Keeps a failure legible now that a result no longer carries any weight. */
+.ai-run-pane__event.is-error {
+  color: var(--text-error);
 }
 
 .ai-run-pane__event--stderr {

--- a/tests/features/ai-task/ai-run-pane-controller.test.ts
+++ b/tests/features/ai-task/ai-run-pane-controller.test.ts
@@ -165,6 +165,51 @@ describe('AiRunPaneController', () => {
    * Rendering it as body text printed every answer twice in the pane, so the
    * row now shows the same summary the log note carries.
    */
+  /**
+   * The metadata rows outnumbered the conversation on a two-turn codex run:
+   * a follow-up restarts the CLI, so the session-id-only init and the figure-
+   * less `turn.completed` repeated around every exchange. They still occupy a
+   * node each — renderEvents pairs appended events with nodes one for one —
+   * but the node is empty, and the stylesheet folds it away.
+   */
+  test('empties the rows that carry nothing a reader can use', () => {
+    controller.mount(container)
+    const run = createRun()
+    manager.emit(run)
+
+    run.events.push({ kind: 'init', sessionId: '01a06111-2a69-7a63-b438' })
+    run.events.push({ kind: 'assistant-text', text: 'Ready.' })
+    run.events.push({ kind: 'result', subtype: 'turn.completed', isError: false })
+    run.events.push({ kind: 'tool-result', text: undefined })
+    manager.emit(run)
+    flushEventFrame()
+
+    const events = container.querySelectorAll('.ai-run-pane__event')
+    expect(events).toHaveLength(4)
+    expect(events[0].textContent).toBe('')
+    expect(events[1].textContent).toBe('Ready.')
+    expect(events[2].textContent).toBe('')
+    expect(events[3].textContent).toBe('')
+  })
+
+  test('keeps the model on an init row, without the session id', () => {
+    controller.mount(container)
+    const run = createRun()
+    manager.emit(run)
+
+    run.events.push({
+      kind: 'init',
+      model: 'claude-opus-5[1m]',
+      sessionId: '77ecf074-36ce-417a-811d-6768fda26607',
+    })
+    manager.emit(run)
+    flushEventFrame()
+
+    const events = container.querySelectorAll('.ai-run-pane__event')
+    expect(events).toHaveLength(1)
+    expect(events[0].textContent).toBe('claude-opus-5[1m]')
+  })
+
   test('summarizes a result event instead of repeating the answer', () => {
     controller.mount(container)
     const run = createRun()
@@ -207,6 +252,24 @@ describe('AiRunPaneController', () => {
     expect(events[0].textContent).toBe(
       'error_during_execution\nthe CLI ran out of credits',
     )
+    // A result carries no weight of its own any more, so the failure needs the
+    // class to stay legible.
+    expect(events[0].classList.contains('is-error')).toBe(true)
+  })
+
+  test('marks a failed tool result too, and leaves successes unmarked', () => {
+    controller.mount(container)
+    const run = createRun()
+    manager.emit(run)
+
+    run.events.push({ kind: 'tool-result', text: 'exit 1', isError: true })
+    run.events.push({ kind: 'tool-result', text: 'exit 0', isError: false })
+    manager.emit(run)
+    flushEventFrame()
+
+    const events = container.querySelectorAll('.ai-run-pane__event')
+    expect(events[0].classList.contains('is-error')).toBe(true)
+    expect(events[1].classList.contains('is-error')).toBe(false)
   })
 
   test('appends only new events on repeated notifications', () => {


### PR DESCRIPTION
Follow-up to #174. With the duplicated answers and the raw JSON gone, what was left standing out in conversation mode was the metadata — and it was the part drawn in bold.

## Before

A two-turn codex exchange: four metadata rows against three lines of conversation.

```
01a06111-2a69-7a63-b438-bb87ad60aad8     ← init (session id only)
Ready—what would you like to test?
turn.completed                           ← result (bold)
│ hi
01a06111-2a69-7a63-b438-bb87ad60aad8     ← the same id again
Hi! What are we working on today?
turn.completed
```

## What changed

**init shows the model, nothing else.** The session id serves resume and means nothing to a reader. A follow-up restarts the CLI, so it reappeared on every turn — and codex sends no model, so all that row ever held was a bare UUID.

**A successful result earns a row only when it reports a figure.** Claude keeps `success (cost $0.01, 2 turns)`. Codex reports neither cost nor turn count, so its `turn.completed` was a protocol word sitting between every exchange, and it goes.

**Errors stay visible.** They keep their body — nothing else carries it — and now get an `is-error` class. Dropping the bold from `--result` would otherwise have left a failure looking like ordinary text. A failed tool result is marked the same way.

**Rows are emptied, not skipped.** `renderEvents` patches the elision marker in place by pairing each appended event with exactly one node, so the buffer and the rendered nodes must stay 1:1. Suppression is therefore an empty node plus `.ai-run-pane__event:empty { display: none }`. That also closes the 2px gaps an empty tool result had been leaving behind.

The run log note is deliberately unchanged: it still records the session id and every result, since that is what a later reader needs.

## After

```
Ready—what would you like to test?
│ hi
Hi! What are we working on today?
```

## Testing

- `npm run lint` — clean
- `npm run test:unit` — 226 suites, 3266 tests
- `npm run test:integration` — 3 suites, 82 tests
- `npm run review:obsidian` — 0 errors, 0 warnings (the 8 capability disclosures are pre-existing)
- `node scripts/obsidian-review-css.mjs` — clean
- `npm run build` — succeeds

New coverage: a session-id-only init, a figureless `turn.completed` and a bodyless tool result each render an empty node while still occupying one; an init keeps its model and drops its session id; an error result carries `is-error` and a successful one does not.