### PR TITLE
Offer a way out when a vault holds no license code

### DIFF
--- a/src/features/license/services/LicenseManager.ts
+++ b/src/features/license/services/LicenseManager.ts
@@ -455,6 +455,29 @@ export class LicenseManager {
     return { ok: true, devicesUsed: result.data.devices_used }
   }
 
+  /**
+   * Give this device's licence up locally, without asking the server.
+   *
+   * The way out of the one state the seat list cannot fix: an active token
+   * with no code behind it. The token lives in device-local storage and the
+   * code in the synced vault settings, so a vault whose data.json never
+   * carried the code — activated in another vault on this machine, or restored
+   * from elsewhere — is licensed but unable to act: every request needs the
+   * code, and the active screen has no field to enter one. Dropping the token
+   * returns the screen to the activation form, which is the field.
+   *
+   * Not a seat release: nothing is sent, so the server still counts this
+   * device. That is deliberate — the device id is kept, so re-entering the code
+   * here reuses the very same seat rather than spending another one. A user who
+   * does not come back can release the seat from any other machine's list.
+   */
+  signOutLocally(): void {
+    this.deps.store.clearToken()
+    // A list drawn from this belongs to a licence this device no longer holds.
+    this.deviceSnapshot = undefined
+    this.setState({ status: 'unlicensed' })
+  }
+
   private async doRefresh(force: boolean): Promise<void> {
     // Undefined once this device gave up its seat, which is what stops a
     // refresh from handing it straight back.

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -85,6 +85,14 @@ export const en = {
       statusActive: "Active",
       statusInactive: "Not activated",
       licenseIdName: "License ID",
+      signOutName: "Sign out on this device",
+      signOutDesc:
+        "This vault has no license code stored, so devices cannot be managed from here. Sign out to enter your code again. The seat stays with this device, so re-entering the same code costs no extra device.",
+      signOut: "Sign out",
+      signOutConfirmTitle: "Sign out on this device?",
+      signOutConfirmBody:
+        "AI tasks stop working on this device until you enter your license code again.",
+      signedOut: "Signed out on this device.",
       devicesName: "Devices",
       devicesValue: "{used} of {max} in use",
       activated: "License activated.",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -81,6 +81,14 @@ export const ja = {
       statusActive: "有効",
       statusInactive: "未アクティベート",
       licenseIdName: "ライセンスID",
+      signOutName: "この端末のライセンスを解除",
+      signOutDesc:
+        "この保管庫にはライセンスコードが保存されていないため、ここから端末を管理できません。解除するとコードを入力し直せます。この端末の枠はそのまま残るので、同じコードを入れ直しても台数は増えません。",
+      signOut: "解除する",
+      signOutConfirmTitle: "この端末のライセンスを解除しますか？",
+      signOutConfirmBody:
+        "ライセンスコードを入力し直すまで、この端末ではAIタスクを利用できなくなります。",
+      signedOut: "この端末のライセンスを解除しました。",
       devicesName: "端末",
       devicesValue: "{max}台中{used}台を使用中",
       activated: "ライセンスを有効化しました。",

--- a/src/settings/sections/pro/license.ts
+++ b/src/settings/sections/pro/license.ts
@@ -1,5 +1,9 @@
 import { Notice, setIcon } from "obsidian"
-import type { Setting, SettingDefinitionItem } from "obsidian"
+import type {
+  Setting,
+  SettingDefinitionItem,
+  SettingDefinitionRender,
+} from "obsidian"
 import { getCurrentLocale, t } from "../../../i18n"
 import { licensePurchaseUrl } from "../../../features/license/config"
 import type { LicenseManager } from "../../../features/license/services/LicenseManager"
@@ -10,7 +14,7 @@ import {
   describeActivationFailure,
   describeApiFailure,
 } from "../../../features/license/ui/licenseMessages"
-import { showInfoModal } from "../../../ui/modals/ConfirmModal"
+import { showConfirmModal, showInfoModal } from "../../../ui/modals/ConfirmModal"
 import type { SectionContext } from "../../types"
 import { LicenseActivationState } from "./licenseActivationState"
 
@@ -161,6 +165,65 @@ function purchaseRow(): SettingDefinitionItem {
   }
 }
 
+/**
+ * The way out of a licence this vault cannot act with.
+ *
+ * The token is device-local and the code lives in the synced vault settings, so
+ * a vault can be licensed while holding no code — activated from another vault
+ * on this machine, or a data.json that never carried it. Everything that talks
+ * to the server then fails on the code that is not there, and the active screen
+ * offers no field to supply one. Signing out drops the token, which brings the
+ * activation form back, and that form is the field.
+ *
+ * Only ever shown in that state: with a code in hand, the seat list already
+ * releases this device properly, and that path tells the server.
+ */
+function signOutRow(
+  ctx: SectionContext,
+  manager: LicenseManager,
+  applyLicenseChange: () => Promise<void>,
+): SettingDefinitionRender {
+  return {
+    name: t("settings.license.signOutName", "Sign out on this device"),
+    desc: t(
+      "settings.license.signOutDesc",
+      "This vault has no license code stored, so devices cannot be managed from here. Sign out to enter your code again. The seat stays with this device, so re-entering the same code costs no extra device.",
+    ),
+    render: (setting) => {
+      setting.addButton((button) => {
+        button
+          .setDestructive()
+          .setButtonText(t("settings.license.signOut", "Sign out"))
+          .onClick(() => {
+            void signOut(ctx, manager, applyLicenseChange)
+          })
+      })
+    },
+  }
+}
+
+async function signOut(
+  ctx: SectionContext,
+  manager: LicenseManager,
+  applyLicenseChange: () => Promise<void>,
+): Promise<void> {
+  const confirmed = await showConfirmModal(ctx.app, {
+    title: t("settings.license.signOutConfirmTitle", "Sign out on this device?"),
+    message: t(
+      "settings.license.signOutConfirmBody",
+      "AI tasks stop working on this device until you enter your license code again.",
+    ),
+    confirmText: t("settings.license.signOut", "Sign out"),
+    destructive: true,
+  })
+  if (!confirmed) return
+
+  manager.signOutLocally()
+  await applyLicenseChange()
+  ctx.update()
+  new Notice(t("settings.license.signedOut", "Signed out on this device."))
+}
+
 async function activate(
   ctx: SectionContext,
   manager: LicenseManager,
@@ -275,14 +338,24 @@ function activeLicenseRows(
           }
         : undefined
 
+  // No code here means no request can be made: the seat list, its refresh and
+  // every release need one. The list would show nothing but a permanent
+  // no_activation_code, so it is replaced by the one action that does work.
+  const codeless = stored === undefined || stored.length === 0
+
   if (identity) {
     rows.push({
       type: "group",
       heading: t("settings.license.heading", "License"),
       cls: "taskchute-license-identity",
-      items: [{ name: identity.name, desc: identity.value }],
+      items: [
+        { name: identity.name, desc: identity.value },
+        ...(codeless ? [signOutRow(ctx, manager, applyLicenseChange)] : []),
+      ],
     })
   }
+
+  if (codeless) return rows
 
   rows.push({
     type: "group",

--- a/tests/features/license/license-manager.test.ts
+++ b/tests/features/license/license-manager.test.ts
@@ -450,6 +450,50 @@ describe('device management', () => {
   })
 })
 
+describe('signOutLocally', () => {
+  /**
+   * The token is device-local and the code is in the synced vault settings, so
+   * a vault can hold a working token and no code — activated from another vault
+   * on this machine, say. Nothing that talks to the server works then, and the
+   * screen an active licence draws has no field to enter a code into. Dropping
+   * the token is the only way back to that field.
+   */
+  test('drops the token so the code can be entered again', () => {
+    const { manager, store } = createHarness()
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    expect(manager.isActive()).toBe(true)
+
+    manager.signOutLocally()
+
+    expect(manager.isActive()).toBe(false)
+    expect(store.getState().token).toBeUndefined()
+  })
+
+  test('keeps the device id, so coming back reuses the same seat', async () => {
+    const { manager, store, client, code } = createHarness()
+    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    manager.initialize()
+    const deviceId = manager.getDeviceId()
+
+    manager.signOutLocally()
+
+    // Not a seat release: nothing was sent, and the latch a real release sets
+    // would refuse the very code the user is about to type.
+    expect(manager.isSeatReleased()).toBe(false)
+    expect(manager.getDeviceId()).toBe(deviceId)
+
+    client.issueToken.mockResolvedValue(issued(tokenFor(store), NOW + 7 * DAY))
+    await manager.activate('TCP-0000-0000-0000-0001')
+
+    expect(client.issueToken).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceId, code: 'TCP-0000-0000-0000-0001' }),
+    )
+    expect(manager.isActive()).toBe(true)
+    expect(code.value).toBe('TCP-0000-0000-0000-0001')
+  })
+})
+
 describe('verifyDeviceRegistration', () => {
   function deviceList(...deviceIds: string[]) {
     return {

--- a/tests/features/license/pro-settings-section.test.ts
+++ b/tests/features/license/pro-settings-section.test.ts
@@ -26,8 +26,17 @@ jest.mock('../../../src/features/license/ui/DeviceListView', () => ({
   DeviceListView: jest.fn().mockImplementation(() => ({ dispose: jest.fn() })),
 }))
 
+jest.mock('../../../src/ui/modals/ConfirmModal', () => ({
+  showConfirmModal: jest.fn().mockResolvedValue(true),
+  showInfoModal: jest.fn().mockResolvedValue(undefined),
+}))
+
 const { DeviceListView } = require('../../../src/features/license/ui/DeviceListView') as {
   DeviceListView: jest.Mock
+}
+
+const { showConfirmModal } = require('../../../src/ui/modals/ConfirmModal') as {
+  showConfirmModal: jest.Mock
 }
 
 function fakeManager(
@@ -53,6 +62,8 @@ function fakeManager(
   } as unknown as LicenseManager
 }
 
+const CODE = 'TCP-AAAA-BBBB-CCCC-DDDD'
+
 const ACTIVE_SUMMARY = {
   license_id: '8F3K2M9QX7RD4WPZ',
   max_devices: 3,
@@ -60,6 +71,11 @@ const ACTIVE_SUMMARY = {
   expires_at: null,
 }
 
+/**
+ * An activated device. Without a stored code it is the state a vault reaches
+ * when the token was issued elsewhere — licensed, but unable to make a single
+ * request, since every one of them needs the code.
+ */
 function activeManager(storedCode?: string): LicenseManager {
   return fakeManager({
     getState: () => ({ status: 'active', token: {}, license: ACTIVE_SUMMARY }),
@@ -153,6 +169,16 @@ function deviceItem(manager: LicenseManager): SettingDefinitionItem {
       candidate.name === '',
   )
   if (!item) throw new Error('Device list row not found')
+  return item
+}
+
+/** The row that gives up the licence on this device. */
+function signOutItem(manager: LicenseManager): SettingDefinitionItem {
+  const item = proItems(manager).find(
+    (candidate) =>
+      'name' in candidate && candidate.name === 'Sign out on this device',
+  )
+  if (!item) throw new Error('Sign out row not found')
   return item
 }
 
@@ -349,42 +375,38 @@ describe('Pro settings section', () => {
 
   describe('when activated', () => {
     test('shows the license details', () => {
-      const items = proItems(activeManager())
+      const items = proItems(activeManager(CODE), CODE)
 
       // Two sections: the licence to read, the seats to act on.
       expect(headings(items)).toEqual(
         expect.arrayContaining(['License', 'Devices']),
       )
-      expect(names(items)).toContain('License ID')
-
-      const licenseId = items.find(
-        (item) => 'name' in item && item.name === 'License ID',
-      )
-      expect((licenseId as { desc: string }).desc).toBe('8F3K-2M9Q-X7RD-4WPZ')
     })
 
     test('shows the code that was entered, not the id derived from it', () => {
       // What the user holds and would re-enter elsewhere is the code; the id
       // means nothing to them.
-      const items = proItems(
-        activeManager('TCP-AAAA-BBBB-CCCC-DDDD'),
-        'TCP-AAAA-BBBB-CCCC-DDDD',
-      )
+      const items = proItems(activeManager(CODE), CODE)
 
       expect(names(items)).toContain('License code')
       expect(names(items)).not.toContain('License ID')
       expect(descs(items)).toContain('TCP-AAAA-BBBB-CCCC-DDDD')
     })
 
-    test('falls back to the license id once this device gave up its seat', () => {
-      // The code is still in data.json — it has to be, other machines share it
-      // — but this device may no longer use it, so showing it here would be
+    test('falls back to the license id when there is no usable code', () => {
+      // The code may still be in data.json — it has to be, other machines share
+      // it — but this device may no longer use it, so showing it here would be
       // offering something that does nothing.
-      const items = proItems(activeManager(), 'TCP-AAAA-BBBB-CCCC-DDDD')
+      const items = proItems(activeManager(), CODE)
 
       expect(names(items)).not.toContain('License code')
       expect(descs(items)).not.toContain('TCP-AAAA-BBBB-CCCC-DDDD')
       expect(names(items)).toContain('License ID')
+
+      const licenseId = items.find(
+        (item) => 'name' in item && item.name === 'License ID',
+      )
+      expect((licenseId as { desc: string }).desc).toBe('8F3K-2M9Q-X7RD-4WPZ')
     })
 
     test('drops the status and expiry rows', () => {
@@ -397,7 +419,7 @@ describe('Pro settings section', () => {
     })
 
     test('mounts the device list and disposes it on teardown', () => {
-      const { cleanup } = invokeRender(deviceItem(activeManager()))
+      const { cleanup } = invokeRender(deviceItem(activeManager(CODE)))
       expect(DeviceListView).toHaveBeenCalledTimes(1)
 
       // The framework tears the row down before replacing it, which is what
@@ -415,7 +437,7 @@ describe('Pro settings section', () => {
      * the row's own control element is what keeps the seats on screen.
      */
     test('mounts the device list into the row, not the group', () => {
-      const { setting, group } = invokeRender(deviceItem(activeManager()))
+      const { setting, group } = invokeRender(deviceItem(activeManager(CODE)))
 
       const container = DeviceListView.mock.calls[0][0] as HTMLElement
       expect(container).toBe(setting.controlEl)
@@ -432,14 +454,73 @@ describe('Pro settings section', () => {
     })
 
     test('does not offer the activation field again', () => {
-      expect(names(proItems(activeManager()))).not.toContain('License code')
+      // The row named for the code is the licence being displayed, not a form:
+      // it carries the code as its value and has nothing to type into.
+      const items = proItems(activeManager(CODE), CODE)
+      const row = items.find(
+        (item) => 'name' in item && item.name === 'License code',
+      )
+
+      expect(row).toBeDefined()
+      expect('render' in (row ?? {})).toBe(false)
+      expect((row as { desc: string }).desc).toBe(CODE)
     })
 
-    test('has no separate sign-out control', () => {
+    /**
+     * The token lives in device-local storage and the code in the synced vault
+     * settings, so a vault can be licensed while holding no code at all. Every
+     * request needs the code, so the seat list can only fail — and the active
+     * screen has no field to supply one. Without a way out, the device is stuck
+     * there until the token expires.
+     */
+    describe('and this vault holds no code', () => {
+      test('offers a way out instead of a seat list that cannot work', () => {
+        const items = proItems(activeManager())
+
+        expect(names(items)).toContain('Sign out on this device')
+        // The list needs the code for its every request, so all it could show
+        // is a permanent no_activation_code.
+        expect(headings(items)).not.toContain('Devices')
+      })
+
+      test('signs out on this device once confirmed', async () => {
+        const manager = fakeManager({
+          getState: () => ({ status: 'active', token: {}, license: ACTIVE_SUMMARY }),
+          isActive: () => true,
+          getLicenseSummary: () => ACTIVE_SUMMARY,
+          getStoredCode: () => undefined,
+          signOutLocally: jest.fn(),
+        })
+        showConfirmModal.mockResolvedValueOnce(true)
+
+        const { setting } = invokeRender(signOutItem(manager))
+        await setting.__buttons[0].__click()
+
+        expect(manager.signOutLocally).toHaveBeenCalledTimes(1)
+      })
+
+      test('keeps the license when the confirmation is declined', async () => {
+        const manager = fakeManager({
+          getState: () => ({ status: 'active', token: {}, license: ACTIVE_SUMMARY }),
+          isActive: () => true,
+          getLicenseSummary: () => ACTIVE_SUMMARY,
+          getStoredCode: () => undefined,
+          signOutLocally: jest.fn(),
+        })
+        showConfirmModal.mockResolvedValueOnce(false)
+
+        const { setting } = invokeRender(signOutItem(manager))
+        await setting.__buttons[0].__click()
+
+        expect(manager.signOutLocally).not.toHaveBeenCalled()
+      })
+    })
+
+    test('has no separate sign-out control while the code is usable', () => {
       // Releasing this device is done from the list like any other seat; a
       // second control that only cleared local state would just be confusing.
-      expect(names(proItems(activeManager()))).not.toContain(
-        'Deactivate on this device',
+      expect(names(proItems(activeManager(CODE), CODE))).not.toContain(
+        'Sign out on this device',
       )
     })
   })
@@ -525,7 +606,7 @@ describe('when the Pro page is shown', () => {
   })
 
   test('the seat list re-asks the server', () => {
-    const manager = activeManager()
+    const manager = activeManager(CODE)
     const row = deviceItem(manager)
     ;(manager.syncFromServer as jest.Mock).mockClear()
 


### PR DESCRIPTION
## The problem

The token lives in device-local storage and the activation code lives in the synced vault settings. So a vault can hold a working token and no code at all — activated from another vault on the same machine, or restored from a `data.json` that never carried it.

Everything that talks to the server then fails on the code that is not there. The seat list, its refresh and every release answer `no_activation_code`, and the screen an active licence draws has no field to enter a code into. The device stays stuck there until the token expires, seven days later.

The state is easy to reach without any tampering: activate in one vault, then open a second vault on the same machine.

## The change

`LicenseManager.signOutLocally()` drops the device-local token, so the page becomes the activation form again — and that form is the field the state was missing.

It is deliberately **not** a seat release. Nothing is sent, and the device id is kept, so re-entering the same code reuses the very same seat rather than spending another one. The seat-released latch is not set either: it exists to stop a code from working on this machine, which would refuse the very code the user is about to type.

The settings page offers the control only in that state, under the licence id, and drops the Devices section there — with no code the list can show nothing but a permanent failure. With a usable code the page is unchanged: this device is released from the seat list like any other seat, and that path tells the server.

## Tests

- `signOutLocally` drops the token, and keeps the device id so coming back reuses the same seat
- The Pro page offers the way out and hides the seat list when the vault holds no code
- Signing out is confirmed first, and a declined confirmation keeps the licence

The `activeManager()` fixture now means "activated, no stored code" — the state under test — so the seat-list tests pass a code explicitly.
