### PR TITLE
Stop caching the license record per process, and order responses by generation

### DIFF
--- a/src/features/license/config.ts
+++ b/src/features/license/config.ts
@@ -12,12 +12,11 @@ import type { LocaleKey } from '../../i18n'
  * Ed25519 public key (base64url, raw 32 bytes) matching the deployed Worker's
  * LICENSE_PRIVATE_KEY.
  *
- * Rotating the key pair means updating both sides together: the license repo's
+ * Rotating the pair means updating both sides together: the license repo's
  * `npm run keys:generate` rewrites this constant and `npm run keys:upload` puts
- * the private half into Cloudflare secrets. Skip either half and the Worker
- * keeps signing happily while every user is rejected with `invalid-signature`.
- *
- * The generator rewrites this line by regex, so keep the declaration shaped as
+ * the private half into Cloudflare secrets. Skip either and the Worker keeps
+ * signing while every user is rejected with `invalid-signature`. The generator
+ * rewrites this line by regex, so keep the declaration shaped as
  * `export const LICENSE_PUBLIC_KEY = '…'`.
  */
 export const LICENSE_PUBLIC_KEY = 'YTWhN3Bl5zorbd6wJVRUF50CDee7hSPseXZiUHMoI0I'
@@ -38,13 +37,37 @@ export const LICENSE_REFRESH_THRESHOLD_SEC = 24 * 60 * 60
 export const LICENSE_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000
 
 /**
- * Floor between two device-presence checks.
- *
- * The check runs whenever the settings tab builds its definitions, which
- * happens again after every control change, so without a floor a few seconds
- * of fiddling in settings would become a burst of requests.
+ * Floor between two device-presence checks. The check runs whenever the settings
+ * tab builds its definitions — again after every control change — so without a
+ * floor, a few seconds of fiddling becomes a burst of requests.
  */
 export const LICENSE_DEVICE_CHECK_MIN_INTERVAL_SEC = 60
+
+/**
+ * Waits before each retry of a token *renewal* whose answer may have been lost.
+ * One entry per retry, so this also sets how many there are.
+ *
+ * The server commits the rotation before answering, so a request that never came
+ * back may still have spent this device's secret. Presenting the same secret
+ * again inside the server's grace window (`REFRESH_GRACE_SEC`) is the only way
+ * to learn the replacement — miss it and the user has to re-enter the code —
+ * hence retrying at once rather than twelve hours later.
+ */
+export const LICENSE_ISSUE_RETRY_BACKOFF_MS = [1_000, 3_000]
+
+/**
+ * Cap on a single attempt. `requestUrl` takes no timeout and cannot be aborted,
+ * so without this one hung request would swallow the whole window.
+ */
+export const LICENSE_ISSUE_ATTEMPT_TIMEOUT_MS = 15_000
+
+/**
+ * How long after the first attempt a retry may still start. Has to fit inside
+ * the grace window with room for the attempt that follows and the server's own
+ * clock: a retry landing after the window closes only spends a request to be
+ * told the same thing.
+ */
+export const LICENSE_ISSUE_RETRY_DEADLINE_MS = 45_000
 
 /**
  * Reject a stored token when the local clock has rewound at least this far
@@ -54,10 +77,8 @@ export const LICENSE_DEVICE_CHECK_MIN_INTERVAL_SEC = 60
 export const LICENSE_CLOCK_ROLLBACK_TOLERANCE_SEC = 24 * 60 * 60
 
 /**
- * Guide page explaining how to buy and activate a Pro license, shown next to
- * the activation form so someone without a code has somewhere to go. The site
- * serves its Japanese pages under `/ja/`, so Japanese users are sent straight
- * there rather than to the English root.
+ * Guide page for buying and activating a Pro license, shown next to the
+ * activation form. The site serves Japanese under `/ja/`.
  */
 const LICENSE_PURCHASE_URL = 'https://obsidian.levers.co.jp/howto/pro-license'
 const LICENSE_PURCHASE_URL_JA =

