### PR TITLE
fix(ai-task): shrink the collapsed AI run pane to its header row

### DIFF
--- a/src/features/ai-task/ui/AiRunPaneController.ts
+++ b/src/features/ai-task/ui/AiRunPaneController.ts
@@ -962,14 +962,15 @@ export class AiRunPaneController {
     this.paneHeightRatio = next
     if (next === null) {
       container.style.removeProperty(PANE_HEIGHT_PROPERTY)
-      container.classList.remove(SIZED_CONTAINER_CLASS)
     } else {
       container.style.setProperty(
         PANE_HEIGHT_PROPERTY,
         `${(next * 100).toFixed(2)}%`,
       )
-      container.classList.add(SIZED_CONTAINER_CLASS)
     }
+    // The --sized class itself is owned by updateContainerChrome, which also
+    // gates it on the pane not being collapsed.
+    this.updateContainerChrome()
     if (persist) {
       this.host.saveLocalStorage?.(AI_PANE_HEIGHT_RATIO_STORAGE_KEY, next)
     }
@@ -2338,6 +2339,15 @@ export class AiRunPaneController {
    * pane height in styles.css) exactly while some panel displays a terminal
    * run on screen, the expanded class exactly while the expanded pane is on
    * screen.
+   *
+   * Every class that gives the container a height — including the dragged
+   * one — drops while the pane is collapsed, so a collapsed pane shrinks to
+   * its header row instead of leaving the box it was dragged to as empty
+   * space above the task list. The ratio itself survives in
+   * `paneHeightRatio` and in storage, so expanding restores the same height.
+   * (--sized only needs the collapse gate: a hidden container is
+   * `display: none`, and keeping the class there preserves the height across
+   * a hidden→revealed cycle.)
    */
   private updateContainerChrome(): void {
     const container = this.containerEl
@@ -2354,6 +2364,10 @@ export class AiRunPaneController {
       anyTerminalOnScreen && visible,
     )
     container.classList.toggle(EXPANDED_CONTAINER_CLASS, this.expanded && visible)
+    container.classList.toggle(
+      SIZED_CONTAINER_CLASS,
+      this.paneHeightRatio !== null && !this.isCollapsed(),
+    )
     container.classList.toggle(VISIBLE_CONTAINER_CLASS, paneVisible)
     container.classList.toggle(
       COLLAPSED_CONTAINER_CLASS,

--- a/styles.css
+++ b/styles.css
@@ -7017,9 +7017,13 @@ body.is-phone .taskchute-modal .backup-confirm-buttons {
   outline: none;
 }
 
-/* Nothing to resize while the pane is collapsed to its header row. */
+/* Nothing to resize while the pane is collapsed to its header row — but the
+   handle keeps its 6px box rather than being removed from the layout, so the
+   collapsed header stays separated from the task list by the same gap it has
+   while expanded. `visibility` (not `display`) also takes the grip, the hover
+   states, the resize cursor and the tab stop out along with it. */
 .ai-pane-container--collapsed .ai-pane-resizer {
-  display: none;
+  visibility: hidden;
 }
 
 .ai-run-pane {

--- a/tests/features/ai-task/ai-run-pane-resize.test.ts
+++ b/tests/features/ai-task/ai-run-pane-resize.test.ts
@@ -60,6 +60,9 @@ describe('AI run pane drag resize', () => {
   const handle = (): HTMLElement =>
     container.querySelector('.ai-pane-resizer') as HTMLElement
 
+  const collapseButton = (): HTMLElement =>
+    container.querySelector('.ai-run-pane__collapse') as HTMLElement
+
   /** jsdom has no PointerEvent; a MouseEvent carrying pointerId is enough. */
   const pointer = (type: string, clientY: number): Event => {
     const event = new MouseEvent(type, { clientY, bubbles: true, button: 0 })
@@ -270,6 +273,42 @@ describe('AI run pane drag resize', () => {
     expect(container.classList.contains('ai-pane-container--collapsed')).toBe(
       false,
     )
+  })
+
+  test('collapsing drops the dragged height, expanding restores it', () => {
+    controller.mount(container)
+    manager.emit({
+      id: 'run-1',
+      taskPath: 'TASKS/ai-sample.md',
+      taskName: 'AI sample',
+      host: 'claude',
+      mode: 'headless',
+      status: 'running',
+      startedAt: Date.now(),
+      events: [],
+    })
+    drag(-300)
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(true)
+    expect(heightProperty()).toBe('70.00%')
+    saveLocalStorage.mockClear()
+
+    // A pane collapsed to its header row must not keep the 70% box it was
+    // dragged to — that box would sit empty above the task list.
+    collapseButton().click()
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(false)
+
+    // The ratio is dropped from the layout, not forgotten: nothing is
+    // re-persisted, and the custom property still carries the dragged value.
+    expect(saveLocalStorage).not.toHaveBeenCalledWith(
+      AI_PANE_HEIGHT_RATIO_STORAGE_KEY,
+      null,
+    )
+    expect(stored.get(AI_PANE_HEIGHT_RATIO_STORAGE_KEY)).toBe(0.7)
+    expect(heightProperty()).toBe('70.00%')
+
+    collapseButton().click()
+    expect(container.classList.contains('ai-pane-container--sized')).toBe(true)
+    expect(heightProperty()).toBe('70.00%')
   })
 
   test('the PTY grid follows the dragged height', () => {

--- a/tests/styles/style-regressions.test.ts
+++ b/tests/styles/style-regressions.test.ts
@@ -111,9 +111,13 @@ describe('style regressions', () => {
     expect(dragging).toMatch(/color-mix\(in srgb, var\(--interactive-accent\)/)
     expect(dragging).not.toMatch(/background:\s*var\(--interactive-accent\);/)
     // The handle sits inside the container so it inherits --visible; it must
-    // still disappear when the pane is collapsed to its header row.
+    // still disappear when the pane is collapsed to its header row. It keeps
+    // its 6px box while doing so, so the collapsed header is separated from
+    // the task list by the same gap it has while expanded — `display: none`
+    // would close that gap and butt the header against the last task row.
     const collapsed = readRule(css, '.ai-pane-container--collapsed .ai-pane-resizer {')
-    expect(collapsed).toMatch(/display:\s*none;/)
+    expect(collapsed).toMatch(/visibility:\s*hidden;/)
+    expect(collapsed).not.toMatch(/display:\s*none;/)
   })
 
   test('a drag-resized AI pane height beats the terminal share but loses to expanded', () => {


### PR DESCRIPTION
## Problem

`.ai-pane-container--sized` — the class carrying the drag-resized pane height — was the only container chrome class not gated on the collapse state. `updateContainerChrome()` gates `--terminal` and `--expanded` on the pane being on screen, but `--sized` was added and removed directly by `applyPaneHeightRatio()`.

So collapsing a pane the user had dragged to, say, 70% of the view left the container at 70% with `.ai-run-pane { flex: 1 }` stretching the header-only pane over the whole box — a large empty rectangle above the task list. A pane at its default height collapsed correctly, because the container then had no explicit height at all.

A second, smaller issue surfaced once the pane actually shrank: `.ai-pane-container--collapsed .ai-pane-resizer { display: none }` took the splitter's 6px box out of the layout along with the handle, so the collapsed header butted straight against the last task row.

## Changes

- Move ownership of `--sized` to `updateContainerChrome()` and toggle it on `paneHeightRatio !== null && !isCollapsed()`. `applyPaneHeightRatio()` keeps the `--tc-ai-pane-height` custom property and the persistence; every existing call path already reaches `updateContainerChrome()`.
- The height ratio is dropped from the layout, not forgotten: `paneHeightRatio`, the custom property and the `taskchute-plus.ai-pane-height-ratio` local-storage entry all survive a collapse, so expanding restores the height the user dragged to.
- `--sized` is gated on collapse only, not on full visibility. A hidden container is `display: none`, so the class is inert there, and keeping it preserves the height across a hidden → revealed cycle.
- Hide the collapsed splitter with `visibility: hidden` instead of `display: none`, so it keeps its 6px box and the collapsed header stays separated from the task list by the same gap it has while expanded. `visibility` takes the grip, the hover states, the resize cursor and the tab stop out along with it.

## Tests

- New case in `ai-run-pane-resize.test.ts`: drag to 70%, collapse, assert `--sized` is gone while the stored ratio and the custom property are untouched and nothing is re-persisted, then expand and assert the height returns. Verified it fails without the collapse gate.
- `style-regressions.test.ts` now asserts `visibility: hidden` on the collapsed splitter and explicitly rejects `display: none`.
- `npm run typecheck`, `npm run lint`, `npm run test:unit` (226 suites, 3272 tests) and `npm run review:obsidian` (0 errors, 0 warnings) all pass locally.