--- a/src/features/license/index.ts
+++ b/src/features/license/index.ts
@@ -37,11 +37,9 @@ function describePlatform(): string | undefined {
 }
 
 /**
- * The machine's hostname, or undefined off desktop.
- *
- * Mobile has no Node runtime, so the label falls back to the platform name.
- * A label only helps the user pick a seat to release; being wrong about it is
- * cosmetic, so every failure path degrades quietly.
+ * The machine's hostname, or undefined off desktop (mobile has no Node runtime,
+ * so the label falls back to the platform name). A label only helps the user
+ * pick a seat to release, so every failure path degrades quietly.
  */
 function readHostname(): string | undefined {
   // Written without optional chaining on purpose: the plugin review rule only
@@ -74,11 +72,9 @@ function cleanPart(value: unknown): string | undefined {
 /**
  * The machine's name as a seat label.
  *
- * A seat is one machine, so the machine name is the whole label — the vault
- * name used to be appended, but every vault on a machine now shares one seat
- * and one device id, which would leave whichever vault refreshed its token last
- * naming the seat for all of them. Kept pure and separate from the platform
- * lookups so the formatting can be tested directly.
+ * A seat is one machine, so the machine name is the whole label. The vault name
+ * used to be appended, but every vault now shares one seat, which left whichever
+ * refreshed last naming it for all of them. Kept pure so it can be tested.
  */
 export function formatDeviceLabel(host: unknown): string | undefined {
   const cleaned = cleanPart(host)
@@ -96,14 +92,11 @@ export function describeDeviceLabel(): string | undefined {
 export function createLicenseManager(plugin: LicensePluginLike): LicenseManager {
   const log = (level: string, ...args: unknown[]) => plugin._log?.(level, ...args)
 
-  // The device state is kept out of the vault-scoped store so that every vault
-  // on one machine shares a single seat; plugin.app is passed only so installs
-  // written by an older version can be migrated. Where the raw store is
-  // unusable the vault-scoped one remains better than no persistence at all —
-  // it costs extra seats, losing the id costs one on every launch.
-  //
-  // App exposes loadLocalStorage/saveLocalStorage but does not declare them in
-  // the public typings; the same cast is used by AiCustomModelStore's callers.
+  // The device state is kept out of the vault-scoped store so every vault on
+  // one machine shares a seat; plugin.app is passed only to migrate installs
+  // written by an older version. Where the raw store is unusable the
+  // vault-scoped one still beats no persistence: it costs extra seats, while
+  // losing the id costs one on every launch.
   const deviceStorage = createDeviceLocalStorageBridge()
   const store = deviceStorage
     ? new LicenseStore(deviceStorage, plugin.app)

--- a/src/features/license/services/LicenseApiClient.ts
+++ b/src/features/license/services/LicenseApiClient.ts
@@ -8,7 +8,12 @@
  */
 import { requestUrl } from 'obsidian'
 
-import { LICENSE_API_BASE } from '../config'
+import {
+  LICENSE_API_BASE,
+  LICENSE_ISSUE_ATTEMPT_TIMEOUT_MS,
+  LICENSE_ISSUE_RETRY_BACKOFF_MS,
+  LICENSE_ISSUE_RETRY_DEADLINE_MS,
+} from '../config'
 
 /**
  * Stable error identifiers from the API (its PublicErrorCode union). Branch on
@@ -62,8 +67,14 @@ export interface DeviceView {
   last_seen_at: number
 }
 
+/**
+ * The seat figures, as the server last reported them.
+ *
+ * No license id: this plugin never sends one — it names itself with the
+ * activation code, and renewals with the refresh secret — so receiving one
+ * would only put a value on the device that nothing here can act on.
+ */
 export interface LicenseSummary {
-  license_id: string
   max_devices: number
   devices_used: number
   /** Unix seconds, or null for a perpetual license. */
@@ -79,6 +90,13 @@ export interface IssueTokenResponse {
    * rotation, or when this client said it cannot store one.
    */
   refresh_secret?: string | null
+  /**
+   * Where that secret sits in the server's order of issues, counting up and
+   * never back. Null or absent from a server that predates it. The only thing
+   * that orders two responses reaching one machine — see
+   * `LicenseDeviceState.secretGeneration`.
+   */
+  secret_generation?: number | null
   license: LicenseSummary
 }
 
@@ -155,7 +173,7 @@ export class LicenseApiClient {
    * both: the inputs are identical, and there is no refresh token.
    */
   async issueToken(request: IssueTokenRequest): Promise<LicenseApiResult<IssueTokenResponse>> {
-    return this.send<IssueTokenResponse>('POST', '/v1/token', {
+    const body = {
       ...(request.code !== undefined ? { code: request.code } : {}),
       ...(request.refreshSecret !== undefined ? { refresh_secret: request.refreshSecret } : {}),
       device_id: request.deviceId,
@@ -166,7 +184,14 @@ export class LicenseApiClient {
       ...(request.label !== undefined ? { label: request.label } : {}),
       ...(request.platform !== undefined ? { platform: request.platform } : {}),
       ...(request.pluginVersion !== undefined ? { plugin_version: request.pluginVersion } : {}),
-    })
+    }
+
+    // Only a renewal retries. Re-sending an activation would re-run it: the
+    // server counts a code presented over a live secret as a reset, and the
+    // license only allows a few of those before it flags the account.
+    return request.refreshSecret === undefined
+      ? this.send<IssueTokenResponse>('POST', '/v1/token', body)
+      : this.sendRenewal<IssueTokenResponse>(body)
   }
 
   /**
@@ -190,6 +215,51 @@ export class LicenseApiClient {
       `/v1/devices/${encodeURIComponent(deviceId)}`,
       { code },
     )
+  }
+
+  /**
+   * Renew, retrying while the answer may simply have been lost. Attempts are
+   * immediate and bounded inside the server's grace window — see
+   * `LICENSE_ISSUE_RETRY_BACKOFF_MS` for why that window is the constraint.
+   */
+  private async sendRenewal<T>(body: Record<string, unknown>): Promise<LicenseApiResult<T>> {
+    const startedAt = Date.now()
+    let result = await this.sendWithinAttemptTimeout<T>('POST', '/v1/token', body)
+
+    for (const backoffMs of LICENSE_ISSUE_RETRY_BACKOFF_MS) {
+      if (result.ok || !mayHaveBeenLost(result)) return result
+
+      const waitMs = jittered(backoffMs)
+      // A retry that lands after the grace window closes spends a request to be
+      // told the same thing, so stop rather than start one that cannot make it.
+      if (Date.now() + waitMs - startedAt >= LICENSE_ISSUE_RETRY_DEADLINE_MS) return result
+
+      await sleep(waitMs)
+      this.log?.('warn', '[License] Retrying a renewal whose answer may have been lost')
+      result = await this.sendWithinAttemptTimeout<T>('POST', '/v1/token', body)
+    }
+
+    return result
+  }
+
+  /**
+   * One attempt, given up on after `LICENSE_ISSUE_ATTEMPT_TIMEOUT_MS`.
+   *
+   * `requestUrl` takes no timeout and cannot be aborted, so the loser of this
+   * race is left to settle on its own. It never rejects — `send` turns every
+   * outcome into a value — so nothing is left unhandled.
+   */
+  private async sendWithinAttemptTimeout<T>(
+    method: string,
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<LicenseApiResult<T>> {
+    const timedOut: LicenseApiFailure = { ok: false, kind: 'network' }
+
+    return Promise.race([
+      this.send<T>(method, path, body),
+      sleep(LICENSE_ISSUE_ATTEMPT_TIMEOUT_MS).then(() => timedOut),
+    ])
   }
 
   private async send<T>(
@@ -230,6 +300,30 @@ export class LicenseApiClient {
 
     return toFailure(status, payload)
   }
+}
+
+/**
+ * Whether a failure leaves it open that the server acted and we never heard.
+ *
+ * A 4xx is an answer, so it is never retried — 429 least of all, since the
+ * server is asking for fewer requests and a rotation cannot have happened.
+ */
+function mayHaveBeenLost(failure: LicenseApiFailure): boolean {
+  if (failure.kind === 'network') return true
+  if (failure.kind === 'no-code') return false
+
+  return failure.status >= 500
+}
+
+/** ±30%, so two vaults that started together do not stay in lockstep. */
+function jittered(delayMs: number): number {
+  return Math.round(delayMs * (0.7 + Math.random() * 0.6))
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms)
+  })
 }
 
 function parseJson(text: string): unknown {

--- a/src/features/license/services/LicenseManager.ts
+++ b/src/features/license/services/LicenseManager.ts
@@ -133,15 +133,8 @@ export class LicenseManager {
 
   /**
    * The activation code this device may act with, or undefined once it has
-   * given up its seat.
-   *
-   * The code cannot simply be deleted: it lives in data.json, which Obsidian
-   * Sync shares, so removing it would take the license away from every other
-   * machine as well. Hiding it behind the device-local latch throws it away
-   * where it has to be thrown away — on this machine — and leaves the others
-   * untouched. Everything downstream then follows for free: no refresh, no
-   * device check, an empty field in settings, and no way back except the user
-   * entering the code again.
+   * given up its seat (see `LicenseDeviceState.seatReleasedAt` for why the code
+   * is latched off rather than deleted).
    */
   getStoredCode(): string | undefined {
     return this.usableCode()
@@ -158,9 +151,9 @@ export class LicenseManager {
    * The refresh secret this device may renew with, or undefined once it has
    * given up its seat.
    *
-   * Preferred over the code for renewals: it proves this machine is the current
-   * holder of the seat rather than merely someone who knows the code, and it
-   * keeps the code off a request that repeats for as long as the license lives.
+   * Preferred over the code for renewals: it proves this machine currently holds
+   * the seat rather than merely knowing the code, and keeps the code off a
+   * request that repeats for as long as the license lives.
    */
   private usableSecret(): string | undefined {
     if (this.deps.store.isSeatReleased()) return undefined
@@ -217,14 +210,12 @@ export class LicenseManager {
    * Settle this device's entitlement against the server and report the result.
    *
    * The single entry point for "am I still Pro?", used on startup, on the
-   * background timer, and when the settings screen is opened. Returns the state
-   * afterwards so a caller that drew the old one can compare and redraw.
+   * background timer and when the settings screen opens. Returns the state
+   * afterwards so a caller that drew the old one can redraw. Never throws:
+   * every failure inside leaves entitlement exactly as it was.
    *
-   * Never throws and never rejects: every failure inside leaves entitlement
-   * exactly as it was, because being unable to ask is not an answer.
-   *
-   * @param options.force Skip the throttle. For the settings screen being
-   * opened, which is a deliberate act by someone waiting to see the answer.
+   * @param options.force Skip the throttle, for the settings screen being
+   * opened with someone waiting on the answer.
    */
   async syncFromServer(options: { force?: boolean } = {}): Promise<LicenseState> {
     if (this.syncInFlight) return this.syncInFlight
@@ -261,14 +252,10 @@ export class LicenseManager {
   }
 
   private async settleAgainstServer(): Promise<LicenseState> {
-    // The seat question comes first. Issuing a token re-registers this device
-    // id, so a refresh that ran ahead of the check would hand the seat straight
-    // back and the list would then honestly report the device present — a
-    // release made from another machine would vanish without a trace.
-    //
-    // Forced because this method's own throttle already decided the call was
-    // due; letting the check's floor veto it again is how a sync a minute after
-    // startup came to do nothing at all.
+    // The seat question comes first: issuing a token re-registers this device
+    // id, so a refresh running ahead of the check would hand the seat back and
+    // a release made from another machine would vanish without a trace. Forced
+    // because this method's own throttle already decided the call was due.
     if ((await this.verifyDeviceRegistration({ force: true })) === 'released') {
       return this.state
     }
@@ -280,15 +267,11 @@ export class LicenseManager {
       return this.state
     }
 
-    // Not active, which offline evidence alone cannot undo — the token may have
-    // simply expired while the machine was away, or the license may have been
-    // un-suspended since. Only the server can say. A device that gave up its
-    // seat has neither a usable secret nor code, so this can never retake one.
-    //
-    // The secret goes first, and not only to keep the code off the wire: a
-    // release performed while this machine was away has already discarded the
-    // secret server-side, so presenting it is what turns "my token expired" into
-    // "my seat is gone" instead of silently registering the device again.
+    // Not active, which only the server can undo: the token may have expired
+    // while the machine was away, or the license may have been un-suspended.
+    // The secret goes first because a release performed meanwhile has already
+    // discarded it server-side — presenting it is what turns "my token expired"
+    // into "my seat is gone" rather than silently registering the device again.
     const secret = this.usableSecret()
     if (secret !== undefined) {
       await this.requestToken({ refreshSecret: secret })
@@ -306,11 +289,10 @@ export class LicenseManager {
   /**
    * Ask the server whether this device still holds a seat.
    *
-   * Offline verification cannot notice a seat released from another machine:
-   * the stored token stays valid for the rest of its 7-day life, and a refresh
-   * would simply claim the seat again under the same device id. So the device
-   * list is the only thing that can tell us, and only a real answer counts —
-   * every failure returns `unknown` and leaves entitlement alone.
+   * Offline verification cannot notice a seat released from another machine —
+   * the stored token stays valid for its 7-day life — so the device list is the
+   * only thing that can tell us. Only a real answer counts: every failure
+   * returns `unknown` and leaves entitlement alone.
    */
   async verifyDeviceRegistration(
     options: { force?: boolean } = {},
@@ -356,11 +338,8 @@ export class LicenseManager {
     // this very screen, say. Acting on a stale reading would clobber it.
     if (this.state.status !== 'active') return 'unknown'
 
-    // Drops the token and, with it, the code — device-locally. The value in
-    // settings is left alone because data.json is synced and clearing it would
-    // strip the license from every other machine that shares it; the latch
-    // makes it unreadable here, which is what "throw the code away" means on
-    // the one device that lost its seat.
+    // Latches the code off device-locally, leaving the synced settings value
+    // alone (see `LicenseDeviceState.seatReleasedAt`).
     this.deps.store.markSeatReleased(this.now())
     this.setState({ status: 'unlicensed' })
 
@@ -399,11 +378,10 @@ export class LicenseManager {
       return { ok: false, failure: { ok: false, kind: 'no-code' } }
     }
 
-    // Opening the Pro screen asks this question twice at once — the sync, to
-    // find out whether this device still holds a seat, and the list the screen
-    // draws. One request answers both, and answers them identically, which a
-    // second request would not guarantee. Only for the stored code: an explicit
-    // one belongs to a different license than the one being coalesced.
+    // Opening the Pro screen asks this twice at once — the sync's seat check and
+    // the list it draws — so one request answers both, and answers them
+    // identically. Only for the stored code: an explicit one belongs to a
+    // different license than the one being coalesced.
     if (explicitCode === undefined && this.deviceListInFlight) {
       return this.deviceListInFlight
     }
@@ -472,10 +450,8 @@ export class LicenseManager {
     // cryptographically, but the seat is gone and no refresh will succeed.
     //
     // The same latch as a release from another machine, and for the same
-    // reason: the code has to stop working here — otherwise the next refresh
-    // would issue a fresh token under the same device id and silently retake
-    // the seat the user just gave up — while staying readable on every other
-    // machine that shares data.json through Obsidian Sync.
+    // reason: without it the next refresh would issue a fresh token under this
+    // device id and silently retake the seat the user just gave up.
     if (deviceId === this.getDeviceId()) {
       this.deps.store.markSeatReleased(this.now())
       this.setState({ status: 'unlicensed' })
@@ -487,18 +463,13 @@ export class LicenseManager {
   /**
    * Give this device's licence up locally, without asking the server.
    *
-   * The way out of the one state the seat list cannot fix: an active token
-   * with no code behind it. The token lives in device-local storage and the
-   * code in the synced vault settings, so a vault whose data.json never
-   * carried the code — activated in another vault on this machine, or restored
-   * from elsewhere — is licensed but unable to act: every request needs the
-   * code, and the active screen has no field to enter one. Dropping the token
-   * returns the screen to the activation form, which is the field.
+   * The way out of the one state the seat list cannot fix: an active token with
+   * no code behind it, which happens to a vault whose data.json never carried
+   * the code. Every request needs the code and the active screen has no field
+   * for one, so dropping the token returns it to the activation form.
    *
-   * Not a seat release: nothing is sent, so the server still counts this
-   * device. That is deliberate — the device id is kept, so re-entering the code
-   * here reuses the very same seat rather than spending another one. A user who
-   * does not come back can release the seat from any other machine's list.
+   * Not a seat release — nothing is sent, and the device id is kept, so
+   * re-entering the code reuses the same seat instead of spending another.
    */
   signOutLocally(): void {
     this.deps.store.clearToken()
@@ -508,12 +479,10 @@ export class LicenseManager {
   }
 
   private async doRefresh(force: boolean): Promise<void> {
-    // Both undefined once this device gave up its seat, which is what stops a
-    // refresh from handing it straight back.
-    //
-    // The secret is preferred; the code is the fallback for an install that
-    // last renewed before rotation existed and so has no secret yet. That
-    // fallback is what migrates it: the response carries the first generation.
+    // Both undefined once this device gave up its seat, which stops a refresh
+    // from handing it back. The secret is preferred; the code is the fallback
+    // for an install that last renewed before rotation existed, and is what
+    // migrates it — the response carries the first generation.
     const secret = this.usableSecret()
     if (secret !== undefined) {
       if (!force && !this.needsRefresh()) return
@@ -547,6 +516,7 @@ export class LicenseManager {
    */
   private async requestToken(
     credentials: { code: string; refreshSecret?: undefined } | { refreshSecret: string; code?: undefined },
+    options: { allowSiblingRetry?: boolean } = {},
   ): Promise<ActivationResult> {
     const result = await this.deps.client.issueToken({
       ...(credentials.code !== undefined ? { code: credentials.code } : {}),
@@ -560,10 +530,32 @@ export class LicenseManager {
     })
 
     if (!result.ok) {
+      // A sibling vault renewed while this request was in flight. It shares this
+      // machine's record, so the generation that replaced ours is already in it
+      // — and latching would take the whole install offline over another
+      // vault's success. Pick the record up and go once more instead.
+      const current = this.usableSecret()
+      if (
+        options.allowSiblingRetry !== false &&
+        result.kind === 'api' &&
+        result.code === 'stale_secret' &&
+        credentials.refreshSecret !== undefined &&
+        current !== undefined &&
+        current !== credentials.refreshSecret
+      ) {
+        return this.requestToken({ refreshSecret: current }, { allowSiblingRetry: false })
+      }
+
       return { ok: false, failure: this.handleFailure(credentials.code, result) }
     }
 
-    const { token, expires_at: expiresAt, refresh_secret: refreshSecret, license } = result.data
+    const {
+      token,
+      expires_at: expiresAt,
+      refresh_secret: refreshSecret,
+      secret_generation: secretGeneration,
+      license,
+    } = result.data
     const verification = verifyToken(LICENSE_PUBLIC_KEY, token, {
       productId: LICENSE_PRODUCT_ID,
       now: this.now(),
@@ -578,21 +570,25 @@ export class LicenseManager {
       return { ok: false, failure: { kind: 'untrusted-token', reason: verification.error } }
     }
 
-    // Only activate() gets this far while the latch is on — every other path
-    // reads its credential through usableCode() / usableSecret(), which return
-    // nothing — so a new token here is always the user deliberately asking for
-    // the seat back.
+    // Only activate() gets this far while the latch is on, since every other
+    // path reads its credential through usableCode() / usableSecret(). So a new
+    // token here is always the user deliberately asking for the seat back.
     this.rejectedCode = undefined
     this.deps.store.clearSeatReleased()
-    this.deps.store.saveToken(
+    this.deps.store.saveToken({
       token,
       expiresAt,
       license,
-      this.now(),
+      now: this.now(),
       // Absent from a server that has not rolled rotation out; the stored one
       // then stays, which is what keeps this release working against both.
-      ...(typeof refreshSecret === 'string' && refreshSecret.length > 0 ? [refreshSecret] : []),
-    )
+      ...(typeof refreshSecret === 'string' && refreshSecret.length > 0 ? { refreshSecret } : {}),
+      ...(typeof secretGeneration === 'number' ? { secretGeneration } : {}),
+      // An activation outranks whatever the record holds: it is the user's
+      // deliberate act, and it may legitimately reset the count by rebuilding
+      // the seat. A renewal takes its turn by generation instead.
+      authoritative: credentials.code !== undefined,
+    })
     this.setState({ status: 'active', token: verification.token, license })
 
     return { ok: true, state: this.state }
@@ -614,15 +610,14 @@ export class LicenseManager {
     }
 
     if (failure.code === 'stale_secret') {
-      // Another machine presenting this device id renewed first, or the seat was
-      // released while we were away. Either way the server has answered, so this
-      // is not the offline case an unexpired token is allowed to ride out.
+      // Another machine renewed first, or the seat was released while we were
+      // away. Either way the server has answered, so this is not the offline
+      // case an unexpired token may ride out. (A sibling vault of this install
+      // looks identical from here; requestToken rules that out before now.)
       //
-      // Latched like a release rather than merely cleared: the code still sits
-      // in the synced data.json, and without the latch the next sync would spend
-      // it re-taking the seat — starting the tug-of-war over from this side and
-      // burning one of the license's resets each lap. Only the user entering the
-      // code again lifts it, which is the deliberate act that should cost one.
+      // Latched rather than merely cleared: without it the next sync would
+      // spend the still-synced code re-taking the seat, burning one of the
+      // license's resets each lap. Only the user re-entering it lifts the latch.
       this.deps.log?.('warn', '[License] Refresh secret is no longer current')
       this.deps.store.markSeatReleased(this.now())
       this.setState({ status: 'unlicensed' })
@@ -636,11 +631,9 @@ export class LicenseManager {
     }
 
     if (failure.code === 'invalid_code' || failure.code === 'malformed_code') {
-      // The stored code is not a license at all; the token cannot be renewed.
-      // Remembered so the periodic sync stops asking: a revoked or suspended
-      // license may be reinstated, but a string that is not a code never
-      // becomes one, and every settings visit would otherwise spend a request
-      // re-learning that.
+      // The stored code is not a license at all. Remembered so the periodic
+      // sync stops asking: a revoked license may be reinstated, but a string
+      // that is not a code never becomes one.
       if (code !== undefined) this.rejectedCode = code
       this.deps.store.clearToken()
       this.setState({ status: 'unlicensed' })

--- a/src/features/license/services/LicenseStore.ts
+++ b/src/features/license/services/LicenseStore.ts
@@ -1,25 +1,23 @@
 /**
  * Persistence for license state, split across two stores on purpose.
  *
- * The activation code lives in settings (data.json) so that a synced vault
- * carries the entitlement to a new machine, which then activates itself.
+ * The activation code lives in settings (data.json) so a synced vault carries
+ * the entitlement to a new machine. Everything device-bound — device id, token,
+ * last known server time — lives in device-local storage instead. This departs
+ * from the API's SPEC 11-1, which puts both in data.json: Obsidian Sync shares
+ * that file, so a synced token would reach a second machine bound to the first
+ * machine's device id and fail with `device-mismatch` forever.
  *
- * Everything device-bound — the device id, the token signed against it, and the
- * last known server time — lives in device-local storage. This is a deliberate
- * deviation from the API's SPEC 11-1, which assumes both go in data.json: with
- * Obsidian Sync that file is shared, so a synced token would arrive on a second
- * machine bound to the first machine's device id and fail verification with
- * `device-mismatch` forever.
+ * The store is raw `window.localStorage`, not Obsidian's `App#saveLocalStorage`
+ * — the latter prefixes keys with the vault's app id, so each vault on one
+ * machine would present its own device id and take a seat of its own. A legacy
+ * bridge for that vault-scoped store can be passed in, and is read once at
+ * construction.
  *
- * The storage is the raw `window.localStorage`, *not* Obsidian's
- * `App#saveLocalStorage`. The latter prefixes every key with the vault's app
- * id, which would make each vault on one machine present a different device id
- * and consume a seat of its own. The raw store is shared by every vault of one
- * Obsidian install, which is as close to "one machine" as the plugin sandbox
- * gets — the same approach DeviceIdentityService already takes for the
- * execution log. Older installs kept their state in the vault-scoped store, so
- * a legacy bridge can be passed in and is read once to adopt its device id
- * (see `read`).
+ * Every vault of one install therefore shares one record, so nothing here
+ * caches it: each operation re-reads, applies its change, and writes back. A
+ * cached copy would restore a refresh secret the server has already replaced
+ * and strand the whole machine on `stale_secret`.
  */
 import type { LicenseSummary } from './LicenseApiClient'
 
@@ -35,17 +33,23 @@ export interface LicenseDeviceState {
    * The one-shot secret that buys the next token, or undefined before the first
    * activation.
    *
-   * This is what makes a copied device state stop working. Every issue replaces
-   * it server-side, so a second machine presenting the same value is refused —
-   * whoever refreshes first keeps the seat and the other is told `stale_secret`.
-   * It is not a counter: there is no "used N times", only "is this the current
-   * generation", which is why copying it to ten machines still leaves one.
-   *
-   * Kept beside the token rather than in settings on purpose. data.json is
-   * synced, and a shared secret would have every machine fighting over one
-   * generation; this file is device-local, which is the granularity a seat has.
+   * Every issue replaces it server-side, which is what makes a copied device
+   * state stop working: whoever refreshes first keeps the seat and the other is
+   * told `stale_secret`. Device-local rather than in the synced data.json,
+   * because a seat is per device.
    */
   refreshSecret?: string
+  /**
+   * Where `refreshSecret` sits in the server's order of issues. Absent before
+   * the first activation, and from a server that predates the number.
+   *
+   * Two vaults of one install share this record, and inside the server's grace
+   * window both can spend the same generation and succeed. The response that
+   * arrives second is not necessarily the one the server treats as current, and
+   * the secrets are indistinguishable — so the record keeps the highest
+   * generation rather than the latest write.
+   */
+  secretGeneration?: number
   /** Token expiry in unix seconds, as reported by the server. */
   expiresAt?: number
   /**
@@ -56,18 +60,64 @@ export interface LicenseDeviceState {
   /** Last known seat/expiry figures, for display while offline. */
   license?: LicenseSummary
   /**
-   * When this device gave up its seat, in unix seconds — whether the user
-   * released it from here or another device released it for them.
+   * When this device gave up its seat, in unix seconds — released from here or
+   * by another device. The canonical explanation of the latch; other code that
+   * sets or reads it points back here.
    *
-   * The activation code itself cannot be thrown away: it lives in data.json,
-   * which Obsidian Sync shares, so deleting it would strip the license from
-   * every other machine too. This is the device-local half of throwing it away.
-   * While it is set the stored code is treated as absent — no refresh, no
-   * device check, and an empty field in settings — so nothing on this machine
-   * quietly retakes the seat. Only an explicit activation lifts it.
+   * The activation code itself cannot be thrown away: data.json is shared by
+   * Obsidian Sync, so deleting it would strip the license from every other
+   * machine. This is the device-local half of throwing it away. While it is set
+   * the stored code reads as absent — no refresh, no device check, an empty
+   * field in settings — so nothing here quietly retakes the seat. Only an
+   * explicit activation lifts it.
    */
   seatReleasedAt?: number
 }
+
+/** A token the server just issued, and what the record needs to file it. */
+export interface SaveTokenInput {
+  token: string
+  expiresAt: number
+  license: LicenseSummary
+  /**
+   * Server-confirmed time, passed in so the rollback watermark and the
+   * manager's expiry checks cannot disagree about the clock.
+   */
+  now: number
+  /** The generation that buys the next token. Absent from an older server. */
+  refreshSecret?: string
+  /** Where that secret sits in the server's order. Absent from an older server. */
+  secretGeneration?: number
+  /**
+   * Whether this response outranks the record whatever its generation says.
+   *
+   * True only for an activation: the user asked for it, only one can be in
+   * flight, and a seat rebuilt from scratch starts counting again, so refusing
+   * it as "older" would strand the machine on a discarded secret. A renewal is
+   * never authoritative — that is what the generation orders.
+   */
+  authoritative?: boolean
+}
+
+/**
+ * Whether a response should be written, or has already been overtaken.
+ *
+ * The comparison is strict: an equal generation is the same issue arriving
+ * twice, and rewriting it would only risk undoing a concurrent one.
+ */
+function outranksRecord(input: SaveTokenInput, record: LicenseDeviceState): boolean {
+  if (input.authoritative === true) return true
+
+  // No order to respect: a server that predates the number, or a record written
+  // by a build that did not keep it. Falls back to last-write-wins.
+  if (input.secretGeneration === undefined) return true
+  if (record.secretGeneration === undefined) return true
+
+  return input.secretGeneration > record.secretGeneration
+}
+
+/** How many times a write will re-assert itself against an older one. */
+const REPAIR_ATTEMPTS = 2
 
 /**
  * Key/value storage for the device state. Shaped after Obsidian's
@@ -86,8 +136,8 @@ const STORAGE_PROBE_KEY = 'taskchute-plus.license-storage-probe'
  * The vault-independent store, or undefined where it cannot be used.
  *
  * Undefined has to stay distinguishable from "empty": a bridge that silently
- * drops writes would hand out a fresh device id on every launch and burn a seat
- * each time, so the caller falls back to the vault-scoped store instead.
+ * drops writes would mint a new device id — a new seat — on every launch, so
+ * the caller falls back to the vault-scoped store instead.
  */
 export function createDeviceLocalStorageBridge(): LicenseStorageBridge | undefined {
   try {
@@ -113,14 +163,11 @@ export function createDeviceLocalStorageBridge(): LicenseStorageBridge | undefin
 /**
  * A fresh device id: a v4 UUID, 36 characters, inside the API's 8–64.
  *
- * Only ever called once per device — an existing id is read back verbatim, so
- * changing the shape here does not disturb installs already holding one
- * (`isValidDeviceId` checks length, not format). Which matters: a new id is a
- * new seat, and re-minting would spend one on every launch.
- *
- * The id identifies a seat; it does not authorize anything. Entitlement rests
- * on the signed token and the refresh secret, so a weaker id from the fallback
- * path below costs nothing beyond a slightly higher chance of collision.
+ * A new id is a new seat, so this runs once per device and never again — an
+ * existing id is read back verbatim, and `isValidDeviceId` checks length rather
+ * than format so the shape can change without disturbing installs holding one.
+ * The id only names a seat; entitlement rests on the token and the refresh
+ * secret, so the weaker fallback below costs nothing but collision odds.
  */
 export function generateDeviceId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -144,10 +191,7 @@ function randomBytes(length: number): Uint8Array {
   return bytes
 }
 
-/**
- * Format 16 bytes as a v4 UUID. Only reached where `crypto.randomUUID` is
- * missing, which is why it is written out rather than pulled from a dependency.
- */
+/** Format 16 bytes as a v4 UUID, for hosts without `crypto.randomUUID`. */
 function uuidV4FromBytes(bytes: Uint8Array): string {
   // Version and variant bits, per RFC 4122 section 4.4
   bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40
@@ -168,17 +212,20 @@ function isValidDeviceId(value: unknown): value is string {
   return typeof value === 'string' && value.length >= 8 && value.length <= 64
 }
 
+/**
+ * Reads only the fields still in use. A record written by an older build also
+ * carries `license_id`; it is left where it is rather than required, so an
+ * install that predates its removal keeps its cached seat figures.
+ */
 function readLicenseSummary(value: unknown): LicenseSummary | undefined {
   if (typeof value !== 'object' || value === null) return undefined
   const record = value as Record<string, unknown>
-  if (typeof record['license_id'] !== 'string') return undefined
   if (typeof record['max_devices'] !== 'number') return undefined
   if (typeof record['devices_used'] !== 'number') return undefined
 
   const expiresAt = record['expires_at']
 
   return {
-    license_id: record['license_id'],
     max_devices: record['max_devices'],
     devices_used: record['devices_used'],
     expires_at: typeof expiresAt === 'number' ? expiresAt : null,
@@ -192,9 +239,8 @@ function readPositiveInt(value: unknown): number | undefined {
 /**
  * One store's state, or undefined when it holds nothing usable.
  *
- * A record without a valid device id is treated as absent in full: whatever
- * token sits beside it is signed against an id this device can no longer
- * present, so it could never verify.
+ * A record without a valid device id is discarded whole: any token beside it is
+ * signed against an id this device can no longer present.
  */
 function readState(bridge: LicenseStorageBridge): LicenseDeviceState | undefined {
   let raw: unknown
@@ -223,6 +269,7 @@ function readState(bridge: LicenseStorageBridge): LicenseDeviceState | undefined
     typeof record['refreshSecret'] === 'string' && record['refreshSecret'].length > 0
       ? record['refreshSecret']
       : undefined
+  const secretGeneration = readPositiveInt(record['secretGeneration'])
   const expiresAt = readPositiveInt(record['expiresAt'])
   const lastServerTimeSec = readPositiveInt(record['lastServerTimeSec'])
   const license = readLicenseSummary(record['license'])
@@ -232,6 +279,7 @@ function readState(bridge: LicenseStorageBridge): LicenseDeviceState | undefined
     deviceId: record['deviceId'],
     ...(token !== undefined ? { token } : {}),
     ...(refreshSecret !== undefined ? { refreshSecret } : {}),
+    ...(secretGeneration !== undefined ? { secretGeneration } : {}),
     ...(expiresAt !== undefined ? { expiresAt } : {}),
     ...(lastServerTimeSec !== undefined ? { lastServerTimeSec } : {}),
     ...(license !== undefined ? { license } : {}),
@@ -240,7 +288,15 @@ function readState(bridge: LicenseStorageBridge): LicenseDeviceState | undefined
 }
 
 export class LicenseStore {
-  private state: LicenseDeviceState
+  /**
+   * The id to present when the record is gone — cleared storage, or a write
+   * that never landed. Minted or migrated once, at construction.
+   *
+   * A fallback, never an override: an id in the record always wins. Minting one
+   * mid-session would spend a second seat, and two vaults doing so on a fresh
+   * install would disagree forever, holding a seat each.
+   */
+  private readonly sessionDeviceId: string
 
   /**
    * `legacy` is the store an older version of the plugin wrote to (the
@@ -249,101 +305,112 @@ export class LicenseStore {
    */
   constructor(
     private readonly bridge: LicenseStorageBridge,
-    private readonly legacy?: LicenseStorageBridge,
+    legacy?: LicenseStorageBridge,
   ) {
-    this.state = this.read()
-    // Persist immediately so a freshly generated device id survives a crash
-    // before the first activation; otherwise a seat could be claimed under an
-    // id this device would never present again.
-    this.write()
+    const stored = readState(this.bridge)
+    const initial = stored ?? (legacy ? readState(legacy) : undefined) ?? {
+      deviceId: generateDeviceId(),
+    }
+    this.sessionDeviceId = initial.deviceId
+
+    // Persist a migrated or fresh id right away, so it survives a crash before
+    // the first activation. An id already in the record needs no rewrite —
+    // that would clobber whatever a sibling vault wrote in between.
+    if (stored === undefined) this.writeRecord(initial)
   }
 
   /** Stable for the lifetime of this device, created on first access. */
   getDeviceId(): string {
-    return this.state.deviceId
+    return this.read().deviceId
   }
 
   getState(): Readonly<LicenseDeviceState> {
-    return this.state
+    return this.read()
   }
 
   /**
-   * Record a successful token issue or refresh. `now` is passed in rather than
-   * read from the clock here, so the rollback watermark and the manager's
-   * expiry checks can never disagree about what time it is.
+   * Record a successful token issue or refresh.
    *
-   * `refreshSecret` is the generation that buys the *next* token; the one this
-   * response was bought with is already spent server-side. Writing it in the
-   * same pass as the token is what keeps the pair consistent — a token stored
-   * without its successor secret would work until expiry and then strand the
-   * device on an activation form.
+   * `refreshSecret` is the generation that buys the *next* token; storing it in
+   * the same pass as the token keeps the pair consistent. A response the record
+   * has already moved past is dropped rather than written (see `outranksRecord`);
+   * callers need not check, since the value that won is in the record either way.
    */
-  saveToken(
-    token: string,
-    expiresAt: number,
-    license: LicenseSummary,
-    now: number,
-    refreshSecret?: string,
-  ): void {
-    this.state = {
-      ...this.state,
-      token,
-      expiresAt,
-      license,
+  saveToken(input: SaveTokenInput): void {
+    const current = this.read()
+    if (!outranksRecord(input, current)) return
+
+    const next: LicenseDeviceState = {
+      ...current,
+      token: input.token,
+      expiresAt: input.expiresAt,
+      license: input.license,
       // Absent from a server that has not rolled the secret out yet, in which
       // case the old one stays: dropping it would force a code re-entry.
-      ...(refreshSecret !== undefined ? { refreshSecret } : {}),
-      // Any successful response proves the clock was at least this far along,
-      // which is what the rollback check compares against. Never moves back.
-      lastServerTimeSec: Math.max(this.state.lastServerTimeSec ?? 0, now),
+      ...(input.refreshSecret !== undefined ? { refreshSecret: input.refreshSecret } : {}),
+      ...(input.secretGeneration !== undefined
+        ? { secretGeneration: input.secretGeneration }
+        : {}),
+      // The watermark the rollback check compares against. Never moves back,
+      // and the floor is the record's value, not one read hours ago.
+      lastServerTimeSec: Math.max(current.lastServerTimeSec ?? 0, input.now),
     }
-    this.write()
+
+    this.writeRecord(next)
+    this.repairOlderWrite(next)
   }
 
-  /** Update the cached seat figures without touching the token. */
-  saveLicenseSummary(license: LicenseSummary): void {
-    this.state = { ...this.state, license }
-    this.write()
+  /**
+   * Put `next` back if a lower generation has since overwritten it.
+   *
+   * The read-modify-write is not atomic, so sibling vaults can interleave and
+   * one can land an older record last. Every writer checking after itself makes
+   * them converge, since both aim at the same maximum. Bounded, because a
+   * *higher* generation means someone else's answer is the one to keep.
+   */
+  private repairOlderWrite(next: LicenseDeviceState): void {
+    const generation = next.secretGeneration
+    // Nothing to order by: a server without the number leaves last-write-wins.
+    if (generation === undefined) return
+
+    for (let attempt = 0; attempt < REPAIR_ATTEMPTS; attempt++) {
+      const stored = this.read().secretGeneration
+      if (stored !== undefined && stored >= generation) return
+
+      this.writeRecord(next)
+    }
   }
 
   /**
    * Drop the token but keep the device id, so re-activation reuses the seat.
    *
-   * The refresh secret goes with it. It is the thing that lets this machine
-   * renew without asking anyone, so leaving it behind would let a device that
-   * has just been told it is unlicensed quietly buy itself another week.
+   * The refresh secret goes with it: it renews without asking anyone, so
+   * leaving it behind would let a device just told it is unlicensed buy itself
+   * another week.
    */
   clearToken(): void {
-    const { deviceId, lastServerTimeSec, seatReleasedAt } = this.state
-    this.state = {
-      deviceId,
-      ...(lastServerTimeSec !== undefined ? { lastServerTimeSec } : {}),
-      ...(seatReleasedAt !== undefined ? { seatReleasedAt } : {}),
-    }
-    this.write()
+    this.writeRecord(withoutToken(this.read()))
   }
 
   /**
    * Record that this device no longer holds a seat. Drops the token like
-   * clearToken(), and latches the fact so nothing on this machine claims the
-   * seat back — only an explicit activation may do that.
+   * clearToken(), and latches `seatReleasedAt` so nothing here claims the seat
+   * back until an explicit activation.
    */
   markSeatReleased(now: number): void {
-    this.clearToken()
-    this.state = { ...this.state, seatReleasedAt: now }
-    this.write()
+    this.writeRecord({ ...withoutToken(this.read()), seatReleasedAt: now })
   }
 
   /** Lift the latch. Only a successful token request has the right to do this. */
   clearSeatReleased(): void {
-    if (this.state.seatReleasedAt === undefined) return
-    const { seatReleasedAt: _removed, ...rest } = this.state
-    this.state = rest
-    this.write()
+    const { seatReleasedAt, ...rest } = this.read()
+    if (seatReleasedAt === undefined) return
+
+    this.writeRecord(rest)
   }
 
   isSeatReleased(): boolean {
-    return this.state.seatReleasedAt !== undefined
+    return this.read().seatReleasedAt !== undefined
   }
 
   /**
@@ -351,38 +418,40 @@ export class LicenseStore {
    * confirmed time to make offline expiry meaningless.
    */
   isClockRolledBack(now: number, toleranceSec: number): boolean {
-    const lastSeen = this.state.lastServerTimeSec
+    const lastSeen = this.read().lastServerTimeSec
     if (lastSeen === undefined) return false
 
     return now < lastSeen - toleranceSec
   }
 
   /**
-   * The stored state, migrating from the legacy store when this one is empty.
+   * The record as it stands now — the only state this class has.
    *
-   * Adopting the legacy device id rather than minting a new one keeps the seat
-   * this vault already holds. Where several vaults on one machine each hold a
-   * seat, whichever launches first wins the machine's id and the others fall in
-   * behind it; their old seats stay until the user releases them from the
-   * device list. The legacy entry is left in place — it is never written again,
-   * and it costs nothing to leave a way back if this store is ever wiped.
+   * The legacy store is not consulted here: reading it a second time could
+   * resurrect a token this device has given up. A missing record falls back to
+   * the session id rather than a new one, which would be a new seat.
    */
   private read(): LicenseDeviceState {
-    const current = readState(this.bridge)
-    if (current) return current
-
-    const migrated = this.legacy ? readState(this.legacy) : undefined
-    if (migrated) return migrated
-
-    return { deviceId: generateDeviceId() }
+    return readState(this.bridge) ?? { deviceId: this.sessionDeviceId }
   }
 
-  private write(): void {
+  private writeRecord(state: LicenseDeviceState): void {
     try {
-      this.bridge.saveLocalStorage?.(LICENSE_DEVICE_STATE_STORAGE_KEY, this.state)
+      this.bridge.saveLocalStorage?.(LICENSE_DEVICE_STATE_STORAGE_KEY, state)
     } catch {
       // Storage is best-effort: losing it costs one re-activation, not access.
     }
+  }
+}
+
+/** Everything a token was bought with, gone; everything about the seat, kept. */
+function withoutToken(state: LicenseDeviceState): LicenseDeviceState {
+  const { deviceId, lastServerTimeSec, seatReleasedAt } = state
+
+  return {
+    deviceId,
+    ...(lastServerTimeSec !== undefined ? { lastServerTimeSec } : {}),
+    ...(seatReleasedAt !== undefined ? { seatReleasedAt } : {}),
   }
 }
 

--- a/src/features/license/token/code.ts
+++ b/src/features/license/token/code.ts
@@ -31,11 +31,9 @@ export function formatActivationCode(raw: string): string {
 /**
  * Reduce a code the user typed or pasted to its comparable form.
  *
- * Absorbs surrounding whitespace, lowercase, omitted hyphens and an omitted
- * prefix. Following Crockford, `I` / `L` read as `1` and `O` as `0`.
- *
- * Returns null when the input cannot be a code at all; callers treat that as a
- * typo rather than as a rejected license.
+ * Absorbs whitespace, lowercase, omitted hyphens and an omitted prefix;
+ * following Crockford, `I` / `L` read as `1` and `O` as `0`. Null means the
+ * input cannot be a code at all, which callers treat as a typo.
  */
 export function normalizeCode(input: string): string | null {
   const compact = input.trim().toUpperCase().replace(/[\s-]/g, '')

--- a/src/features/license/token/primitives.ts
+++ b/src/features/license/token/primitives.ts
@@ -27,9 +27,9 @@ export function utf8Decode(bytes: Uint8Array): string | null {
 }
 
 /**
- * Decode base64url (RFC 4648 section 5, unpadded). Returns null on malformed
- * input because tokens are untrusted external data, not a configuration error.
- * Standard base64 `+/` is accepted too, to absorb copy-paste mix-ups.
+ * Decode base64url (RFC 4648 section 5, unpadded). Null on malformed input:
+ * tokens are untrusted data, not a configuration error. Standard base64 `+/`
+ * is accepted too, to absorb copy-paste mix-ups.
  */
 export function decodeBase64Url(input: string): Uint8Array | null {
   const normalized = input.replace(/-/g, '+').replace(/_/g, '/').replace(/=+$/, '')
@@ -55,9 +55,9 @@ export const PUBLIC_KEY_BYTES = 32
 export const SIGNATURE_BYTES = 64
 
 /**
- * Turn a base64url key back into bytes. Throws on a bad length because the
- * public key is a build-time constant, not user input: failing loudly during
- * development beats silently rejecting every token in production.
+ * Turn a base64url key back into bytes. Throws on a bad length: the public key
+ * is a build-time constant, so failing loudly in development beats silently
+ * rejecting every token in production.
  */
 export function importKey(keyB64: string, expectedBytes: number): Uint8Array {
   const bytes = decodeBase64Url(keyB64.trim())
@@ -70,9 +70,4 @@ export function importKey(keyB64: string, expectedBytes: number): Uint8Array {
     )
   }
   return bytes
-}
-
-/** Format an id for display in 4-character groups (e.g. 8F3K-2M9Q-X7RD-4WPZ). */
-export function formatLicenseId(licenseId: string): string {
-  return (licenseId.match(/.{1,4}/g) ?? [licenseId]).join('-')
 }

--- a/src/features/license/token/token.ts
+++ b/src/features/license/token/token.ts
@@ -124,8 +124,8 @@ export const DEFAULT_LEEWAY_SEC = 300
  * Verify an auth token. Performs no network I/O.
  *
  * Expiry depends on the local clock, hence the leeway. A large deliberate
- * rollback is not defensible here: the caller compares against the last known
- * server time instead (see LicenseStore / SPEC 11-5).
+ * rollback is the caller's to catch, against the last known server time
+ * (see LicenseStore / SPEC 11-5).
  */
 export function verifyToken(
   publicKeyB64: string,

--- a/src/features/license/ui/DeviceListView.ts
+++ b/src/features/license/ui/DeviceListView.ts
@@ -5,11 +5,9 @@
  * vault changes the device id, leaving the old device holding a seat forever
  * (SPEC 11-3).
  *
- * One renderer serves both entry points. The API answers a 409
- * device_limit_reached with a `details.devices` array in exactly the shape of
- * the list endpoint, so an activation failure can seed the same view with the
- * devices it already carries — no second request, and the list appears in the
- * same beat as the error that sent the user there.
+ * One renderer serves both entry points: a 409 device_limit_reached carries
+ * `details.devices` in exactly the shape of the list endpoint, so an activation
+ * failure seeds the same view without a second request.
  */
 import { Notice } from 'obsidian'
 
@@ -26,10 +24,9 @@ export interface DeviceListViewOptions {
   initialDevices?: DeviceView[]
   initialMaxDevices?: number
   /**
-   * The activation code to act with, for a list shown before the code is
-   * stored. Activation stores the code only on success, so the 409 that sends
-   * the user here leaves nothing behind and a release would have no code to
-   * send. Omit when the license is already active: the stored code is used.
+   * The activation code to act with, for a list shown before the code is stored.
+   * Activation stores it only on success, so the 409 that sends the user here
+   * leaves nothing behind. Omit when active: the stored code is used.
    */
   code?: string
   /** Called after a successful release, so callers can refresh their own UI. */
@@ -126,11 +123,9 @@ export class DeviceListView {
   }
 
   /**
-   * Stop touching the DOM. The settings tab rebuilds its whole container on
-   * every display(), so an in-flight request must not write into the old tree.
-   *
-   * The tree this view owns goes with it: a host that is reused across renders
-   * would otherwise accumulate one dead list per pass.
+   * Stop touching the DOM. The settings tab rebuilds its container on every
+   * display(), so an in-flight request must not write into the old tree, and
+   * the tree this view owns goes with it rather than accumulating per pass.
    */
   dispose(): void {
     this.disposed = true
@@ -140,11 +135,8 @@ export class DeviceListView {
 
   /**
    * Re-ask the server for both halves of what this screen shows: whether this
-   * device is still licensed, and which seats the license holds.
-   *
-   * One request covers both — the manager coalesces the seat list it fetches to
-   * answer the first question with the one this list needs — so the two can
-   * never come back disagreeing with each other.
+   * device is still licensed, and which seats the license holds. The manager
+   * coalesces them into one request, so they cannot come back disagreeing.
    */
   private async refresh(): Promise<void> {
     if (this.refreshing || this.busyDeviceId !== undefined) return

--- a/src/features/license/ui/licenseMessages.ts
+++ b/src/features/license/ui/licenseMessages.ts
@@ -5,9 +5,8 @@
  * field is Japanese prose and would leak into an English UI. The server text is
  * kept only as a last resort for a code this build does not recognize.
  *
- * Every message carries its code. The prose is what the user acts on, but the
- * code is what support asks for and what a bug report has to contain, and a
- * failure that reaches the screen without one leaves both sides guessing.
+ * Every message carries its code — the prose is what the user acts on, but the
+ * code is what support asks for and what a bug report has to contain.
  */
 import { t } from '../../../i18n'
 import type { ActivationFailure } from '../services/LicenseManager'
@@ -55,9 +54,8 @@ function messageForCode(code: string, vars?: Record<string, string>): string {
 }
 
 /**
- * The message the user reads, with the code that identifies the failure.
- *
- * The code goes last and in parentheses so it never gets in the way of the
+ * The message the user reads, with the code that identifies the failure. The
+ * code goes last and in parentheses so it never gets in the way of the
  * instruction, which is the part most users need.
  */
 function withCode(message: string, code: string): string {

--- a/src/features/license/ui/notifySeatReleased.ts
+++ b/src/features/license/ui/notifySeatReleased.ts
@@ -21,23 +21,20 @@ export interface SeatCheckResult {
   /** Entitlement afterwards, or undefined where there was no manager to ask. */
   state?: LicenseState
   /**
-   * Whether the sync moved entitlement. What a caller that drew the old state
-   * needs to know — narrower than "the seat was released", which is only one of
-   * the ways the answer can change.
+   * Whether the sync moved entitlement. Narrower than "the seat was released",
+   * which is only one of the ways the answer can change.
    */
   changed: boolean
 }
 
 /**
  * Settle this device's entitlement against the server, telling the user if it
- * lost its seat. Reports whether anything moved, so a caller that draws license
- * state can redraw itself.
+ * lost its seat, and report whether anything moved so a caller can redraw.
  *
  * Never throws: it runs on startup, on a timer and whenever the settings screen
  * is built, none of which may be derailed by the license server.
  *
- * @param force Skip the throttle — for the settings screen being opened, where
- * someone is waiting on the answer.
+ * @param force Skip the throttle, for the settings screen being opened.
  */
 export async function checkSeatRegistration(
   host: SeatCheckHost,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -84,7 +84,6 @@ export const en = {
       statusName: "Status",
       statusActive: "Active",
       statusInactive: "Not activated",
-      licenseIdName: "License ID",
       signOutName: "Sign out on this device",
       signOutDesc:
         "This vault has no license code stored, so devices cannot be managed from here. Sign out to enter your code again. The seat stays with this device, so re-entering the same code costs no extra device.",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -80,7 +80,6 @@ export const ja = {
       statusName: "状態",
       statusActive: "有効",
       statusInactive: "未アクティベート",
-      licenseIdName: "ライセンスID",
       signOutName: "この端末のライセンスを解除",
       signOutDesc:
         "この保管庫にはライセンスコードが保存されていないため、ここから端末を管理できません。解除するとコードを入力し直せます。この端末の枠はそのまま残るので、同じコードを入れ直しても台数は増えません。",

--- a/src/settings/sections/pro/license.ts
+++ b/src/settings/sections/pro/license.ts
@@ -7,7 +7,6 @@ import type {
 import { getCurrentLocale, t } from "../../../i18n"
 import { licensePurchaseUrl } from "../../../features/license/config"
 import type { LicenseManager } from "../../../features/license/services/LicenseManager"
-import { formatLicenseId } from "../../../features/license/token/primitives"
 import { DeviceListView } from "../../../features/license/ui/DeviceListView"
 import { checkSeatRegistration } from "../../../features/license/ui/notifySeatReleased"
 import {
@@ -316,46 +315,37 @@ function activeLicenseRows(
   manager: LicenseManager,
   applyLicenseChange: () => Promise<void>,
 ): SettingDefinitionItem[] {
-  const summary = manager.getLicenseSummary()
   // Two sections rather than a single card: the licence is a fact to read once,
   // the seats are a list to act on, and a heading over each says which is which.
   // No status or expiry rows — the page header already says "Active".
   const rows: SettingDefinitionItem[] = []
 
-  // The code the user actually typed, not the id derived from it: that is what
-  // they hold, what support asks for, and what they would re-enter elsewhere.
-  // The id is the fallback for a licence activated before the code was stored.
-  // Read through the manager so a device that gave up its seat does not show a
-  // code it can no longer use.
+  // The code the user actually typed: what they hold, what support asks for,
+  // and what they would re-enter elsewhere. Read through the manager so a
+  // device that gave up its seat does not show a code it can no longer use.
+  //
+  // Nothing stands in for it. The licence id used to, but the server no longer
+  // sends one — and a value the user can neither act on nor quote to support
+  // was never the point. This device is identified in the seat list below.
   const stored = manager.getStoredCode()
-  const identity =
-    stored !== undefined && stored.length > 0
-      ? { name: t("settings.license.codeName", "License code"), value: stored }
-      : summary
-        ? {
-            name: t("settings.license.licenseIdName", "License ID"),
-            value: formatLicenseId(summary.license_id),
-          }
-        : undefined
+  const code = stored !== undefined && stored.length > 0 ? stored : undefined
 
-  // No code here means no request can be made: the seat list, its refresh and
-  // every release need one. The list would show nothing but a permanent
-  // no_activation_code, so it is replaced by the one action that does work.
-  const codeless = stored === undefined || stored.length === 0
+  rows.push({
+    type: "group",
+    heading: t("settings.license.heading", "License"),
+    cls: "taskchute-license-identity",
+    items:
+      code !== undefined
+        ? [{ name: t("settings.license.codeName", "License code"), desc: code }]
+        : // Nothing to name the licence with, so the section carries the one
+          // action that still works instead.
+          [signOutRow(ctx, manager, applyLicenseChange)],
+  })
 
-  if (identity) {
-    rows.push({
-      type: "group",
-      heading: t("settings.license.heading", "License"),
-      cls: "taskchute-license-identity",
-      items: [
-        { name: identity.name, desc: identity.value },
-        ...(codeless ? [signOutRow(ctx, manager, applyLicenseChange)] : []),
-      ],
-    })
-  }
-
-  if (codeless) return rows
+  // No code means no request can be made: the seat list, its refresh and every
+  // release need one. The list would show nothing but a permanent
+  // no_activation_code, so it is left out entirely.
+  if (code === undefined) return rows
 
   rows.push({
     type: "group",

--- a/tests/features/license/license-api-client.test.ts
+++ b/tests/features/license/license-api-client.test.ts
@@ -1,5 +1,6 @@
 import { requestUrl } from 'obsidian'
 
+import { LICENSE_ISSUE_RETRY_BACKOFF_MS } from '../../../src/features/license/config'
 import {
   isTransientFailure,
   LicenseApiClient,
@@ -26,7 +27,7 @@ describe('LicenseApiClient', () => {
     respond(200, {
       token: 'TCPT1.a.b',
       expires_at: 1787604800,
-      license: { license_id: 'L', max_devices: 3, devices_used: 1, expires_at: null },
+      license: { max_devices: 3, devices_used: 1, expires_at: null },
     })
 
     const result = await client.issueToken({
@@ -41,7 +42,7 @@ describe('LicenseApiClient', () => {
       data: {
         token: 'TCPT1.a.b',
         expires_at: 1787604800,
-        license: { license_id: 'L', max_devices: 3, devices_used: 1, expires_at: null },
+        license: { max_devices: 3, devices_used: 1, expires_at: null },
       },
     })
 
@@ -66,7 +67,7 @@ describe('LicenseApiClient', () => {
       token: 'TCPT1.a.b',
       expires_at: 1787604800,
       refresh_secret: 'next-generation',
-      license: { license_id: 'L', max_devices: 3, devices_used: 1, expires_at: null },
+      license: { max_devices: 3, devices_used: 1, expires_at: null },
     })
 
     const result = await client.issueToken({
@@ -173,6 +174,121 @@ describe('LicenseApiClient', () => {
     const result = await client.listDevices('code')
 
     expect(result).toEqual({ ok: false, kind: 'network' })
+  })
+})
+
+/**
+ * The server commits a rotation before it answers, so a renewal whose answer is
+ * lost may still have spent this device's secret. Presenting the same secret
+ * again inside the server's grace window is the only way to obtain the
+ * replacement, and the next scheduled attempt is twelve hours or a restart
+ * away — far outside it.
+ */
+describe('LicenseApiClient renewal retries', () => {
+  const client = new LicenseApiClient({ baseUrl: 'https://example.test' })
+
+  const RENEWAL = { refreshSecret: 'this-generation', deviceId: 'DEVICE-0001' }
+  const ISSUED = {
+    token: 'TCPT1.a.b',
+    expires_at: 1787604800,
+    refresh_secret: 'next-generation',
+    license: { max_devices: 3, devices_used: 1, expires_at: null },
+  }
+
+  beforeEach(() => {
+    requestUrlMock.mockReset()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  /** Runs the call to completion, letting every backoff elapse instantly. */
+  async function settle<T>(pending: Promise<T>): Promise<T> {
+    await jest.advanceTimersByTimeAsync(60_000)
+    return pending
+  }
+
+  test('retries a request that never reached the server', async () => {
+    requestUrlMock.mockRejectedValueOnce(new Error('offline'))
+    respond(200, ISSUED)
+
+    const result = await settle(client.issueToken(RENEWAL))
+
+    expect(requestUrlMock).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({ ok: true })
+  })
+
+  test('retries a server error, which may have followed a committed rotation', async () => {
+    respond(500, { ok: false, error: 'internal' })
+    respond(200, ISSUED)
+
+    const result = await settle(client.issueToken(RENEWAL))
+
+    expect(requestUrlMock).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({ ok: true })
+  })
+
+  test('gives up after the configured number of retries', async () => {
+    requestUrlMock.mockRejectedValue(new Error('offline'))
+
+    const result = await settle(client.issueToken(RENEWAL))
+
+    expect(requestUrlMock).toHaveBeenCalledTimes(LICENSE_ISSUE_RETRY_BACKOFF_MS.length + 1)
+    expect(result).toEqual({ ok: false, kind: 'network' })
+  })
+
+  test('presents the same secret every time', async () => {
+    // A different one would be a different generation; the point is to ask
+    // again for the answer to the request already committed.
+    requestUrlMock.mockRejectedValueOnce(new Error('offline'))
+    respond(200, ISSUED)
+
+    await settle(client.issueToken(RENEWAL))
+
+    const [first, second] = requestUrlMock.mock.calls
+    expect(JSON.parse(second[0].body)).toEqual(JSON.parse(first[0].body))
+  })
+
+  test.each([
+    ['stale_secret', 401, 'stale_secret'],
+    ['a rate limit', 429, 'rate_limited'],
+    ['a revoked license', 403, 'license_revoked'],
+  ])('does not retry %s', async (_label, status, error) => {
+    respond(status, { ok: false, error })
+
+    const result = await settle(client.issueToken(RENEWAL))
+
+    // The server answered. Asking again spends a request to be told the same
+    // thing — and for 429 it is being asked for fewer, not more.
+    expect(requestUrlMock).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ ok: false, kind: 'api' })
+  })
+
+  test('does not retry an activation', async () => {
+    // The server counts a code presented over a live secret as a reset, and a
+    // license only allows a few of those before it is flagged.
+    requestUrlMock.mockRejectedValue(new Error('offline'))
+
+    const result = await settle(
+      client.issueToken({ code: 'TCP-0000-0000-0000-0001', deviceId: 'DEVICE-0001' }),
+    )
+
+    expect(requestUrlMock).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ ok: false, kind: 'network' })
+  })
+
+  test('gives up on an attempt that never answers, and retries', async () => {
+    // requestUrl has no timeout of its own, so one hung request would otherwise
+    // swallow the whole grace window.
+    requestUrlMock.mockReturnValueOnce(new Promise(() => undefined))
+    respond(200, ISSUED)
+
+    const result = await settle(client.issueToken(RENEWAL))
+
+    expect(requestUrlMock).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({ ok: true })
   })
 })
 

--- a/tests/features/license/license-manager.test.ts
+++ b/tests/features/license/license-manager.test.ts
@@ -21,7 +21,7 @@ import { signTestToken } from './signTestToken'
 
 const NOW = 1_787_000_000
 const DAY = 24 * 60 * 60
-const SUMMARY = { license_id: 'TESTLICENSE00001', max_devices: 3, devices_used: 1, expires_at: null }
+const SUMMARY = { max_devices: 3, devices_used: 1, expires_at: null }
 
 function createBridge(): LicenseStorageBridge {
   const store = new Map<string, unknown>()
@@ -90,7 +90,12 @@ describe('initialize', () => {
 
   test('activates from a stored token without any network call', () => {
     const { manager, store, client } = createHarness()
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
 
     const state = manager.initialize()
 
@@ -100,7 +105,12 @@ describe('initialize', () => {
 
   test('rejects an expired stored token', () => {
     const { manager, store } = createHarness()
-    store.saveToken(tokenFor(store, { expiresAt: NOW - DAY }), NOW - DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store, { expiresAt: NOW - DAY }),
+      expiresAt: NOW - DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
 
     expect(manager.initialize()).toEqual({ status: 'unlicensed' })
   })
@@ -112,7 +122,7 @@ describe('initialize', () => {
       issuedAt: NOW - DAY,
       expiresAt: NOW + 7 * DAY,
     })
-    store.saveToken(foreign, NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({ token: foreign, expiresAt: NOW + 7 * DAY, license: SUMMARY, now: NOW })
 
     // This is what a data.json synced from another machine would look like.
     expect(manager.initialize()).toEqual({ status: 'unlicensed' })
@@ -121,12 +131,12 @@ describe('initialize', () => {
   test('refuses a valid token when the local clock has been wound back', () => {
     const store = new LicenseStore(createBridge())
     // Saved 30 days "ago" by the server's reckoning, then the clock moved back.
-    store.saveToken(
-      tokenFor(store, { expiresAt: NOW + 40 * DAY }),
-      NOW + 40 * DAY,
-      SUMMARY,
-      NOW + 30 * DAY,
-    )
+    store.saveToken({
+      token: tokenFor(store, { expiresAt: NOW + 40 * DAY }),
+      expiresAt: NOW + 40 * DAY,
+      license: SUMMARY,
+      now: NOW + 30 * DAY,
+    })
 
     const manager = new LicenseManager({
       client: {} as unknown as LicenseApiClient,
@@ -207,7 +217,12 @@ describe('activate', () => {
     'blocks and clears the token on %s',
     async (code) => {
       const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-      store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+      store.saveToken({
+        token: tokenFor(store),
+        expiresAt: NOW + 7 * DAY,
+        license: SUMMARY,
+        now: NOW,
+      })
       manager.initialize()
       expect(manager.isActive()).toBe(true)
 
@@ -223,7 +238,12 @@ describe('activate', () => {
 describe('refreshIfNeeded', () => {
   test('does nothing while the token has plenty of life left', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store, { expiresAt: NOW + 7 * DAY }), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store, { expiresAt: NOW + 7 * DAY }),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
 
     await manager.refreshIfNeeded()
@@ -233,7 +253,12 @@ describe('refreshIfNeeded', () => {
 
   test('renews once the token is inside the refresh window', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store, { expiresAt: NOW + 3600 }), NOW + 3600, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store, { expiresAt: NOW + 3600 }),
+      expiresAt: NOW + 3600,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue(issued(tokenFor(store), NOW + 7 * DAY))
 
@@ -268,7 +293,12 @@ describe('refreshIfNeeded', () => {
     ['an upstream outage', { ok: false, kind: 'api', code: 'upstream_unavailable', status: 502 }],
   ])('keeps working through %s', async (_label, failure) => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store, { expiresAt: NOW + 3600 }), NOW + 3600, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store, { expiresAt: NOW + 3600 }),
+      expiresAt: NOW + 3600,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue(failure)
 
@@ -281,7 +311,12 @@ describe('refreshIfNeeded', () => {
 
   test('clears a code the server does not recognize', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue({
       ok: false,
@@ -300,7 +335,12 @@ describe('refreshIfNeeded', () => {
 describe('device management', () => {
   test('releasing another device leaves this one licensed', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 1 } })
 
@@ -312,7 +352,12 @@ describe('device management', () => {
 
   test('releasing this device drops the local token and stops using the code', async () => {
     const { manager, store, client, code } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 0 } })
 
@@ -333,7 +378,12 @@ describe('device management', () => {
     // Whichever end the release came from, this device must stop acting on the
     // code and must not show it as something the user can still use here.
     const { manager, store, client, code } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.listDevices.mockResolvedValue({
       ok: true,
@@ -351,7 +401,12 @@ describe('device management', () => {
     // The latch has to reach every path that reads the stored code, or the
     // seat list would keep loading and a refresh would retake the seat.
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 0 } })
 
@@ -375,7 +430,12 @@ describe('device management', () => {
 
   test('a release is not undone by the next refresh', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 0 } })
     client.issueToken.mockResolvedValue(issued(tokenFor(store), NOW + 7 * DAY))
@@ -396,7 +456,12 @@ describe('device management', () => {
       code: 'TCP-0000-0000-0000-0001',
       failSetCode: true,
     })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 0 } })
 
@@ -460,7 +525,12 @@ describe('signOutLocally', () => {
    */
   test('drops the token so the code can be entered again', () => {
     const { manager, store } = createHarness()
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     expect(manager.isActive()).toBe(true)
 
@@ -472,7 +542,12 @@ describe('signOutLocally', () => {
 
   test('keeps the device id, so coming back reuses the same seat', async () => {
     const { manager, store, client, code } = createHarness()
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     const deviceId = manager.getDeviceId()
 
@@ -507,7 +582,12 @@ describe('verifyDeviceRegistration', () => {
 
   function activeHarness(): Harness {
     const harness = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    harness.store.saveToken(tokenFor(harness.store), NOW + 7 * DAY, SUMMARY, NOW)
+    harness.store.saveToken({
+      token: tokenFor(harness.store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     harness.manager.initialize()
     return harness
   }
@@ -635,7 +715,12 @@ describe('syncFromServer', () => {
     // and the list would then honestly report the device present — the release
     // would disappear without a trace.
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
 
     const calls: string[] = []
@@ -658,7 +743,12 @@ describe('syncFromServer', () => {
 
   test('does not renew a token for a seat that is gone', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.listDevices.mockResolvedValue({
       ok: true,
@@ -676,7 +766,12 @@ describe('syncFromServer', () => {
     // that from a revoked license, so the screen would keep saying "not
     // activated" until something asked.
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store, { expiresAt: NOW - DAY }), NOW - DAY, SUMMARY, NOW - 2 * DAY)
+    store.saveToken({
+      token: tokenFor(store, { expiresAt: NOW - DAY }),
+      expiresAt: NOW - DAY,
+      license: SUMMARY,
+      now: NOW - 2 * DAY,
+    })
     manager.initialize()
     expect(manager.isActive()).toBe(false)
 
@@ -691,7 +786,12 @@ describe('syncFromServer', () => {
 
   test('leaves a released device alone', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.deactivateDevice.mockResolvedValue({ ok: true, data: { devices_used: 0 } })
     await manager.deactivateDevice(manager.getDeviceId())
@@ -724,7 +824,12 @@ describe('syncFromServer', () => {
 
   test('throttles unless forced', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.listDevices.mockResolvedValue({
       ok: true,
@@ -743,7 +848,12 @@ describe('syncFromServer', () => {
 
   test('never rejects, whatever the server does', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.listDevices.mockRejectedValue(new Error('offline'))
 
@@ -757,7 +867,12 @@ describe('the seat list snapshot', () => {
     // Opening the Pro screen asks the same question twice at once. Two requests
     // could come back disagreeing; one cannot.
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
 
     let resolveList: (value: unknown) => void = () => undefined
@@ -785,7 +900,12 @@ describe('the seat list snapshot', () => {
 
   test('tells watchers about a list they did not ask for', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.listDevices.mockResolvedValue({
       ok: true,
@@ -804,7 +924,12 @@ describe('the seat list snapshot', () => {
 
   test('drops a released seat without re-fetching', async () => {
     const { manager, store, client } = createHarness({ code: 'TCP-0000-0000-0000-0001' })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.listDevices.mockResolvedValue({
       ok: true,
@@ -872,7 +997,13 @@ describe('refresh secret rotation', () => {
 
   test('renews with the secret and without the code', async () => {
     const { manager, store, client } = createHarness({ code: CODE })
-    store.saveToken(tokenFor(store), NOW + DAY / 2, SUMMARY, NOW, 'generation-1')
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + DAY / 2,
+      license: SUMMARY,
+      now: NOW,
+      refreshSecret: 'generation-1',
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue({
       ok: true,
@@ -896,7 +1027,12 @@ describe('refresh secret rotation', () => {
     // An install that last renewed before rotation existed. The response is
     // what migrates it.
     const { manager, store, client } = createHarness({ code: CODE })
-    store.saveToken(tokenFor(store), NOW + DAY / 2, SUMMARY, NOW)
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + DAY / 2,
+      license: SUMMARY,
+      now: NOW,
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue({
       ok: true,
@@ -914,9 +1050,112 @@ describe('refresh secret rotation', () => {
     expect(store.getState().refreshSecret).toBe('generation-1')
   })
 
+  test('stores the generation the server hands back', async () => {
+    const { manager, store, client } = createHarness()
+    client.issueToken.mockResolvedValue({
+      ok: true,
+      data: {
+        token: tokenFor(store),
+        expires_at: NOW + 7 * DAY,
+        refresh_secret: 'generation-1',
+        secret_generation: 1,
+        license: SUMMARY,
+      },
+    })
+
+    await manager.activate(CODE)
+
+    expect(store.getState().secretGeneration).toBe(1)
+  })
+
+  test('a sibling vault renewing first is not a lost seat', async () => {
+    // Both vaults of an install share one record, so the generation that
+    // replaced ours is already in it. Latching here would take the whole
+    // machine offline over another vault's success.
+    const { manager, store, client } = createHarness({ code: CODE })
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + DAY / 2,
+      license: SUMMARY,
+      now: NOW,
+      refreshSecret: 'generation-1',
+      secretGeneration: 1,
+    })
+    expect(manager.initialize().status).toBe('active')
+
+    client.issueToken
+      .mockImplementationOnce(() => {
+        // The sibling's renewal lands while this request is in flight.
+        store.saveToken({
+          token: tokenFor(store),
+          expiresAt: NOW + 7 * DAY,
+          license: SUMMARY,
+          now: NOW,
+          refreshSecret: 'generation-2',
+          secretGeneration: 2,
+        })
+        return Promise.resolve(stale())
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          token: tokenFor(store),
+          expires_at: NOW + 7 * DAY,
+          refresh_secret: 'generation-3',
+          secret_generation: 3,
+          license: SUMMARY,
+        },
+      })
+
+    await manager.refreshIfNeeded()
+
+    expect(manager.getState().status).toBe('active')
+    expect(manager.isSeatReleased()).toBe(false)
+    expect(client.issueToken.mock.calls[1][0].refreshSecret).toBe('generation-2')
+    expect(store.getState().refreshSecret).toBe('generation-3')
+  })
+
+  test('gives up after one retry rather than chasing the record', async () => {
+    const { manager, store, client } = createHarness({ code: CODE })
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + DAY / 2,
+      license: SUMMARY,
+      now: NOW,
+      refreshSecret: 'generation-1',
+      secretGeneration: 1,
+    })
+    manager.initialize()
+
+    let generation = 1
+    client.issueToken.mockImplementation(() => {
+      generation += 1
+      store.saveToken({
+        token: tokenFor(store),
+        expiresAt: NOW + 7 * DAY,
+        license: SUMMARY,
+        now: NOW,
+        refreshSecret: `generation-${generation}`,
+        secretGeneration: generation,
+      })
+      return Promise.resolve(stale())
+    })
+
+    await manager.refreshIfNeeded()
+
+    expect(client.issueToken).toHaveBeenCalledTimes(2)
+    expect(manager.isSeatReleased()).toBe(true)
+  })
+
   test('a stale secret revokes entitlement here and latches the code off', async () => {
     const { manager, store, client } = createHarness({ code: CODE })
-    store.saveToken(tokenFor(store), NOW + DAY / 2, SUMMARY, NOW, 'overtaken')
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + DAY / 2,
+      license: SUMMARY,
+      now: NOW,
+      refreshSecret: 'overtaken',
+    })
     expect(manager.initialize().status).toBe('active')
     client.issueToken.mockResolvedValue(stale())
 
@@ -932,7 +1171,13 @@ describe('refresh secret rotation', () => {
 
   test('the latch stops a sync from quietly retaking the seat', async () => {
     const { manager, store, client } = createHarness({ code: CODE })
-    store.saveToken(tokenFor(store), NOW + DAY / 2, SUMMARY, NOW, 'overtaken')
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + DAY / 2,
+      license: SUMMARY,
+      now: NOW,
+      refreshSecret: 'overtaken',
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue(stale())
     await manager.refreshIfNeeded()
@@ -946,7 +1191,13 @@ describe('refresh secret rotation', () => {
 
   test('re-entering the code lifts the latch and takes the seat back', async () => {
     const { manager, store, client } = createHarness({ code: CODE })
-    store.saveToken(tokenFor(store), NOW + DAY / 2, SUMMARY, NOW, 'overtaken')
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + DAY / 2,
+      license: SUMMARY,
+      now: NOW,
+      refreshSecret: 'overtaken',
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue(stale())
     await manager.refreshIfNeeded()
@@ -977,7 +1228,13 @@ describe('refresh secret rotation', () => {
     ['a server error', { ok: false, kind: 'api', code: 'internal', status: 500 }],
   ])('keeps the secret and the token through %s', async (_label, failure) => {
     const { manager, store, client } = createHarness({ code: CODE })
-    store.saveToken(tokenFor(store), NOW + DAY / 2, SUMMARY, NOW, 'generation-1')
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + DAY / 2,
+      license: SUMMARY,
+      now: NOW,
+      refreshSecret: 'generation-1',
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue(failure)
 
@@ -990,7 +1247,13 @@ describe('refresh secret rotation', () => {
 
   test('a refused reset is reported without knocking this device offline', async () => {
     const { manager, store, client } = createHarness({ code: CODE })
-    store.saveToken(tokenFor(store), NOW + 7 * DAY, SUMMARY, NOW, 'generation-1')
+    store.saveToken({
+      token: tokenFor(store),
+      expiresAt: NOW + 7 * DAY,
+      license: SUMMARY,
+      now: NOW,
+      refreshSecret: 'generation-1',
+    })
     manager.initialize()
     client.issueToken.mockResolvedValue({
       ok: false,

--- a/tests/features/license/license-store.test.ts
+++ b/tests/features/license/license-store.test.ts
@@ -4,6 +4,7 @@ import {
   LICENSE_DEVICE_STATE_STORAGE_KEY,
   LicenseStore,
   type LicenseStorageBridge,
+  type SaveTokenInput,
 } from '../../../src/features/license/services/LicenseStore'
 
 function createBridge(initial?: unknown): LicenseStorageBridge & { store: Map<string, unknown> } {
@@ -19,7 +20,7 @@ function createBridge(initial?: unknown): LicenseStorageBridge & { store: Map<st
   }
 }
 
-const SUMMARY = { license_id: 'L1', max_devices: 3, devices_used: 1, expires_at: null }
+const SUMMARY = { max_devices: 3, devices_used: 1, expires_at: null }
 
 /**
  * A freshly minted id is a v4 UUID. Ids already stored by older versions keep
@@ -60,7 +61,12 @@ describe('LicenseStore', () => {
 
   test('saves and reloads a token', () => {
     const bridge = createBridge()
-    new LicenseStore(bridge).saveToken('TCPT1.a.b', 1787604800, SUMMARY, 1787000000)
+    new LicenseStore(bridge).saveToken({
+      token: 'TCPT1.a.b',
+      expiresAt: 1787604800,
+      license: SUMMARY,
+      now: 1787000000,
+    })
 
     const reloaded = new LicenseStore(bridge).getState()
     expect(reloaded.token).toBe('TCPT1.a.b')
@@ -93,7 +99,7 @@ describe('LicenseStore', () => {
       deviceId: 'DEVICE-00000001',
       token: 123,
       expiresAt: 'soon',
-      license: { license_id: 'L1' },
+      license: { max_devices: 'three' },
     })
 
     const state = new LicenseStore(bridge).getState()
@@ -105,13 +111,13 @@ describe('LicenseStore', () => {
   describe('refresh secret', () => {
     test('round-trips beside the token', () => {
       const bridge = createBridge()
-      new LicenseStore(bridge).saveToken(
-        'TCPT1.a.b',
-        1787604800,
-        SUMMARY,
-        1787000000,
-        'generation-1',
-      )
+      new LicenseStore(bridge).saveToken({
+        token: 'TCPT1.a.b',
+        expiresAt: 1787604800,
+        license: SUMMARY,
+        now: 1787000000,
+        refreshSecret: 'generation-1',
+      })
 
       expect(new LicenseStore(bridge).getState().refreshSecret).toBe('generation-1')
     })
@@ -120,9 +126,15 @@ describe('LicenseStore', () => {
       // A server that has not rolled rotation out yet. Dropping the secret would
       // force a code re-entry for no reason.
       const store = new LicenseStore(createBridge())
-      store.saveToken('TCPT1.a.b', 1, SUMMARY, 1787000000, 'generation-1')
+      store.saveToken({
+        token: 'TCPT1.a.b',
+        expiresAt: 1,
+        license: SUMMARY,
+        now: 1787000000,
+        refreshSecret: 'generation-1',
+      })
 
-      store.saveToken('TCPT1.c.d', 2, SUMMARY, 1787000001)
+      store.saveToken({ token: 'TCPT1.c.d', expiresAt: 2, license: SUMMARY, now: 1787000001 })
 
       expect(store.getState().refreshSecret).toBe('generation-1')
     })
@@ -131,7 +143,13 @@ describe('LicenseStore', () => {
       // It is what lets this machine renew unattended, so a device that has just
       // been told it is unlicensed must not keep one.
       const store = new LicenseStore(createBridge())
-      store.saveToken('TCPT1.a.b', 1, SUMMARY, 1787000000, 'generation-1')
+      store.saveToken({
+        token: 'TCPT1.a.b',
+        expiresAt: 1,
+        license: SUMMARY,
+        now: 1787000000,
+        refreshSecret: 'generation-1',
+      })
 
       store.clearToken()
 
@@ -140,7 +158,13 @@ describe('LicenseStore', () => {
 
     test('goes away when the seat is released', () => {
       const store = new LicenseStore(createBridge())
-      store.saveToken('TCPT1.a.b', 1, SUMMARY, 1787000000, 'generation-1')
+      store.saveToken({
+        token: 'TCPT1.a.b',
+        expiresAt: 1,
+        license: SUMMARY,
+        now: 1787000000,
+        refreshSecret: 'generation-1',
+      })
 
       store.markSeatReleased(1787100000)
 
@@ -154,11 +178,121 @@ describe('LicenseStore', () => {
     })
   })
 
+  /**
+   * Two vaults can spend the same generation inside the server's grace window
+   * and both succeed. The response that lands second is not necessarily the one
+   * the server kept, so the record follows the highest generation rather than
+   * the last write.
+   */
+  describe('secret generation', () => {
+    function issue(generation: number, extra: Partial<SaveTokenInput> = {}): SaveTokenInput {
+      return {
+        token: `token-${generation}`,
+        expiresAt: 1787604800,
+        license: SUMMARY,
+        now: 1787000000,
+        refreshSecret: `secret-${generation}`,
+        secretGeneration: generation,
+        ...extra,
+      }
+    }
+
+    test('keeps the highest generation whatever order the responses arrive in', () => {
+      const store = new LicenseStore(createBridge())
+      store.saveToken(issue(3))
+
+      store.saveToken(issue(2))
+
+      expect(store.getState().secretGeneration).toBe(3)
+      expect(store.getState().refreshSecret).toBe('secret-3')
+      expect(store.getState().token).toBe('token-3')
+    })
+
+    test('ignores the same generation arriving twice', () => {
+      const store = new LicenseStore(createBridge())
+      store.saveToken(issue(2))
+
+      store.saveToken(issue(2, { token: 'later' }))
+
+      expect(store.getState().token).toBe('token-2')
+    })
+
+    test('an activation applies even when its generation is lower', () => {
+      // The seat can be rebuilt from scratch, which starts the count again.
+      // Refusing that as "older" would leave the machine holding a secret the
+      // server has already thrown away.
+      const store = new LicenseStore(createBridge())
+      store.saveToken(issue(5))
+
+      store.saveToken(issue(1, { authoritative: true }))
+
+      expect(store.getState().secretGeneration).toBe(1)
+      expect(store.getState().refreshSecret).toBe('secret-1')
+    })
+
+    test('applies a response from a server that sends no generation', () => {
+      const store = new LicenseStore(createBridge())
+      store.saveToken(issue(3))
+
+      store.saveToken({
+        token: 'no-generation',
+        expiresAt: 1787604801,
+        license: SUMMARY,
+        now: 1787000001,
+        refreshSecret: 'plain',
+      })
+
+      expect(store.getState().token).toBe('no-generation')
+      expect(store.getState().refreshSecret).toBe('plain')
+    })
+
+    test('re-asserts its write when an older one lands on top', () => {
+      // The read-modify-write is not atomic, so a sibling vault can interleave
+      // and leave an older record last. Every writer checking after itself is
+      // what makes them converge on the same maximum.
+      const bridge = createBridge({ deviceId: 'DEVICE-00000001' })
+      const store = new LicenseStore(bridge)
+      const save = bridge.saveLocalStorage
+      let interfered = false
+
+      bridge.saveLocalStorage = (key: string, value: unknown) => {
+        save?.(key, value)
+        if (interfered) return
+
+        // The sibling's older write lands right on top of ours, once.
+        interfered = true
+        bridge.store.set(key, {
+          deviceId: 'DEVICE-00000001',
+          refreshSecret: 'secret-1',
+          secretGeneration: 1,
+        })
+      }
+
+      store.saveToken(issue(3))
+
+      expect(bridge.store.get(LICENSE_DEVICE_STATE_STORAGE_KEY)).toMatchObject({
+        secretGeneration: 3,
+        refreshSecret: 'secret-3',
+      })
+    })
+
+    test('ignores a stored value with the wrong type', () => {
+      const bridge = createBridge({ deviceId: 'DEVICE-00000001', secretGeneration: 'two' })
+
+      expect(new LicenseStore(bridge).getState().secretGeneration).toBeUndefined()
+    })
+  })
+
   test('clearToken keeps the device id so re-activation reuses the seat', () => {
     const bridge = createBridge()
     const store = new LicenseStore(bridge)
     const deviceId = store.getDeviceId()
-    store.saveToken('TCPT1.a.b', 1787604800, SUMMARY, 1787000000)
+    store.saveToken({
+      token: 'TCPT1.a.b',
+      expiresAt: 1787604800,
+      license: SUMMARY,
+      now: 1787000000,
+    })
 
     store.clearToken()
 
@@ -172,7 +306,12 @@ describe('LicenseStore', () => {
       const bridge = createBridge()
       const store = new LicenseStore(bridge)
       const deviceId = store.getDeviceId()
-      store.saveToken('TCPT1.a.b', 1787604800, SUMMARY, 1787000000)
+      store.saveToken({
+        token: 'TCPT1.a.b',
+        expiresAt: 1787604800,
+        license: SUMMARY,
+        now: 1787000000,
+      })
 
       store.markSeatReleased(1787100000)
 
@@ -221,7 +360,12 @@ describe('LicenseStore', () => {
     }
 
     const store = new LicenseStore(bridge)
-    expect(() => store.saveToken('TCPT1.a.b', 1, SUMMARY, 1787000000)).not.toThrow()
+    expect(() => store.saveToken({
+      token: 'TCPT1.a.b',
+      expiresAt: 1,
+      license: SUMMARY,
+      now: 1787000000,
+    })).not.toThrow()
     expect(store.getDeviceId()).toMatch(UUID_V4)
   })
 
@@ -236,7 +380,12 @@ describe('LicenseStore', () => {
     test('flags a clock wound back past the tolerance', () => {
       const lastServerTime = 1_787_000_000
       const store = new LicenseStore(createBridge())
-      store.saveToken('TCPT1.a.b', 1787604800, SUMMARY, lastServerTime)
+      store.saveToken({
+        token: 'TCPT1.a.b',
+        expiresAt: 1787604800,
+        license: SUMMARY,
+        now: lastServerTime,
+      })
 
       expect(store.isClockRolledBack(lastServerTime - TOLERANCE - 1, TOLERANCE)).toBe(true)
       expect(store.isClockRolledBack(lastServerTime - TOLERANCE + 1, TOLERANCE)).toBe(false)
@@ -246,13 +395,115 @@ describe('LicenseStore', () => {
 
     test('never lets the last known server time move backwards', () => {
       const store = new LicenseStore(createBridge())
-      store.saveToken('TCPT1.a.b', 1, SUMMARY, 2_000_000_000)
+      store.saveToken({ token: 'TCPT1.a.b', expiresAt: 1, license: SUMMARY, now: 2_000_000_000 })
 
       // A device whose clock is now wrong must not erase the earlier evidence.
-      store.saveToken('TCPT1.c.d', 2, SUMMARY, 1_000_000_000)
+      store.saveToken({ token: 'TCPT1.c.d', expiresAt: 2, license: SUMMARY, now: 1_000_000_000 })
 
       expect(store.getState().lastServerTimeSec).toBe(2_000_000_000)
     })
+  })
+})
+
+/**
+ * Two vaults open on one machine are two LicenseStore instances over one shared
+ * record. Nothing may be cached between them: a value read at launch is stale
+ * the moment the other vault renews, and writing it back would restore a
+ * refresh secret the server has already replaced.
+ */
+describe('LicenseStore with a sibling vault', () => {
+  test('reads the generation a sibling rotated to', () => {
+    const bridge = createBridge({ deviceId: 'DEVICE-00000001' })
+    const vaultA = new LicenseStore(bridge)
+    const vaultB = new LicenseStore(bridge)
+
+    vaultA.saveToken({
+      token: 'TCPT1.new',
+      expiresAt: 1787604800,
+      license: SUMMARY,
+      now: 1787000000,
+      refreshSecret: 'generation-2',
+    })
+
+    expect(vaultB.getState().refreshSecret).toBe('generation-2')
+    expect(vaultB.getState().expiresAt).toBe(1787604800)
+  })
+
+  test('a sibling write does not restore the secret it was holding', () => {
+    // Vault B was launched while the machine was latched, so its view says
+    // "released". The user then re-activates from vault A. B's next write must
+    // build on the record, not on what it read at launch — otherwise it drops
+    // the token A just bought and the machine is stranded on stale_secret.
+    const bridge = createBridge({ deviceId: 'DEVICE-00000001', seatReleasedAt: 1787000000 })
+    const vaultB = new LicenseStore(bridge)
+    const vaultA = new LicenseStore(bridge)
+
+    vaultA.saveToken({
+      token: 'TCPT1.new',
+      expiresAt: 1787604800,
+      license: SUMMARY,
+      now: 1787100000,
+      refreshSecret: 'generation-2',
+    })
+    vaultA.clearSeatReleased()
+
+    vaultB.clearSeatReleased()
+
+    expect(vaultB.getState().token).toBe('TCPT1.new')
+    expect(vaultB.getState().refreshSecret).toBe('generation-2')
+  })
+
+  test('a sibling release takes the whole machine with it', () => {
+    // The inverse, and correct: one install holds one seat, so a release seen
+    // by either vault applies to both.
+    const bridge = createBridge({ deviceId: 'DEVICE-00000001' })
+    const vaultA = new LicenseStore(bridge)
+    const vaultB = new LicenseStore(bridge)
+    vaultA.saveToken({
+      token: 'TCPT1.a.b',
+      expiresAt: 1787604800,
+      license: SUMMARY,
+      now: 1787000000,
+      refreshSecret: 'generation-1',
+    })
+
+    vaultB.markSeatReleased(1787100000)
+
+    expect(vaultA.isSeatReleased()).toBe(true)
+    expect(vaultA.getState().refreshSecret).toBeUndefined()
+  })
+
+  test('both vaults settle on one device id when neither found one', () => {
+    // The launch race on a fresh install: both read an empty record, both mint
+    // an id, and the second write wins. The first vault has to fall in behind
+    // it rather than keep presenting the id it minted, or the install holds two
+    // seats forever. Re-emptying the bridge is what makes A's read racy here.
+    const bridge = createBridge()
+    const vaultA = new LicenseStore(bridge)
+    bridge.store.clear()
+    const vaultB = new LicenseStore(bridge)
+
+    expect(vaultA.getDeviceId()).toBe(vaultB.getDeviceId())
+  })
+
+  test('keeps presenting its id when the record is wiped mid-session', () => {
+    // Storage cleared underneath a running vault. Minting a fresh id here would
+    // claim a second seat; the one this session has been presenting is the only
+    // safe answer.
+    const bridge = createBridge()
+    const store = new LicenseStore(bridge)
+    const deviceId = store.getDeviceId()
+
+    bridge.store.clear()
+
+    expect(store.getDeviceId()).toBe(deviceId)
+    store.saveToken({
+      token: 'TCPT1.a.b',
+      expiresAt: 1787604800,
+      license: SUMMARY,
+      now: 1787000000,
+    })
+    expect(bridge.store.get(LICENSE_DEVICE_STATE_STORAGE_KEY)).toMatchObject({ deviceId })
   })
 })
 
@@ -330,7 +581,12 @@ describe('LicenseStore migration from the vault-scoped store', () => {
     const legacy = createBridge({ deviceId: 'DEVICE-LEGACY01' })
     const store = new LicenseStore(createBridge(), legacy)
 
-    store.saveToken('TCPT1.a.b', 1787604800, SUMMARY, 1787000000)
+    store.saveToken({
+      token: 'TCPT1.a.b',
+      expiresAt: 1787604800,
+      license: SUMMARY,
+      now: 1787000000,
+    })
 
     expect(legacy.store.get(LICENSE_DEVICE_STATE_STORAGE_KEY)).toEqual({
       deviceId: 'DEVICE-LEGACY01',

--- a/tests/features/license/pro-settings-section.test.ts
+++ b/tests/features/license/pro-settings-section.test.ts
@@ -65,7 +65,6 @@ function fakeManager(
 const CODE = 'TCP-AAAA-BBBB-CCCC-DDDD'
 
 const ACTIVE_SUMMARY = {
-  license_id: '8F3K2M9QX7RD4WPZ',
   max_devices: 3,
   devices_used: 2,
   expires_at: null,
@@ -393,20 +392,18 @@ describe('Pro settings section', () => {
       expect(descs(items)).toContain('TCP-AAAA-BBBB-CCCC-DDDD')
     })
 
-    test('falls back to the license id when there is no usable code', () => {
+    test('shows nothing in place of a code this device may not use', () => {
       // The code may still be in data.json — it has to be, other machines share
       // it — but this device may no longer use it, so showing it here would be
-      // offering something that does nothing.
+      // offering something that does nothing. The licence id used to stand in;
+      // the server no longer sends one, and it named nothing the user could act
+      // on. What is left is the way out.
       const items = proItems(activeManager(), CODE)
 
       expect(names(items)).not.toContain('License code')
       expect(descs(items)).not.toContain('TCP-AAAA-BBBB-CCCC-DDDD')
-      expect(names(items)).toContain('License ID')
-
-      const licenseId = items.find(
-        (item) => 'name' in item && item.name === 'License ID',
-      )
-      expect((licenseId as { desc: string }).desc).toBe('8F3K-2M9Q-X7RD-4WPZ')
+      expect(names(items)).not.toContain('License ID')
+      expect(names(items)).toContain('Sign out on this device')
     })
 
     test('drops the status and expiry rows', () => {


### PR DESCRIPTION
## Why

The device record lives in raw `localStorage`, shared by every vault of one Obsidian install — deliberately, so vaults do not each take a seat. But `LicenseStore` read it once at construction and wrote its whole in-memory copy back. With two vaults open:

- vault A rotates the refresh secret; vault B never learns, presents the old one, and is told `stale_secret`
- any write from B rebuilds the record from its stale copy, rolling back the generation A just obtained

`stale_secret` latches immediately, which wipes the shared record's token and forces the user to re-enter their code — spending one of the license's resets. This is not a frequency problem: two vaults open across a single rotation is enough, and the 12-hour timers stay in phase with each other, so an affected machine hits it every cycle.

## What changed

**No cache.** Every read and write goes to the record, and writes apply only the fields they touch. The device id is kept as a per-session fallback, but a value in the record always wins.

**Generation ordering.** The API now returns `secret_generation`, which counts up per issue and never back. Two vaults can spend the same generation inside the server's grace window and both succeed, and the responses are indistinguishable random strings — so the record keeps the highest generation rather than the latest write, and converges on the server's current one whatever the arrival order. `localStorage` has no CAS, so a write re-asserts itself if an older one lands on top. An activation applies regardless: rebuilding a seat legitimately restarts the count.

**`stale_secret` is no longer proof of a lost seat.** If the record's secret differs from the one presented, a sibling vault rotated — adopt it and retry once. A copied device state on another machine shares no record, so its value never changes underneath it and the deterrent is unaffected.

**Immediate retry on a renewal.** The server commits the rotation before answering, so a lost answer may still have spent the secret; presenting it again inside the grace window is the only recovery, and the next scheduled attempt was twelve hours away. Network failures and 5xx only — never 429, and never an activation, since re-sending a code counts a second reset.

The server-side half is deployed (`REFRESH_GRACE_SEC` is now derived from this retry budget: 600 → 120).

**License id dropped from the UI.** The API no longer returns one — the plugin never sent it, and it named nothing the user could act on.

## Testing

`npm run typecheck && npm run lint && npm run test:unit` — 3312 tests pass. New coverage: two stores over one storage, generation ordering and write repair, sibling-vault `stale_secret` recovery, and the renewal retry budget.